### PR TITLE
Add some querystring filters for pages and versions!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,10 +15,7 @@ AllCops:
     - vendor/**/*
 
 Metrics/ClassLength:
-  Exclude:
-    - 'lib/versionista_service/*'
-    - 'app/jobs/import_versions_job.rb'
-    - 'test/**/*.rb'
+  Enabled: false
 
 Metrics/ParameterLists:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,9 @@ Style/EmptyLines:
 Style/GuardClause:
   Enabled: false
 
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 Style/RegexpLiteral:
   AllowInnerSlashes: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Metrics/ClassLength:
   Exclude:
     - 'lib/versionista_service/*'
     - 'app/jobs/import_versions_job.rb'
+    - 'test/**/*.rb'
 
 Metrics/ParameterLists:
   Exclude:

--- a/app/controllers/api/v0/annotations_controller.rb
+++ b/app/controllers/api/v0/annotations_controller.rb
@@ -50,7 +50,7 @@ class Api::V0::AnnotationsController < Api::V0::ApiController
       from_uuid: parent_change.from_version.id,
       to_uuid: parent_change.version.id
     })
-    api_v0_page_annotations_path(*args)
+    api_v0_page_annotations_url(*args)
   end
 
   def set_annotation

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -75,26 +75,11 @@ class Api::V0::ApiController < ApplicationController
     end
   end
 
-  def where_range_or_exact_param(collection, name, attribute = nil, &parse)
+  def where_in_range_param(collection, name, attribute = nil, &parse)
+    return collection unless params[name]
+
     attribute = name if attribute.nil?
     range = parse_unbounded_range!(params[name], name, &parse)
-    return collection unless range
-
-    if attribute.is_a?(String) && attribute.include?('.')
-      join_model = attribute.split('.')[0].to_sym
-      collection = collection.joins(join_model)
-    end
-
-    if range.is_a? Array
-      where_in_unbounded_range(collection, attribute, *range)
-    elsif range
-      collection.where("#{attribute} = ?", range)
-    end
-  end
-
-  def where_in_unbounded_range(collection, attribute, from, to)
-    collection = collection.where("#{attribute} >= ?", from) if from
-    collection = collection.where("#{attribute} <= ?", to) if to
-    collection
+    collection.where_in_unbounded_range(attribute, range)
   end
 end

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -48,4 +48,16 @@ class Api::V0::ApiController < ApplicationController
       (error.try(:has_key?, :message) && error.send(:[], :message)) ||
       error.to_s
   end
+
+  def filter_param(collection, name, attribute = nil)
+    attribute = name if attribute.nil?
+    params[name] ? collection.where(attribute => params[name]) : collection
+  end
+
+  def parse_date!(date)
+    raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d\:\d\d(\:\d\d(\.\d+)?)?(Z|([+\-]\d{4})))?$/)
+    DateTime.parse date
+  rescue
+    raise Api::InputError, "Invalid date: '#{date}'"
+  end
 end

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -49,15 +49,52 @@ class Api::V0::ApiController < ApplicationController
       error.to_s
   end
 
-  def filter_param(collection, name, attribute = nil)
-    attribute = name if attribute.nil?
-    params[name] ? collection.where(attribute => params[name]) : collection
-  end
-
   def parse_date!(date)
     raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d\:\d\d(\:\d\d(\.\d+)?)?(Z|([+\-]\d{4})))?$/)
     DateTime.parse date
   rescue
     raise Api::InputError, "Invalid date: '#{date}'"
