### PR TITLE
Make annotations editable

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -2,7 +2,7 @@ class Annotation < ApplicationRecord
   include UuidPrimaryKey
 
   belongs_to :change, foreign_key: :change_uuid, required: true, inverse_of: :annotations
-  belongs_to :author, class_name: 'User', foreign_key: :author_id, required: false
+  belongs_to :author, class_name: 'User', foreign_key: :author_id, required: true
   validate :annotation_must_be_an_object
 
   def as_json(options = nil)

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -23,7 +23,7 @@ class Change < ApplicationRecord
       end
   end
 
-  def annotate(data, author = nil)
+  def annotate(data, author)
     if data.blank?
       return
     end
@@ -36,13 +36,7 @@ class Change < ApplicationRecord
       self.save
     end
 
-    annotation =
-      if author
-        annotations.find_or_initialize_by(author: author)
-      else
-        annotations.new
-      end
-
+    annotation = annotations.find_or_initialize_by(author: author)
     annotation.annotation = data
     annotation.save
 

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -48,14 +48,6 @@ class Change < ApplicationRecord
     annotation
   end
 
-  def regenerate_current_annotation
-    self.current_annotation = annotations.reduce({}) do |merged, annotation|
-      merge_annotations(merged, annotation.annotation)
-    end
-  end
-
-  protected
-
   # Update the `current_annotation property, which is a materialized view of
   # all annotations stacked together. If a property does not exist in the
   # the current annotation, it simply does not affect the materialized
@@ -69,9 +61,13 @@ class Change < ApplicationRecord
   # Result in this materialized annotation:
   #   {"a": "Not one anymore!", "c": "three"}
   #
-  def update_current_annotation(new_annotation)
-    self.current_annotation = merge_annotations(self.current_annotation, new_annotation)
+  def regenerate_current_annotation
+    self.current_annotation = annotations.reduce({}) do |merged, annotation|
+      merge_annotations(merged, annotation.annotation)
+    end
   end
+
+  protected
 
   def merge_annotations(base, updates)
     base.with_indifferent_access

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,7 +1,7 @@
 class Page < ApplicationRecord
   include UuidPrimaryKey
 
-  has_many :versions, -> { order(created_at: :desc) }, foreign_key: 'page_uuid', inverse_of: :page
+  has_many :versions, -> { order(capture_time: :desc) }, foreign_key: 'page_uuid', inverse_of: :page
 
   before_save :normalize_url
   validate :url_must_have_domain

