### PR TITLE
Normalize page URLs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,12 @@ Metrics/ParameterLists:
   Exclude:
     - 'lib/versionista_service/*'
 
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/IndentHash:
+  EnforcedStyle: consistent
+
 Style/EmptyLines:
   Enabled: false
 
@@ -37,5 +43,5 @@ Style/RegexpLiteral:
 Style/SafeNavigation:
   Enabled: false
 
-Layout/IndentHash:
-  EnforcedStyle: consistent
+Style/GuardClause:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -77,20 +77,6 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-# Offense count: 14
-# Configuration parameters: MinBodyLength.
-Style/GuardClause:
-  Exclude:
-    - 'app/controllers/admin_controller.rb'
-    - 'app/controllers/api/v0/api_controller.rb'
-    - 'app/controllers/versions_controller.rb'
-    - 'app/helpers/pages_helper.rb'
-    - 'app/models/annotation.rb'
-    - 'app/models/change.rb'
-    - 'app/models/concerns/uuid_primary_key.rb'
-    - 'app/models/invitation.rb'
-    - 'app/models/user.rb'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,6 +3,9 @@ class Page < ApplicationRecord
 
   has_many :versions, -> { order(created_at: :desc) }, foreign_key: 'page_uuid', inverse_of: :page
 
+  before_save :normalize_url
+  validate :url_must_have_domain
+
   # A serialized page should always include some version info. If expanded
   # version objects weren't requested, it includes the latest version.
   def as_json(*args)
@@ -11,5 +14,19 @@ class Page < ApplicationRecord
       result['latest'] = self.versions.first.as_json
     end
     result
+  end
+
+  protected
+
+  def normalize_url
+    unless self.url.match(/^[\w\+\-\.]+:\/\//)
+      self.url = "http://#{url}"
+    end
+  end
+
+  def url_must_have_domain
+    unless url.match(/^([\w\+\-\.]+:\/\/)?[^\/]+\.[^\/]{2,}/)
+      errors.add(:url, "must have a domain")
+    end
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -19,14 +19,14 @@ class Page < ApplicationRecord
   protected
 
   def normalize_url
-    unless self.url.match(/^[\w\+\-\.]+:\/\//)
+    unless self.url.match?(/^[\w\+\-\.]+:\/\//)
       self.url = "http://#{url}"
     end
   end
 
   def url_must_have_domain
-    unless url.match(/^([\w\+\-\.]+:\/\/)?[^\/]+\.[^\/]{2,}/)
-      errors.add(:url, "must have a domain")
+    unless url.match?(/^([\w\+\-\.]+:\/\/)?[^\/]+\.[^\/]{2,}/)
+      errors.add(:url, 'must have a domain')
     end
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -4,9 +4,9 @@ class Version < ApplicationRecord
   belongs_to :page, foreign_key: :page_uuid, required: true, inverse_of: :versions
   has_many :tracked_changes, class_name: 'Change', foreign_key: 'uuid_to'
   has_many :invalid_changes,
-           ->(version) { where.not(uuid_from: version.previous.uuid) },
-           class_name: 'Change',
-           foreign_key: 'uuid_to'
+    ->(version) { where.not(uuid_from: version.previous.uuid) },
+    class_name: 'Change',
+    foreign_key: 'uuid_to'
 
   def previous
     self.page.versions.where('capture_time < ?', self.capture_time).first

--- a/db/migrate/20170425211418_add_missing_page_schemes.rb
+++ b/db/migrate/20170425211418_add_missing_page_schemes.rb
@@ -1,0 +1,11 @@
+class AddMissingPageSchemes < ActiveRecord::Migration[5.0]
+  def up
+    Page.where("url NOT LIKE 'http://%' AND url NOT LIKE 'https://%' AND url NOT LIKE 'ftp://%'").each do |page|
+      page.save
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "This migration modifies existing bad data and cannot be reversed."
+  end
+end

--- a/db/migrate/20170425211418_add_missing_page_schemes.rb
+++ b/db/migrate/20170425211418_add_missing_page_schemes.rb
@@ -1,11 +1,10 @@
 class AddMissingPageSchemes < ActiveRecord::Migration[5.0]
   def up
-    Page.where("url NOT LIKE 'http://%' AND url NOT LIKE 'https://%' AND url NOT LIKE 'ftp://%'").each do |page|
-      page.save
-    end
+    Page.where("url NOT LIKE 'http://%' AND url NOT LIKE 'https://%' AND url NOT LIKE 'ftp://%'").each(&:save)
   end
 
   def down
-    raise ActiveRecord::IrreversibleMigration, "This migration modifies existing bad data and cannot be reversed."
+    raise ActiveRecord::IrreversibleMigration,
+      'This migration modifies existing bad data and cannot be reversed.'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170314230643) do
+ActiveRecord::Schema.define(version: 20170425211418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class PageTest < ActiveSupport::TestCase
-  test "page urls should always have a protocol" do
+  test 'page urls should always have a protocol' do
     page = Page.create(url: 'www.example.com/whatever')
     assert_equal('http://www.example.com/whatever', page.url, 'The URL was not given a protocol')
 
@@ -9,7 +9,7 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('https://www.example.com/whatever', page.url, 'The URL was modified unnecessarily')
   end
 
-  test "page urls without a domain should be invalid" do
+  test 'page urls without a domain should be invalid' do
     page = Page.create(url: 'some/path/to/a/page')
     assert_not(page.valid?, 'The page should be invalid because it has no domain')
   end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -1,7 +1,16 @@
 require 'test_helper'
 
 class PageTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "page urls should always have a protocol" do
+    page = Page.create(url: 'www.example.com/whatever')
+    assert_equal('http://www.example.com/whatever', page.url, 'The URL was not given a protocol')
+
+    page = Page.create(url: 'https://www.example.com/whatever')
+    assert_equal('https://www.example.com/whatever', page.url, 'The URL was modified unnecessarily')
+  end
+
+  test "page urls without a domain should be invalid" do
+    page = Page.create(url: 'some/path/to/a/page')
+    assert_not(page.valid?, 'The page should be invalid because it has no domain')
+  end
 end


### PR DESCRIPTION
Fixes #25 and ensures that pages always have absolute URLs.

- If they are missing a scheme, it adds `https://`
- If they are missing a domain and TLD, they are marked as invalid so the page can’t be saved

This also adds a migration that fixes up existing page records.