+  end
+
+  def parse_unbounded_range!(string_range, param = nil)
+    return nil unless string_range
+
+    if string_range.include? '..'
+      from, to = string_range.split(/\.\.\.?/)
+      from = from.present? ? (yield from) : nil
+      to = to.present? ? (yield to) : nil
+
+      if from.nil? && to.nil?
+        name = param ? "#{param} range" : 'Range'
+        raise Api::InputError, "#{name} must have a start or end"
+      end
+
+      [from, to]
+    else
+      yield string_range
+    end
+  end
+
+  def where_range_or_exact_param(collection, name, attribute = nil, &parse)
+    attribute = name if attribute.nil?
+    range = parse_unbounded_range!(params[name], name, &parse)
+    return collection unless range
+
+    if attribute.is_a?(String) && attribute.include?('.')
+      join_model = attribute.split('.')[0].to_sym
+      collection = collection.joins(join_model)
+    end
+
+    if range.is_a? Array
+      where_in_unbounded_range(collection, attribute, *range)
+    elsif range
+      collection.where("#{attribute} = ?", range)
+    end
+  end
+
+  def where_in_unbounded_range(collection, attribute, from, to)
+    collection = collection.where("#{attribute} >= ?", from) if from
+    collection = collection.where("#{attribute} <= ?", to) if to
+    collection
   end
 end

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -26,7 +26,7 @@ class Api::V0::PagesController < Api::V0::ApiController
   def page_collection
     collection = Page.where(params.permit(:site, :agency))
 
