### PR TITLE
Send hash of versions to simplediff differs

### DIFF
--- a/lib/differ/simple_diff.rb
+++ b/lib/differ/simple_diff.rb
@@ -8,7 +8,9 @@ module Differ
       options ||= {}
       query = options.merge(
         a: change.from_version.uri,
-        b: change.version.uri
+        a_hash: change.from_version.version_hash,
+        b: change.version.uri,
+        b_hash: change.version.version_hash
       )
 
       response = HTTParty.get(@url, query: query)

--- a/test/lib/differ/simple_diff_test.rb
+++ b/test/lib/differ/simple_diff_test.rb
@@ -7,7 +7,9 @@ class Differ::SimpleDiffTest < ActiveSupport::TestCase
     expected_request = stub_request(:any, 'http://testdiff.com')
       .with(query: {
         'a' => change.from_version.uri,
-        'b' => change.version.uri
+        'a_hash' => change.from_version.version_hash,
+        'b' => change.version.uri,
+        'b_hash' => change.version.version_hash
       })
       .to_return(body: 'DIFF!', status: 200)
 
@@ -24,7 +26,9 @@ class Differ::SimpleDiffTest < ActiveSupport::TestCase
     expected_request = stub_request(:any, 'http://testdiff.com')
       .with(query: {
         'a' => change.from_version.uri,
+        'a_hash' => change.from_version.version_hash,
         'b' => change.version.uri,
+        'b_hash' => change.version.version_hash,
         'something' => 'funky'
       })
 
@@ -40,7 +44,9 @@ class Differ::SimpleDiffTest < ActiveSupport::TestCase
     stub_request(:any, 'http://testdiff.com')
       .with(query: {
         'a' => change.from_version.uri,
-        'b' => change.version.uri
+        'a_hash' => change.from_version.version_hash,
+        'b' => change.version.uri,
+        'b_hash' => change.version.version_hash
       })
       .to_return(
         body: '{"key": "value"}',


### PR DESCRIPTION
Send the version hash for each version being diffed to the differ. This allows differs to do smarter caching. Fixes #84.