### PR TITLE
Add contributors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ User.create(
 ```
 
 
+## Contributors
+
+This project wouldn’t exist without a lot of amazing people’s help. Thanks to the following for all their contributions!
+
+<!-- ALL-CONTRIBUTORS-LIST:START -->
+| Contributions | Name |
+| :---: | :---: |
+| [💻](# "Code") [🚇](# "Infrastructure") [📖](# "Documentation") [💬](# "Answering Questions") [👀](# "Reviewer") | [Rob Brackett](https://github.com/Mr0grog) |
+| [📖](# "Documentation") [👀](# "Reviewer") | [Dan Allan](https://github.com/danielballan) |
+| [📖](# "Documentation") [📋](# "Organizer") | [Dawn Walker](https://github.com/dcwalk) |
+| [📖](# "Documentation") [📋](# "Organizer") [📢](# "Talks") | [Matt Price](https://github.com/titaniumbones) |
+| [📖](# "Documentation") | [Patrick Connolly](https://github.com/patcon) |
+| [💻](# "Code") | [Robert Dalin](https://github.com/rdalin82) |
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+(For a key to the contribution emoji or more info on this format, check out [“All Contributors.”](https://github.com/kentcdodds/all-contributors))
+
+
 ## License & Copyright
 
 Copyright (C) 2017 Environmental Data and Governance Initiative (EDGI)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ This project wouldn’t exist without a lot of amazing people’s help. Thanks t
 | [📖](# "Documentation") [📋](# "Organizer") | [Dawn Walker](https://github.com/dcwalk) |
 | [📖](# "Documentation") [📋](# "Organizer") [📢](# "Talks") | [Matt Price](https://github.com/titaniumbones) |
 | [📖](# "Documentation") | [Patrick Connolly](https://github.com/patcon) |
+| [📋](# "Organizer") [🔍](# "Funding/Grant Finder") | [Toly Rinberg](https://github.com/trinberg) |
+| [📋](# "Organizer") [🔍](# "Funding/Grant Finder") | [Andrew Bergman](https://github.com/ambergman) |
 | [💻](# "Code") | [Robert Dalin](https://github.com/rdalin82) |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 


### PR DESCRIPTION
Should’ve added this a long time ago! This is more-or-less following [all-contributors](https://github.com/kentcdodds/all-contributors/) style, minus avatars.

@danielballan, @dcwalk, @patcon, @titaniumbones, @rdalin82, let me know if I missed anybody and feel free to change your listing, link to your own home page, whatever.