### PR TITLE
Add differs from web-monitoring-processing#59

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,12 @@ export ALLOWED_ARCHIVE_HOSTS='https://edgi-versionista-archive.s3.amazonaws.com/
 # export AWS_ARCHIVE_BUCKET=some-public-archival-bucket
 # # The bucket to use for internal temporary file storage
 # export AWS_WORKING_BUCKET=your-private-bucket
+#
+# If you are developing this web-monitoring-db Rails app + wm-differ-differ locally,
+# then settings below are the default settings. If you are running against a
+# production deployment, change 'localhost:8888' to the production URL.
+export DIFFER_LENGTH=http://localhost:8888/length
+export DIFFER_IDENTICAL_BYTES=http://localhost:8888/identical_bytes
+export DIFFER_PAGEFREEZER=http://localhost:8888/pagefreezer
+export DIFFER_HTML_SOURCE=http://localhost:8888/html_source_diff
+export DIFFER_HTML_TEXT=http://localhost:8888/html_text_diff

--- a/config/initializers/differ.rb
+++ b/config/initializers/differ.rb
@@ -4,3 +4,29 @@ require_dependency 'differ/simple_diff'
 if ENV['DIFFER_SOURCE']
   Differ.register(:source, Differ::SimpleDiff.new(ENV['DIFFER_SOURCE']))
 end
+
+if ENV['DIFFER_LENGTH']
+  Differ.register(:length, Differ::SimpleDiff.new(ENV['DIFFER_LENGTH']))
+end
+
+if ENV['DIFFER_IDENTICAL_BYTES']
+  Differ.register(:identical_bytes,
+                  Differ::SimpleDiff.new(ENV['DIFFER_IDENTICAL_BYTES']))
+end
+
+if ENV['DIFFER_SIDE_BY_SIDE_TEXT']
+  Differ.register(:side_by_side_text,
+                  Differ::SimpleDiff.new(ENV['DIFFER_SIDE_BY_SIDE_TEXT']))
+end
+
+if ENV['DIFFER_PAGEFREEZER']
+  Differ.register(:pagefreezer, Differ::SimpleDiff.new(ENV['DIFFER_PAGEFREEZER']))
+end
+
+if ENV['DIFFER_HTML_SOURCE']
+  Differ.register(:html_source, Differ::SimpleDiff.new(ENV['DIFFER_HTML_SOURCE']))
+end
+
+if ENV['DIFFER_HTML_TEXT']
+  Differ.register(:html_text, Differ::SimpleDiff.new(ENV['DIFFER_HTML_TEXT']))
+end


### PR DESCRIPTION
I left DIFF_SOURCE in place in case we want to continue to run go-calc-diff alongside web-monitoring-processing similar utility for awhile.