### PR TITLE
Send e-mails with Postmark

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,14 @@ export HOST_URL='web-monitoring-db.dev'
 # OPTIONAL: only set this if your Redis is at a non-standard location
 # REDIS_URL=redis://user:password@localhost:6379
 
-# OPTIONAL: Uncomment and fill in to use an actual SMTP server instead of
-# sendmail for user invitations and other e-mails
-# export MAIL_SENDER='some-email-account@example.com'
+# E-mail address to use as the "from" address
+export MAIL_SENDER='some-email-account@example.com'
+
+# OPTIONAL: Use the following to send e-mail via Postmark instead of sendmail
+# (We use this in production)
+# export POSTMARK_API_TOKEN=XXX
+
+# OPTIONAL: Use the following to send via SMTP instead of sendmail
 # export MAIL_SMTP_ADDRESS='smtp.example.com'
 # export MAIL_SMTP_DOMAIN='example.com'
 # export MAIL_SMTP_USER='some-email-account'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'devise'
 gem 'httparty'
 gem 'rails', '~> 5.1.1'
 gem 'pg', '~> 0.18'
+# Send transactional e-mail with Postmark
+gem 'postmark-rails'
 gem 'puma', '~> 3.0'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'resque'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       activesupport (>= 3.0.0)
       multi_json (>= 1.2)
     jmespath (1.3.1)
+    json (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -97,6 +98,12 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.20.0)
+    postmark (1.10.0)
+      json
+      rake
+    postmark-rails (0.15.0)
+      actionmailer (>= 3.0.0)
+      postmark (~> 1.10.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -217,6 +224,7 @@ DEPENDENCIES
   jbuilder (~> 2.6)
   listen (~> 3.1)
   pg (~> 0.18)
+  postmark-rails
   pry-rails
   puma (~> 3.0)
   rack-cors

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,9 @@ Rails.application.configure do
   end
 
   # Mailers
-  config.action_mailer.default_url_options = { :host => ENV.fetch('HOST_URL', 'localhost:3000') }
+  config.action_mailer.default_url_options = {
+    :host => ENV.fetch('HOST_URL', 'localhost:3000')
+  }
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,25 +55,18 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "webpage-versions-db_#{Rails.env}"
-  config.action_mailer.perform_caching = false
 
-  # Action Mailer host default
-  config.action_mailer.default_url_options = { :host => ENV.fetch('HOST_URL', 'web-monitoring-db.herokuapp.com') }
-  config.action_mailer.smtp_settings = {
-    address: ENV.fetch('MAIL_SMTP_ADDRESS'),
-    port: ENV.fetch('MAIL_SMTP_PORT', 587).to_i,
-    domain: ENV.fetch('MAIL_SMTP_DOMAIN', 'gmail.com'),
-    user_name: ENV.fetch('MAIL_SMTP_USER'),
-    password: ENV.fetch('MAIL_SMTP_PASSWORD'),
-    authentication: ENV.fetch('MAIL_SMTP_AUTH', 'plain'),
-    enable_starttls_auto: ENV.fetch('MAIL_SMTP_TLS', 'true') == 'true'
+  # Action Mailer configuration
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch('HOST_URL', 'web-monitoring-db.herokuapp.com')
   }
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :postmark
+  config.action_mailer.postmark_settings = {
+    api_key: ENV.fetch('POSTMARK_API_TOKEN')
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
**DO NOT MERGE:** Postmark still has to approve the account before we can send to most public e-mail addresses. This should happen by 2017-05-26.

Addresses #50.

Setup e-mail sending via Postmark. I’ve set up an account and this is working for me locally. When deployed, this will be sending from an account at my personal domain. We’ll want to change that (see discussion about domains and e-mail etc. in the EDGI Slack #tools_talk), but user accounts are kinda broken right now and I want to at least get them working so other people can test against the live DB without me manually setting up accounts in the console or cajoling GMail into behaving.