### PR TITLE
Fix #90 by adding NodeJs to installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,23 +27,35 @@ It’s a Rails app that:
     On Debian Linux:
 
     ```sh
-    $ apt-get install redis
+    # apt-get install redis
     ```
 
-4. Clone this repo
-5. If you don’t have the `bundler` Ruby gem, install it:
+4. Ensure you have a JavaScript Runtime
+
+    On OSX:
+    You do not need to do anything.  Apple JavaScriptCore fulfills this dependency
+
+    On Debian Linux:
+    
+    ```sh
+    # apt-get install nodejs
+    ```
+    If you wish to use another runtime you can use one listed [here](https://github.com/rails/execjs/blob/master/README.md)
+
+5. Clone this repo
+6. If you don’t have the `bundler` Ruby gem, install it:
 
     ```sh
     $ gem install bundler
     ```
 
-6. Wherever you cloned the repo, go to that directory and install dependencies:
+7. Wherever you cloned the repo, go to that directory and install dependencies:
 
     ```sh
     $ bundle install --without production
     ```
 
-7. Set up your database. The simple way to do this is:
+8. Set up your database. The simple way to do this is:
 
     ```sh
     $ bundle exec rake db:setup
@@ -55,7 +67,7 @@ It’s a Rails app that:
     
     If you're getting error such as `FATAL: role "user" doesn't exist. Couldn't create database.` check [troubleshooting](#troubleshooting) below. 
 
-8. Start the server!
+9. Start the server!
 
     ```sh
     $ bundle exec rails server
@@ -63,7 +75,7 @@ It’s a Rails app that:
 
     You should now have a server running and can visit it at http://localhost:3000/. Open that up in a browser and go to town!
 
-9. Bulk importing (and, in the future, potentially other features) make use of a
+10. Bulk importing (and, in the future, potentially other features) make use of a
    Redis queue. If you plan to use any of these features, you must also start a
    Redis server and worker.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It’s a Rails app that:
     On Debian Linux:
 
     ```sh
-    # apt-get install redis
+    $ apt-get install redis
     ```
 
 4. Ensure you have a JavaScript Runtime
@@ -38,7 +38,7 @@ It’s a Rails app that:
     On Debian Linux:
     
     ```sh
-    # apt-get install nodejs
+    $ apt-get install nodejs
     ```
     If you wish to use another runtime you can use one listed [here](https://github.com/rails/execjs/blob/master/README.md)
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ It’s a Rails app that:
 
     On OSX:
 
-    You do not need to do anything.  Apple JavaScriptCore fulfills this dependency
+    You do not need to do anything.  Apple JavaScriptCore fulfills this dependency.
 
     On Debian Linux:
     
     ```sh
     $ apt-get install nodejs
     ```
-    If you wish to use another runtime you can use one listed [here](https://github.com/rails/execjs/blob/master/README.md)
+    If you wish to use another runtime you can use one listed [here](https://github.com/rails/execjs/blob/master/README.md).
 
 5. Clone this repo
 6. If you don’t have the `bundler` Ruby gem, install it:

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ This project wouldn’t exist without a lot of amazing people’s help. Thanks t
 | [📋](# "Organizer") [🔍](# "Funding/Grant Finder") | [Andrew Bergman](https://github.com/ambergman) |
 | [💻](# "Code") | [Robert Dalin](https://github.com/rdalin82) |
 | [💻](# "Code") [📖](# "Documentation") | [Krzysztof Madejski](https://github.com/KrzysztofMadejski) |
+| [📖](# "Documentation") | [Michael Hardy](https://github.com/michardy) |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 (For a key to the contribution emoji or more info on this format, check out [“All Contributors.”](https://github.com/kentcdodds/all-contributors))

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It’s a Rails app that:
 4. Ensure you have a JavaScript Runtime
 
     On OSX:
+
     You do not need to do anything.  Apple JavaScriptCore fulfills this dependency
 
     On Debian Linux:


### PR DESCRIPTION
The installation instructions in the readme fail on clean Linux installs because of the lack of installed JavaScript runtime.  