-    collection = where_range_or_exact_param(
+    collection = where_in_range_param(
       collection,
       :capture_time,
       'versions.capture_time',

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -1,9 +1,6 @@
 class Api::V0::PagesController < Api::V0::ApiController
   def index
-    query = Page.all
-    query = query.where(site: params[:site]) if params[:site]
-    query = query.where(agency: params[:agency]) if params[:agency]
-
+    query = page_collection
     paging = pagination(query)
     pages = query.order(updated_at: :desc).limit(paging[:page_items]).offset(paging[:offset])
 
@@ -24,5 +21,21 @@ class Api::V0::PagesController < Api::V0::ApiController
 
   def paging_path_for_page(*args)
     api_v0_pages_path(*args)
+  end
+
+  def page_collection
+    collection = Page.all
+    collection = collection.where(site: params[:site]) if params[:site]
+    collection = collection.where(agency: params[:agency]) if params[:agency]
+    if params[:url]
+      query = params[:url]
+      if query.include? '*'
+        query = query.gsub('%', '\%').gsub('_', '\_').tr('*', '%')
+        collection = collection.where('url LIKE ?', query)
+      else
+        collection = collection.where(url: query)
+      end
+    end
+    collection
   end
 end

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -20,7 +20,7 @@ class Api::V0::PagesController < Api::V0::ApiController
   protected
 
   def paging_path_for_page(*args)
-    api_v0_pages_path(*args)
+    api_v0_pages_url(*args)
   end
 
   def page_collection

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -24,7 +24,7 @@ class Api::V0::PagesController < Api::V0::ApiController
   end
 
   def page_collection
-    collection = Page.where(params.permit(:site, :agency))
+    collection = Page.where(params.permit(:agency, :site, :title))
 
     collection = where_in_range_param(
       collection,

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -25,8 +25,9 @@ class Api::V0::PagesController < Api::V0::ApiController
 
   def page_collection
     collection = Page.all
-    collection = collection.where(site: params[:site]) if params[:site]
-    collection = collection.where(agency: params[:agency]) if params[:agency]
+    collection = filter_param(collection, :site)
+    collection = filter_param(collection, :agency)
+
     if params[:url]
       query = params[:url]
       if query.include? '*'
@@ -36,6 +37,31 @@ class Api::V0::PagesController < Api::V0::ApiController
         collection = collection.where(url: query)
       end
     end
+
+    capture_time = params[:capture_time]
+    if capture_time
+      if capture_time.include? '..'
+        from, to = capture_time.split(/\.\.\.?/)
+        if from.empty? && to.empty?
+          raise Api::InputError, "Invalid date range: '#{capture_time}'"
+        end
+
+        with_versions = collection.joins(:versions)
+        if from.present?
+          from = parse_date! from
+          collection = with_versions.where('versions.capture_time >= ?', from)
+        end
+        if to.present?
+          to = parse_date! to
+          collection = with_versions.where('versions.capture_time <= ?', to)
+        end
+      else
+        collection = with_versions.where(versions: {
+          capture_time: parse_date!(capture_time)
+        })
+      end
+    end
+
     collection
   end
 end

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -1,7 +1,10 @@
 class Api::V0::PagesController < Api::V0::ApiController
   def index
-    paging = pagination(Page.all)
-    pages = Page.order(updated_at: :desc).limit(paging[:page_items]).offset(paging[:offset])
+    query = Page.all
+    query = query.where(site: params[:site]) if params[:site]
+
+    paging = pagination(query)
+    pages = query.order(updated_at: :desc).limit(paging[:page_items]).offset(paging[:offset])
 
     render json: {
       links: paging[:links],

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -2,6 +2,7 @@ class Api::V0::PagesController < Api::V0::ApiController
   def index
     query = Page.all
     query = query.where(site: params[:site]) if params[:site]
+    query = query.where(agency: params[:agency]) if params[:agency]
 
     paging = pagination(query)
     pages = query.order(updated_at: :desc).limit(paging[:page_items]).offset(paging[:offset])

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -4,9 +4,12 @@ class Api::V0::PagesController < Api::V0::ApiController
     paging = pagination(query)
     pages = query.order(updated_at: :desc).limit(paging[:page_items]).offset(paging[:offset])
 
+    json_options = {}
+    json_options[:include] = :versions if should_include_versions
+
     render json: {
       links: paging[:links],
-      data: pages
+      data: pages.as_json(json_options)
     }
   end
 
@@ -21,6 +24,10 @@ class Api::V0::PagesController < Api::V0::ApiController
 
   def paging_path_for_page(*args)
     api_v0_pages_url(*args)
+  end
+
+  def should_include_versions
+    'true'.casecmp?(params[:include_versions] || '')
   end
 
   def page_collection
@@ -42,6 +49,8 @@ class Api::V0::PagesController < Api::V0::ApiController
         collection = collection.where(url: query)
       end
     end
+
+    collection = collection.includes(:versions) if should_include_versions
 
     collection
   end

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -40,6 +40,14 @@ class Api::V0::PagesController < Api::V0::ApiController
       &method(:parse_date!)
     )
 
+    version_params = params.permit(:hash, :source_type)
+    if version_params.present?
+      collection = collection.joins(:versions).where(versions: {
+        version_hash: params[:hash],
+        source_type: params[:source_type]
+      }.compact)
+    end
+
     if params[:url]
       query = params[:url]
       if query.include? '*'

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -80,7 +80,8 @@ class Api::V0::VersionsController < Api::V0::ApiController
 
   def version_collection
     collection = page.versions
-    collection = collection.where(version_hash: params[:hash]) if params[:hash]
+    collection = filter_param(collection, :hash, :version_hash)
+    collection = filter_param(collection, :source_type)
 
     capture_time = params[:capture_time]
     if capture_time
@@ -103,6 +104,11 @@ class Api::V0::VersionsController < Api::V0::ApiController
     end
 
     collection
+  end
+
+  def filter_param(collection, name, attribute = nil)
+    attribute = name if attribute.nil?
+    params[name] ? collection.where(attribute => params[name]) : collection
   end
 
   def parse_date!(date)

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -11,7 +11,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
   end
 
   def show
-    @version ||= page.versions.find(params[:id])
+    @version ||= version_collection.find(params[:id])
     render json: {
       links: {
         page: api_v0_page_url(@version.page),
@@ -54,10 +54,15 @@ class Api::V0::VersionsController < Api::V0::ApiController
   protected
 
   def paging_path_for_version(*args)
-    api_v0_page_versions_path(*args)
+    if page
+      api_v0_page_versions_url(*args)
+    else
+      api_v0_versions_url(*args)
+    end
   end
 
   def page
+    return nil unless params.key? :page_id
     @page ||= Page.find(params[:page_id])
   end
 
@@ -79,7 +84,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
   end
 
   def version_collection
-    collection = page.versions
+    collection = page ? page.versions : Version.all
     collection = filter_param(collection, :hash, :version_hash)
     collection = filter_param(collection, :source_type)
 

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -95,6 +95,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
         if from.empty? && to.empty?
           raise Api::InputError, "Invalid date range: '#{capture_time}'"
         end
+
         if from.present?
           from = parse_date! from
           collection = collection.where('capture_time >= ?', from)
@@ -109,17 +110,5 @@ class Api::V0::VersionsController < Api::V0::ApiController
     end
 
     collection
-  end
-
-  def filter_param(collection, name, attribute = nil)
-    attribute = name if attribute.nil?
-    params[name] ? collection.where(attribute => params[name]) : collection
-  end
-
-  def parse_date!(date)
-    raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d\:\d\d(\:\d\d(\.\d+)?)?(Z|([+\-]\d{4})))?$/)
-    DateTime.parse date
-  rescue
-    raise Api::InputError, "Invalid date: '#{date}'"
   end
 end

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -106,11 +106,9 @@ class Api::V0::VersionsController < Api::V0::ApiController
   end
 
   def parse_date!(date)
-    begin
-      raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d\:\d\d(\:\d\d(\.\d+)?)?(Z|([+\-]\d{4})))?$/)
-      DateTime.parse date
-    rescue
-      raise Api::InputError, "Invalid date: '#{date}'"
-    end
+    raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d\:\d\d(\:\d\d(\.\d+)?)?(Z|([+\-]\d{4})))?$/)
+    DateTime.parse date
+  rescue
+    raise Api::InputError, "Invalid date: '#{date}'"
   end
 end

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -1,7 +1,8 @@
 class Api::V0::VersionsController < Api::V0::ApiController
   def index
