### PR TITLE
Return 404 error when annotating first version of a page

### DIFF
--- a/app/controllers/api/v0/annotations_controller.rb
+++ b/app/controllers/api/v0/annotations_controller.rb
@@ -64,7 +64,8 @@ class Api::V0::AnnotationsController < Api::V0::ApiController
         if params[:from_uuid].present?
           Change.between(from: Version.find(params[:from_uuid]), to: to_version)
         else
-          to_version.change_from_previous
+          to_version.change_from_previous ||
+            (raise ActiveRecord::RecordNotFound, "There is no version prior to #{to_version.uuid}. Annotations describe the change between versions, so this this version cannot be annotated.")
         end
     end
     @change

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -13,14 +13,16 @@ class Version < ApplicationRecord
   end
 
   def change_from_previous
-    Change.between(to: self)
+    Change.between(from: previous, to: self)
   end
 
   def current_annotation
-    self.change_from_previous.current_annotation
+    change = self.change_from_previous
+    change && change.current_annotation
   end
 
   def annotations
-    self.change_from_previous.annotations
+    change = self.change_from_previous
+    change ? change.annotations : []
   end
 end

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
   test 'can list versions' do
     get(api_v0_page_versions_url(pages(:home_page)))
     assert_response(:success)
@@ -145,5 +147,41 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     types = body_json['data'].collect {|v| v['source_type']}.uniq
 
     assert_equal ['pagefreezer'], types, 'Got versions with wrong source_type'
+  end
+
+  test 'can annotate versions' do
+    version = versions(:page1_v2)
+
+    sign_in users(:alice)
+    post(
+      api_v0_page_version_annotations_url(pages(:home_page), version),
+      as: :json,
+      params: { something: 'some value' }
+    )
+
+    assert_response(:success)
+
+    body = JSON.parse @response.body
+    annotation_id = body['data']['uuid']
+    ids = version.change_from_previous.annotations.pluck(:uuid)
+    assert_includes(ids, annotation_id, 'Annotation was not added to version')
+    assert_equal(
+      'some value',
+      version.current_annotation['something'],
+      'Annotation was not incorporated into "current_annotaiton"'
+    )
+  end
+
+  test 'cannot annotate the first version of a page' do
+    version = versions(:page1_v1)
+
+    sign_in users(:alice)
+    post(
+      api_v0_page_version_annotations_url(pages(:home_page), version),
+      as: :json,
+      params: { something: 'some value' }
+    )
+
+    assert_response(:not_found)
   end
 end


### PR DESCRIPTION
The first version of a page can’t be annotated (because annotations are really on the change between a version and its previous version — and there is no version before the first version). We raised an exception from down in the depths of the app for this before, which did not clearly indicate the problem. This provides clients with a 404 error (indicating the issue is on their side) and a clearer message about what was wrong (no previous version to annotate).

Fixes #81.