### PR TITLE
Allow a variety of booleans for include_versions

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -49,6 +49,12 @@ class Api::V0::ApiController < ApplicationController
       error.to_s
   end
 
+  def boolean_param(param, presence_implies_true = true)
+    value = params[param]
+    return true if params.key?(param) && value.nil? && presence_implies_true
+    /^(true|t|1)$/i.match? value
+  end
+
   def parse_date!(date)
     raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d\:\d\d(\:\d\d(\.\d+)?)?(Z|([+\-]\d{4})))?$/)
     DateTime.parse date

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -27,7 +27,7 @@ class Api::V0::PagesController < Api::V0::ApiController
   end
 
   def should_include_versions
-    'true'.casecmp?(params[:include_versions] || '')
+    boolean_param :include_versions
   end
 
   def page_collection

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -136,4 +136,32 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     home_page = results.find {|page| page['uuid'] == pages(:home_page).uuid}
     assert_equal 1, home_page['versions'].length, '"Home page" included too many versions'
   end
+
+  test 'include_versions can be "1"' do
+    get api_v0_pages_path(include_versions: 1)
+    body = JSON.parse @response.body
+    results = body['data']
+    assert results.all? {|p| p.key? 'versions'}, 'Some pages did not have a "versions" property'
+  end
+
+  test 'include_versions can be "t"' do
+    get api_v0_pages_path(include_versions: 't')
+    body = JSON.parse @response.body
+    results = body['data']
+    assert results.all? {|p| p.key? 'versions'}, 'Some pages did not have a "versions" property'
+  end
+
+  test 'include_versions can be value-less (e.g. "pages?include_versions")' do
+    get "#{api_v0_pages_path}?include_versions"
+    body = JSON.parse @response.body
+    results = body['data']
+    assert results.all? {|p| p.key? 'versions'}, 'Some pages did not have a "versions" property'
+  end
+
+  test 'include_versions cannot be an empty string (e.g. "pages?include_versions")' do
+    get "#{api_v0_pages_path}?include_versions="
+    body = JSON.parse @response.body
+    results = body['data']
+    assert_not results.any? {|p| p.key? 'versions'}, 'Some pages have a "versions" property'
+  end
 end


### PR DESCRIPTION
It can be:

- valueless (`?include_versions`, but not `?include_versions=`)
- t
- 1

As a bonus, this is fairly generic so we can use it for other things in the future.