-    paging = pagination(page.versions)
-    versions = page.versions.limit(paging[:page_items]).offset(paging[:offset])
+    query = version_collection
+    paging = pagination(query)
+    versions = query.limit(paging[:page_items]).offset(paging[:offset])
 
     render json: {
       links: paging[:links],
@@ -75,5 +76,11 @@ class Api::V0::VersionsController < Api::V0::ApiController
       .require(:version)
       .select {|key| permitted_keys.include?(key)}
       .permit!
+  end
+
+  def version_collection
+    collection = page.versions
+    collection = collection.where(version_hash: params[:hash]) if params[:hash]
+    collection
   end
 end

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -91,6 +91,6 @@ class Api::V0::VersionsController < Api::V0::ApiController
       source_type: params[:source_type]
     }.compact)
 
-    where_range_or_exact_param(collection, :capture_time, &method(:parse_date!))
+    where_in_range_param(collection, :capture_time, &method(:parse_date!))
   end
 end

--- a/app/controllers/concerns/paging_concern.rb
+++ b/app/controllers/concerns/paging_concern.rb
@@ -33,16 +33,36 @@ module PagingConcern
     page_offset = (page_number - 1) * PAGE_SIZE
 
     links = {
-      first: path_resolver.call(collection_type, page: 1, format: format_type),
-      last: path_resolver.call(collection_type, page: total_pages, format: format_type),
+      first: path_resolver.call(
+        collection_type,
+        page: 1,
+        format: format_type,
+        params: request.query_parameters
+      ),
+      last: path_resolver.call(
+        collection_type,
+        page: total_pages,
+        format: format_type,
+        params: request.query_parameters
+      ),
       prev: nil,
       next: nil
     }
     if page_number > 1
-      links[:prev] = path_resolver.call(collection_type, page: page_number - 1, format: format_type)
+      links[:prev] = path_resolver.call(
+        collection_type,
+        page: page_number - 1,
+        format: format_type,
+        params: request.query_parameters
+      )
     end
     if page_number < total_pages
