### PR TITLE
Optimize the basic page listing call in the API

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -4,8 +4,9 @@ class Api::V0::PagesController < Api::V0::ApiController
     paging = pagination(query)
     pages = query.order(updated_at: :desc).limit(paging[:page_items]).offset(paging[:offset])
 
-    json_options = {}
-    json_options[:include] = :versions if should_include_versions
+    json_options = {
+      include: should_include_versions ? :versions : :latest
+    }
 
     render json: {
       links: paging[:links],
@@ -58,7 +59,9 @@ class Api::V0::PagesController < Api::V0::ApiController
       end
     end
 
-    collection = collection.includes(:versions) if should_include_versions
+    collection = collection.includes(
+      should_include_versions ? :versions : :latest
+    )
 
     collection
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,11 +2,18 @@ class Page < ApplicationRecord
   include UuidPrimaryKey
 
   has_many :versions, -> { order(capture_time: :desc) }, foreign_key: 'page_uuid', inverse_of: :page
-  has_one :latest, (lambda do
-    relation = order('versions.page_uuid')
-    relation.select_values = ['DISTINCT ON (versions.page_uuid) versions.*']
-    relation.order('versions.capture_time DESC')
-  end), foreign_key: 'page_uuid', class_name: 'Version'
+  has_one :latest,
+    (lambda do
+      # DISTINCT ON requires the first ORDER to be the distinct column(s)
+      relation = order('versions.page_uuid')
+      # HACK: This is not public API, but I couldn't find a better way. The
+      # `DISTINCT ON` statement has to be at the start of the WHERE clause, but
+      # all public methods append to the end.
+      relation.select_values = ['DISTINCT ON (versions.page_uuid) versions.*']
+      relation.order('versions.capture_time DESC')
+    end),
+    foreign_key: 'page_uuid',
+    class_name: 'Version'
 
   before_save :normalize_url
   validate :url_must_have_domain

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,6 +2,11 @@ class Page < ApplicationRecord
   include UuidPrimaryKey
 
   has_many :versions, -> { order(capture_time: :desc) }, foreign_key: 'page_uuid', inverse_of: :page
+  has_one :latest, (lambda do
+    relation = order('versions.page_uuid')
+    relation.select_values = ['DISTINCT ON (versions.page_uuid) versions.*']
+    relation.order('versions.capture_time DESC')
+  end), foreign_key: 'page_uuid', class_name: 'Version'
 
   before_save :normalize_url
   validate :url_must_have_domain
@@ -13,16 +18,6 @@ class Page < ApplicationRecord
     else
       "http://#{url}"
     end
-  end
-
-  # A serialized page should always include some version info. If expanded
-  # version objects weren't requested, it includes the latest version.
-  def as_json(*args)
-    result = super(*args)
-    if result['versions'].nil?
-      result['latest'] = self.versions.first.as_json
-    end
-    result
   end
 
   protected


### PR DESCRIPTION
While working on https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/48, I realized I was pushing the staging server pretty hard. I knew the queries being done at `/api/v0/pages` were sub-optimal, but hadn’t bothered to fix them. Now that the logger is sending me a big pile of e-mails, it seemed like a good idea to fix it :P

Anyway, the basic idea here is to turn `Page#latest` into an actual association (albeit a little bit of an oddball one) so that ActiveRecord can actually preload it. Now we perform 2 queries for the whole page instead of 101 queries.