### PR TITLE
Ensure included versions on page API are ordered

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -59,9 +59,12 @@ class Api::V0::PagesController < Api::V0::ApiController
       end
     end
 
-    collection = collection.includes(
-      should_include_versions ? :versions : :latest
-    )
+    collection =
+      if should_include_versions
+        collection.includes(:versions).order('versions.capture_time')
+      else
+        collection.includes(:latest)
+      end
 
     collection
   end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -137,6 +137,21 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, home_page['versions'].length, '"Home page" included too many versions'
   end
 
+  test 'Included versions should be in capture_time order' do
+    # Add a version whose natural order and capture_time order are different
+    latest_time = pages(:home_page).versions.first.capture_time
+    pages(:home_page).versions.create(capture_time: latest_time - 1.day)
+
+    get api_v0_pages_path(
+      include_versions: true,
+      capture_time: '2017-01-01..',
+      url: pages(:home_page).url
+    )
+    body = JSON.parse(@response.body)
+    times = body['data'][0]['versions'].pluck('capture_time')
+    assert_ordered(times, name: 'Versions')
+  end
+
   test 'include_versions can be "1"' do
     get api_v0_pages_path(include_versions: 1)
     body = JSON.parse @response.body

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,4 +8,9 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  def assert_ordered(list, reverse: false, name: 'Items')
+    sorted = list.sort
+    sorted = sorted.reverse if reverse
+    assert_equal(sorted, list, "#{name} were not in order: #{list}")
+  end
 end


### PR DESCRIPTION
This fixes #70.