-      links[:next] = path_resolver.call(collection_type, page: page_number + 1, format: format_type)
+      links[:next] = path_resolver.call(
+        collection_type,
+        page: page_number + 1,
+        format: format_type,
+        params: request.query_parameters
+      )
     end
 
     {

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,23 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.where_in_unbounded_range(attribute, range, exact = true)
+    result = self
+
+    if attribute.is_a?(String) && attribute.include?('.')
+      join_model = attribute.split('.')[0].to_sym
+      result = result.joins(join_model)
+    end
+
+    if range.is_a? Array
+      result = result.where("#{attribute} >= ?", range[0]) if range[0]
+      result = result.where("#{attribute} <= ?", range[1]) if range[1]
+    elsif exact
+      result = result.where("#{attribute} = ?", range)
+    else
+      raise StandardError, 'Range must be an array in `where_in_unbounded_range`'
+    end
+
+    result
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
           only: [:index, :show, :create]
       end
 
+      resources :versions, only: [:index, :show], format: :json
       resources :imports, only: [:create, :show], format: :json
     end
   end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -9,4 +9,16 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert body_json.key?('links'), 'Response should have a "links" property'
     assert body_json.key?('data'), 'Response should have a "data" property'
   end
+
+  test 'can filter pages by site' do
+    site = 'http://example.com/'
+    get "/api/v0/pages/?site=#{URI.encode_www_form_component site}"
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, pages(:home_page).uuid,
+      'Results did not include pages for the filtered site'
+    assert_not_includes ids, pages(:home_page_site2).uuid,
+      'Results included pages not matching filtered site'
+  end
 end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -34,6 +34,18 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
       'Results included pages not matching filtered agency'
   end
 
+  test 'can filter pages by title' do
+    title = 'Page One'
+    get api_v0_pages_path(title: title)
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, pages(:home_page).uuid,
+      'Results did not include pages for the filtered site'
+    assert_not_includes ids, pages(:home_page_site2).uuid,
+      'Results included pages not matching filtered site'
+  end
+
   test 'can filter pages by URL' do
     url = 'http://example.com/'
     get "/api/v0/pages/?url=#{URI.encode_www_form_component url}"

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -74,6 +74,28 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
       'Results included pages not matching filtered URL'
   end
 
+  test 'can filter pages by version source_type' do
+    get api_v0_pages_path(source_type: 'pagefreezer')
+    body = JSON.parse @response.body
+    ids = body['data'].pluck 'uuid'
+
+    assert_includes ids, pages(:home_page).uuid,
+      'Results did not include pages with versions captured by pagefreezer'
+    assert_not_includes ids, pages(:home_page_site2).uuid,
+      'Results included pages with versions not captured by pagreezer'
+  end
+
+  test 'can filter pages by version hash' do
+    get api_v0_pages_path(hash: 'def')
+    body = JSON.parse @response.body
+    ids = body['data'].pluck 'uuid'
+
+    assert_includes ids, pages(:sub_page).uuid,
+      'Results did not include pages with versions matching the given hash'
+    assert_not_includes ids, pages(:home_page_site2).uuid,
+      'Results included pages with versions not matching the given hash'
+  end
+
   test 'can filter pages by version capture_time' do
     get api_v0_pages_url(
       capture_time: '2017-03-01T00:00:00Z..2017-03-01T12:00:00Z'

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Api::PagesControllerTest < ActionDispatch::IntegrationTest
+class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   test 'can list pages' do
     get '/api/v0/pages/'
     assert_response :success

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -61,4 +61,17 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes ids, pages(:home_page_site2).uuid,
       'Results included pages not matching filtered URL'
   end
+
+  test 'can filter pages by version capture_time' do
+    get api_v0_pages_url(
+      capture_time: '2017-03-01T00:00:00Z..2017-03-01T12:00:00Z'
+    )
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, pages(:home_page).uuid,
+      'Results did not include pages with versions captured in the filtered date range'
+    assert_not_includes ids, pages(:home_page_site2).uuid,
+      'Results included pages with versions not captured in the filtered date range'
+  end
 end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -33,4 +33,32 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes ids, pages(:home_page_site2).uuid,
       'Results included pages not matching filtered agency'
   end
+
+  test 'can filter pages by URL' do
+    url = 'http://example.com/'
+    get "/api/v0/pages/?url=#{URI.encode_www_form_component url}"
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, pages(:home_page).uuid,
+      'Results did not include the page with the filtered URL'
+    assert_not_includes ids, pages(:home_page_site2).uuid,
+      'Results included pages not matching filtered URL'
+    assert_not_includes ids, pages(:sub_page).uuid,
+      'Results included pages with similar but not same filtered URL'
+  end
+
+  test 'can filter pages by URL with "*" wildcard' do
+    url = 'http://example.com/*'
+    get "/api/v0/pages/?url=#{URI.encode_www_form_component url}"
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, pages(:home_page).uuid,
+      'Results did not include the page with the filtered URL'
+    assert_includes ids, pages(:sub_page).uuid,
+      'Results did not include the page with the filtered URL'
+    assert_not_includes ids, pages(:home_page_site2).uuid,
+      'Results included pages not matching filtered URL'
+  end
 end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -21,4 +21,16 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes ids, pages(:home_page_site2).uuid,
       'Results included pages not matching filtered site'
   end
+
+  test 'can filter pages by agency' do
+    agency = 'Department of Testing'
+    get "/api/v0/pages/?agency=#{URI.encode_www_form_component agency}"
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, pages(:dot_home_page).uuid,
+      'Results did not include pages for the filtered agency'
+    assert_not_includes ids, pages(:home_page_site2).uuid,
+      'Results included pages not matching filtered agency'
+  end
 end

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -37,4 +37,14 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     #   }
     # })
   end
+
+  test 'can filter versions by hash' do
+    target = versions(:page1_v1)
+    get api_v0_page_versions_url(pages(:home_page), hash: target.version_hash)
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, target.uuid,
+      'Results did not include pages for the filtered hash'
+  end
 end

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -129,4 +129,13 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/date/i, body_json['errors'][0]['title'],
       'Error does not mention date')
   end
+
+  test 'can filter versions by source_type' do
+    get api_v0_page_versions_url(pages(:home_page), source_type: 'pagefreezer')
+
+    body_json = JSON.parse @response.body
+    types = body_json['data'].collect {|v| v['source_type']}.uniq
+
+    assert_equal ['pagefreezer'], types, 'Got versions with wrong source_type'
+  end
 end

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -8,7 +8,15 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     body_json = JSON.parse(@response.body)
     assert(body_json.key?('links'), 'Response should have a "links" property')
     assert(body_json.key?('data'), 'Response should have a "data" property')
-    assert(body_json['data'].is_a?(Array), 'Data shoudl be an array')
+    assert(body_json['data'].is_a?(Array), 'Data should be an array')
+  end
+
+  test 'can list versions independent of pages' do
+    get api_v0_versions_url
+    assert_response(:success)
+    body_json = JSON.parse(@response.body)
+    assert(body_json.key?('data'), 'Response should have a "data" property')
+    assert(body_json['data'].is_a?(Array), 'Data should be an array')
   end
 
   test 'can post a new version' do

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -45,6 +45,88 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, target.uuid,
-      'Results did not include pages for the filtered hash'
+      'Results did not include versions for the filtered hash'
+  end
+
+  test 'can filter versions by exact date' do
+    get api_v0_page_versions_url(
+      pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z'
+    )
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, versions(:page1_v1).uuid,
+      'Results did not include versions captured on the filtered date'
+    assert_not_includes ids, versions(:page1_v2).uuid,
+      'Results included versions not captured on the filtered date'
+  end
+
+  test 'returns meaningful error for bad dates' do
+    get api_v0_page_versions_url(
+      pages(:home_page),
+      capture_time: 'ugh'
+    )
+    assert_response :bad_request
+
+    body_json = JSON.parse @response.body
+    assert body_json.key?('errors'), 'Response should have an "errors" property'
+    assert_match(/date/i, body_json['errors'][0]['title'],
+      'Error does not mention date')
+  end
+
+  test 'can filter versions by date range' do
+    get api_v0_page_versions_url(
+      pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z..2017-03-01T12:00:00Z'
+    )
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, versions(:page1_v1).uuid,
+      'Results did not include versions captured in the filtered date range'
+    assert_not_includes ids, versions(:page1_v2).uuid,
+      'Results included versions not captured in the filtered date range'
+  end
+
+  test 'can filter versions captured before a date' do
+    get api_v0_page_versions_url(
+      pages(:home_page),
+      capture_time: '..2017-03-01T12:00:00Z'
+    )
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, versions(:page1_v1).uuid,
+      'Results did not include versions captured in the filtered date range'
+    assert_not_includes ids, versions(:page1_v2).uuid,
+      'Results included versions not captured in the filtered date range'
+  end
+
+  test 'can filter versions captured after a date' do
+    get api_v0_page_versions_url(
+      pages(:home_page),
+      capture_time: '2017-03-01T12:00:00Z..'
+    )
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, versions(:page1_v2).uuid,
+      'Results did not include versions captured in the filtered date range'
+    assert_not_includes ids, versions(:page1_v1).uuid,
+      'Results included versions not captured in the filtered date range'
+  end
+
+  test 'returns meaningful error for bad date ranges' do
+    get api_v0_page_versions_url(
+      pages(:home_page),
+      capture_time: 'ugh..2017-03-04'
+    )
+    assert_response :bad_request
+
+    body_json = JSON.parse @response.body
+    assert body_json.key?('errors'), 'Response should have an "errors" property'
+    assert_match(/date/i, body_json['errors'][0]['title'],
+      'Error does not mention date')
   end
 end

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -15,3 +15,9 @@ home_page_site2:
   title: 'Site 2, yo!'
   agency: 'Department of Examples'
   site: 'http://example2.com/'
+
+dot_home_page:
+  url: 'http://depart-of-testing.com/index.html'
+  title: 'Welcome to the Department of Testing'
+  agency: 'Department of Testing'
+  site: 'DOT - Home Site'

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -9,3 +9,9 @@ sub_page:
   title: 'Page Two'
   agency: 'Department of Examples'
   site: 'http://example.com/'
+
+home_page_site2:
+  url: 'http://example2.com/index.html'
+  title: 'Site 2, yo!'
+  agency: 'Department of Examples'
+  site: 'http://example2.com/'

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -93,3 +93,16 @@ page1_v3:
       diff_length: 1234672,
       diff_hash: '749ab2c0d06c42ae3b841b79e79875f02b3a042e43c92378cd28bd444c04d284'
     }
