### PR TITLE
Return unique records in `where_in_unbounded_range`

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,7 +6,8 @@ class ApplicationRecord < ActiveRecord::Base
 
     if attribute.is_a?(String) && attribute.include?('.')
       join_model = attribute.split('.')[0].to_sym
-      result = result.joins(join_model)
+      # Use distinct to indicate that we only want one record per joined match
+      result = result.joins(join_model).distinct
     end
 
     if range.is_a? Array

--- a/test/models/application_record_test.rb
+++ b/test/models/application_record_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class ApplicationRecordTest < ActiveSupport::TestCase
+  test 'where_in_unbounded_range on an association should not return repeated primary model records' do
+    pages = Page.where_in_unbounded_range(
+      'versions.capture_time',
+      [DateTime.parse('2017-01-01'), nil]
+    ).pluck(:uuid).to_a
+
+    unique_pages = pages.uniq
+    assert_equal(unique_pages, pages, 'The same page was returned multiple times')
+  end
+end


### PR DESCRIPTION
This is a fix for #85.

ActiveRecord does not actually try to figure out that a `joins(:some_association)` call may return multiple instances of a given record and coalesce them into a single result, so we also need to tell it to only get distinct results when auto-joining in `ApplicationRecord#where_in_unbounded_range`.

In #85, `where_in_unbounded_range` is used on pages’ association with versions to query on `capture_time`. This caused an INNER JOIN to versions, which meant we’d see duplicate page entries for every version that matched. We really only want *one* page entry if any of that pages’ versions that match.