### PR TITLE
Environment banner

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -31,6 +31,19 @@ html, body {
   border-bottom: 1px solid #bbb;
 }
 
+.page-header-environment {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #f2dede;
+  border-bottom: 1px solid #bbb;
+  color: #3b4151;
+}
+.page-header-environment > * {
+  margin: 0;
+  padding: 0.5em;
+}
+
 .page-header-main > * {
   margin: 0;
   padding: 0.5em;

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -89,8 +89,10 @@ class Api::V0::ApiController < ApplicationController
     range = parse_unbounded_range!(params[name], name, &parse)
     collection.where_in_unbounded_range(attribute, range)
   end
+
   private
+
   def set_environment_header
-    response["X-Environment"] = Rails.env 
+    response['X-Environment'] = Rails.env
   end
 end

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -1,6 +1,7 @@
 class Api::V0::ApiController < ApplicationController
   include PagingConcern
   before_action :require_authentication!, only: [:create]
+  before_action :set_environment_header
 
   rescue_from StandardError, with: :render_errors if Rails.env.production?
   rescue_from Api::NotImplementedError, with: :render_errors
@@ -87,5 +88,9 @@ class Api::V0::ApiController < ApplicationController
     attribute = name if attribute.nil?
     range = parse_unbounded_range!(params[name], name, &parse)
     collection.where_in_unbounded_range(attribute, range)
+  end
+  private
+  def set_environment_header
+    response["X-Environment"] = Rails.env 
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  # pass
   before_action :set_environment
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
   # pass
+  before_action :set_environment
+
+  private
+  def set_environment
+    @env = Rails.env
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :set_environment
 
   private
+
   def set_environment
     @env = Rails.env
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,13 +12,11 @@
 
   <body>
     <% unless @env == "production" %>
-      <header class="page-header">
-        <div class="page-header-environment">
-          <p class="page-header-title">
-            <%= "Environment is: " + @env %>
-          </p>
-        </div>
-      </header>
+      <div class="page-header-environment">
+        <p class="page-header-title">
+          <%= "Environment is: " + @env %>
+        </p>
+      </div>
     <% end %>
     <header class="page-header">
       <div class="page-header-main">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,10 +11,18 @@
   </head>
 
   <body>
+    <% unless @env == "production" %>
+      <header class="page-header">
+        <div class="page-header-environment">
+          <p class="page-header-title">
+            <%= "Environment is: " + @env %>
+          </p>
+        </div>
+      </header>
+    <% end %>
     <header class="page-header">
       <div class="page-header-main">
         <p class="page-header-title"><%= link_to('EDGI Web-Monitoring Database', '/') %></p>
-
         <% if user_signed_in? && current_user.admin? %>
           <p><%= link_to('Admin', admin_path) %></p>
         <% end %>
@@ -36,7 +44,6 @@
         <% end %>
       </div>
     </header>
-
     <div class="page-content">
       <%= yield %>
     </div>

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -164,4 +164,8 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     results = body['data']
     assert_not results.any? {|p| p.key? 'versions'}, 'Some pages have a "versions" property'
   end
+  test "includes environment in header of response" do
+    get '/api/v0/pages/'
+    assert_equal("test", @response.get_header("X-Environment") )
+  end
 end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -164,6 +164,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     results = body['data']
     assert_not results.any? {|p| p.key? 'versions'}, 'Some pages have a "versions" property'
   end
+  
   test 'includes environment in header of response' do
     get '/api/v0/pages/'
     assert_equal('test', @response.get_header('X-Environment'))

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -164,8 +164,8 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     results = body['data']
     assert_not results.any? {|p| p.key? 'versions'}, 'Some pages have a "versions" property'
   end
-  test "includes environment in header of response" do
+  test 'includes environment in header of response' do
     get '/api/v0/pages/'
-    assert_equal("test", @response.get_header("X-Environment") )
+    assert_equal('test', @response.get_header('X-Environment'))
   end
 end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -164,7 +164,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     results = body['data']
     assert_not results.any? {|p| p.key? 'versions'}, 'Some pages have a "versions" property'
   end
-  
+
   test 'includes environment in header of response' do
     get '/api/v0/pages/'
     assert_equal('test', @response.get_header('X-Environment'))


### PR DESCRIPTION
fixes, [#67](https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/67), I haven't setup a test yet for the environment banner, if you need a test setup for it I'd recommend doing an integration test with capybara which I could setup.  I didn't want to add the dependency to your project without your input first since it would be bringing in a library just to test one thing.   I also added some color to the banner and made it center, hopefully it sticks out more.  

I added a test for the X-Environment header, its not very expansive, but I think with a little guidance I could add more tests. 

![environmentbannerwithcolor](https://cloud.githubusercontent.com/assets/5727364/26758087/cfae74ec-4899-11e7-8029-09518372c48e.png)