+
+page1_v4:
+  page: home_page
+  capture_time: '2017-03-04T00:00:00Z'
+  version_hash: 'pqr'
+  source_type: 'pagefreezer'
+  source_metadata: >
+    {
+      account: 'test@example.com',
+      site_id: 1,
+      page_id: 11,
+      version_id: 114
+    }

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -7,6 +7,7 @@
 page1_v1:
   page: home_page
   capture_time: '2017-03-01T00:00:00Z'
+  version_hash: 'abc'
   source_type: 'versionista'
   source_metadata: >
     {
@@ -24,6 +25,7 @@ page1_v1:
 page2_v1:
   page: sub_page
   capture_time: '2017-03-01T00:00:00Z'
+  version_hash: 'def'
   source_type: 'versionista'
   source_metadata: >
     {
@@ -41,6 +43,7 @@ page2_v1:
 page1_v2:
   page: home_page
   capture_time: '2017-03-02T00:00:00Z'
+  version_hash: 'ghi'
   source_type: 'versionista'
   source_metadata: >
     {
@@ -58,6 +61,7 @@ page1_v2:
 page2_v2:
   page: sub_page
   capture_time: '2017-03-02T00:00:00Z'
+  version_hash: 'jkl'
   source_type: 'versionista'
   source_metadata: >
     {
@@ -75,6 +79,7 @@ page2_v2:
 page1_v3:
   page: home_page
   capture_time: '2017-03-03T00:00:00Z'
+  version_hash: 'mno'
   source_type: 'versionista'
   source_metadata: >
     {

--- a/test/lib/file_storage/local_file_test.rb
+++ b/test/lib/file_storage/local_file_test.rb
@@ -1,4 +1,4 @@
-require_dependency 'file_storage/local_file'
+require 'test_helper'
 
 class FileStorage::LocalFileTest < ActiveSupport::TestCase
   storage_path = Rails.root.join('tmp/test/storage')

--- a/test/lib/file_storage/s3_test.rb
+++ b/test/lib/file_storage/s3_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require_dependency 'file_storage/s3'
 
 class FileStorage::S3Test < ActiveSupport::TestCase
   def test_storage


### PR DESCRIPTION
Pages can be filtered by:

- Site (`/pages?site={site name}`)
- Agency (`/pages?agency={agency name}`)
- URL (`/pages?url={url}` where `url` can contain `*` as a wildcard)

Versions can be filtered by:

- Hash (`/pages/{page id}/versions?hash={hash}`)
- Capture time (`/pages/{page id}/versions?capture_time={time}` where `time` is a [W3C-style ISO 8601 date/time](https://www.w3.org/TR/NOTE-datetime))

    Note `time` can also be a range, as in `time..time`, e.g. `2017-04-01T10:00Z..2017-04-01T12:00Z` for versions between 10am and noon on April 1st.

Fixes #13.