--- a/db/migrate/20170517222310_change_annotation_author_to_not_null.rb
+++ b/db/migrate/20170517222310_change_annotation_author_to_not_null.rb
@@ -1,0 +1,23 @@
+class ChangeAnnotationAuthorToNotNull < ActiveRecord::Migration[5.1]
+  def do_sql(*args)
+    expression = ActiveRecord::Base.send :sanitize_sql, args
+    ActiveRecord::Base.connection.exec_query(expression)
+  end
+
+  def up
+    default_author_id = do_sql(
+      'SELECT id FROM users ORDER BY created_at ASC LIMIT 1'
+    ).first['id']
+
+    do_sql(
+      'UPDATE annotations SET author_id = ? WHERE author_id IS NULL',
+      default_author_id
+    )
+
+    change_column_null :annotations, :author_id, false
+  end
+
+  def down
+    change_column_null :annotations, :author_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,101 +10,101 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170508221326) do
+ActiveRecord::Schema.define(version: 20170517222310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "annotations", primary_key: "uuid", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "change_uuid", null: false
-    t.integer  "author_id"
-    t.jsonb    "annotation",  null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["author_id"], name: "index_annotations_on_author_id", using: :btree
-    t.index ["change_uuid"], name: "index_annotations_on_change_uuid", using: :btree
+    t.uuid "change_uuid", null: false
+    t.integer "author_id", null: false
+    t.jsonb "annotation", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_annotations_on_author_id"
+    t.index ["change_uuid"], name: "index_annotations_on_change_uuid"
   end
 
   create_table "changes", primary_key: "uuid", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "uuid_from",                        null: false
-    t.uuid     "uuid_to",                          null: false
-    t.float    "priority",           default: 0.5
-    t.jsonb    "current_annotation"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.index ["uuid_to", "uuid_from"], name: "index_changes_on_uuid_to_and_uuid_from", unique: true, using: :btree
-    t.index ["uuid_to"], name: "index_changes_on_uuid_to", using: :btree
+    t.uuid "uuid_from", null: false
+    t.uuid "uuid_to", null: false
+    t.float "priority", default: 0.5
+    t.jsonb "current_annotation"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uuid_to", "uuid_from"], name: "index_changes_on_uuid_to_and_uuid_from", unique: true
+    t.index ["uuid_to"], name: "index_changes_on_uuid_to"
   end
 
-  create_table "imports", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "status",            default: 0, null: false
-    t.string   "file"
-    t.jsonb    "processing_errors"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.index ["user_id"], name: "index_imports_on_user_id", using: :btree
+  create_table "imports", id: :serial, force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "status", default: 0, null: false
+    t.string "file"
+    t.jsonb "processing_errors"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_imports_on_user_id"
   end
 
-  create_table "invitations", force: :cascade do |t|
-    t.integer  "issuer_id"
-    t.integer  "redeemer_id"
-    t.string   "code"
-    t.string   "email"
+  create_table "invitations", id: :serial, force: :cascade do |t|
+    t.integer "issuer_id"
+    t.integer "redeemer_id"
+    t.string "code"
+    t.string "email"
     t.datetime "expires_on"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["code"], name: "index_invitations_on_code", using: :btree
-    t.index ["issuer_id"], name: "index_invitations_on_issuer_id", using: :btree
-    t.index ["redeemer_id"], name: "index_invitations_on_redeemer_id", using: :btree
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_invitations_on_code"
+    t.index ["issuer_id"], name: "index_invitations_on_issuer_id"
+    t.index ["redeemer_id"], name: "index_invitations_on_redeemer_id"
   end
 
   create_table "pages", primary_key: "uuid", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "url",        null: false
-    t.string   "title"
-    t.string   "agency"
-    t.string   "site"
+    t.string "url", null: false
+    t.string "title"
+    t.string "agency"
+    t.string "site"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["url"], name: "index_pages_on_url", using: :btree
-    t.index ["uuid", "site"], name: "index_pages_on_uuid_and_site", using: :btree
+    t.index ["url"], name: "index_pages_on_url"
+    t.index ["uuid", "site"], name: "index_pages_on_uuid_and_site"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
-    t.string   "reset_password_token"
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,     null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.string   "confirmation_token"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email"
-    t.boolean  "admin",                  default: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.string "unconfirmed_email"
+    t.boolean "admin", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   create_table "versions", primary_key: "uuid", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid     "page_uuid",       null: false
-    t.datetime "capture_time",    null: false
-    t.string   "uri"
-    t.string   "version_hash"
-    t.string   "source_type"
-    t.jsonb    "source_metadata"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.index ["capture_time"], name: "index_versions_on_capture_time", using: :btree
-    t.index ["page_uuid"], name: "index_versions_on_page_uuid", using: :btree
-    t.index ["version_hash"], name: "index_versions_on_version_hash", using: :btree
+    t.uuid "page_uuid", null: false
+    t.datetime "capture_time", null: false
+    t.string "uri"
+    t.string "version_hash"
+    t.string "source_type"
+    t.jsonb "source_metadata"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["capture_time"], name: "index_versions_on_capture_time"
+    t.index ["page_uuid"], name: "index_versions_on_page_uuid"
+    t.index ["version_hash"], name: "index_versions_on_version_hash"
   end
 
   add_foreign_key "annotations", "users", column: "author_id"

--- a/test/controllers/api/v0/annotations_controller_test.rb
+++ b/test/controllers/api/v0/annotations_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'can annotate a version' do
+    page = pages(:home_page)
+    annotation = { 'test_key' => 'test_value' }
+
+    sign_in users(:alice)
+    post(
+      api_v0_page_version_annotations_path(page, page.versions[0]),
+      as: :json,
+      params: annotation
+    )
+
+    assert_response :success
+    assert_equal 'application/json', @response.content_type
+    body = JSON.parse @response.body
+    assert body.key?('links'), 'Response should have a "links" property'
+    assert body.key?('data'), 'Response should have a "data" property'
+    assert_equal annotation, body['data']['annotation']
+  end
+end

--- a/test/controllers/api/v0/annotations_controller_test.rb
+++ b/test/controllers/api/v0/annotations_controller_test.rb
@@ -21,4 +21,54 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
     assert body.key?('data'), 'Response should have a "data" property'
     assert_equal annotation, body['data']['annotation']
   end
+
+  test 'posting a new annotation updates previous annotations by the same user' do
+    page = pages(:home_page)
+    annotation1 = { 'test_key' => 'test_value' }
+    annotation2 = { 'test_key' => 'new_value' }
+
+    sign_in users(:alice)
+    post(
+      api_v0_page_version_annotations_path(page, page.versions[0]),
+      as: :json,
+      params: annotation1
+    )
+    post(
+      api_v0_page_version_annotations_path(page, page.versions[0]),
+      as: :json,
+      params: annotation2
+    )
+    get(api_v0_page_version_annotations_path(page, page.versions[0]))
+
+    assert_response :success
+    body = JSON.parse @response.body
+    assert_equal 1, body['data'].length, 'Multiple annotations were created'
+    assert_equal annotation2, body['data'][0]['annotation']
+  end
+
+  test 'multiple users can annotate a change' do
+    page = pages(:home_page)
+    annotation1 = { 'test_key' => 'test_value' }
+    annotation2 = { 'test_key' => 'new_value' }
+
+    sign_in users(:alice)
+    post(
+      api_v0_page_version_annotations_path(page, page.versions[0]),
+      as: :json,
+      params: annotation1
+    )
+
+    sign_in users(:admin_user)
+    post(
+      api_v0_page_version_annotations_path(page, page.versions[0]),
+      as: :json,
+      params: annotation2
+    )
+
+    get(api_v0_page_version_annotations_path(page, page.versions[0]))
+
+    assert_response :success
+    body = JSON.parse @response.body
+    assert_equal 2, body['data'].length, 'Two annotations were not created'
+  end
 end

--- a/test/models/annotation_test.rb
+++ b/test/models/annotation_test.rb
@@ -1,21 +1,33 @@
 require 'test_helper'
 
 class AnnotationTest < ActiveSupport::TestCase
+  test 'annotations must have authors' do
+    annotation = Annotation.new(
+      change: changes(:page1_change_1_2),
+      annotation: { key: 'value' }
+    )
+    assert_not annotation.valid?
+    assert_includes annotation.errors, :author, 'There was no error for :author'
+  end
+
   test 'annotations must be objects' do
     created_with_nil = Annotation.create(
       change: changes(:page1_change_1_2),
+      author: users(:alice),
       annotation: nil
     )
     assert_not created_with_nil.valid? 'A nil annotation was valid'
 
     created_with_an_array = Annotation.create(
       change: changes(:page1_change_1_2),
+      author: users(:alice),
       annotation: ['a']
     )
     assert_not created_with_an_array.valid? 'An array annotation was valid'
 
     created_with_an_object = Annotation.create(
       change: changes(:page1_change_1_2),
+      author: users(:alice),
       annotation: { a: 'b' }
     )
     assert created_with_an_object.valid? 'An object annotation was not valid'

--- a/test/models/change_test.rb
+++ b/test/models/change_test.rb
@@ -3,14 +3,14 @@ require 'test_helper'
 class ChangeTest < ActiveSupport::TestCase
   test 'annotate should create an annotation' do
     change = versions(:page2_v2).change_from_previous
-    change.annotate({ test_field: 'test_value' })
+    change.annotate({ test_field: 'test_value' }, users(:alice))
 
     assert_equal 1, change.annotations.length, 'The wrong number of annotations were added!'
   end
 
   test 'adding an annotation should update current_annotation' do
     change = versions(:page2_v2).change_from_previous
-    change.annotate({ test_field: 'test_value' })
+    change.annotate({ test_field: 'test_value' }, users(:alice))
 
     assert_equal({ 'test_field' => 'test_value' }, change.current_annotation)
   end
@@ -18,8 +18,8 @@ class ChangeTest < ActiveSupport::TestCase
   test 'annotations should merge by including omitted properties and removing null properties' do
     change = versions(:page2_v2).change_from_previous
 
-    change.annotate({ one: 'a', two: 'b', three: 'c' })
-    change.annotate({ one: 'new!', three: nil })
+    change.annotate({ one: 'a', two: 'b', three: 'c' }, users(:admin_user))
+    change.annotate({ one: 'new!', three: nil }, users(:alice))
 
     assert_equal({ 'one' => 'new!', 'two' => 'b' }, change.current_annotation)
   end
@@ -28,7 +28,7 @@ class ChangeTest < ActiveSupport::TestCase
     change = versions(:page2_v2).change_from_previous
     assert_not change.persisted?, 'The change we are testing was not newly created'
 
-    change.annotate({ test_field: 'test_value' })
+    change.annotate({ test_field: 'test_value' }, users(:alice))
     assert change.persisted?, 'The change was not persisted'
   end
 
@@ -48,15 +48,6 @@ class ChangeTest < ActiveSupport::TestCase
 
     change.annotate({ one: 'a', two: 'b', three: 'c' }, users(:alice))
     change.annotate({ one: 'new!', three: nil }, users(:admin_user))
-
-    assert_equal 2, change.annotations.count, 'The wrong number of annotations were made'
-  end
-
-  test 'subsequent annotations with no user should create new annotations' do
-    change = versions(:page2_v2).change_from_previous
-
-    change.annotate({ one: 'a', two: 'b', three: 'c' })
-    change.annotate({ one: 'new!', three: nil })
 
     assert_equal 2, change.annotations.count, 'The wrong number of annotations were made'
   end


### PR DESCRIPTION
When POSTing an annotation, any existing annotation by the current user on the current change gets edited/overwritten instead of appending a new annotation. The basic effect is that each change can only have one annotation per user, which is updated whenever the user posts a new annotation.

This shouldn’t really affect the API significantly; it allows a UI to push new annotations as the user works instead of waiting for them to explicitly commit (without winding up with a gazillion annotations).

Fixes #46