### PR TITLE
Fix totally borked invitation code generation

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -56,8 +56,10 @@ class Invitation < ApplicationRecord
   private
 
   def assign_code
-    token = generate_code while Invitation.where(:code => token).exists?
-    self.code = token
+    self.code = loop do
+      token = generate_code
+      break token unless Invitation.where(:code => token).exists?
+    end
   end
 
   def generate_code

--- a/test/fixtures/invitations.yml
+++ b/test/fixtures/invitations.yml
@@ -6,3 +6,4 @@
 #
 with_email:
   email: test-unknown@example.com
+  code: abc


### PR DESCRIPTION
Well this is embarrassing.

Ridiculously, the first invitation created would wind up having no invitation code. This is because I'm an idiot and am not used to Ruby's while/if-at-the-end-of-the-line style and didn't realize the code would first be initialized to Nil instead of a generated hash value. Once we had one bad invitation in the DB, others would behave because the routine would see that their Nil code collided with the original Nil code.

Also fixes the poorly-coded fixture that masked this issue in tests.

This is one of two problems we have with sending invitations and confirming new users in production. The other is #50.