### PR TITLE
Ensure no duplicate pages when querying by version attributes

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -66,6 +66,7 @@ class Api::V0::PagesController < Api::V0::ApiController
         collection.includes(:latest)
       end
 
-    collection
+    # If any queries create implicit joins, ensure we get a list of unique pages
+    collection.distinct
   end
 end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -184,4 +184,12 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     get '/api/v0/pages/'
     assert_equal('test', @response.get_header('X-Environment'))
   end
+
+  test 'does not return duplicate records when querying by version-specific parameters' do
+    get api_v0_pages_path(source_type: 'versionista')
+    body = JSON.parse(@response.body)
+
+    page_ids = body['data'].pluck('uuid')
+    assert_equal(page_ids.uniq, page_ids, 'The same page was returned multiple times')
+  end
 end


### PR DESCRIPTION
This is a pretty similar issue to #85, discovered while adding remote login support for UI.

Joining pages to versions means our output will have repeated pages. The API, however, should always be returning a unique list of pages (with versions rolled up as attributes of the pages).

The `distinct` call here would be more technically correct if only used where we do a join, but always adding at the end like this *shouldn't* have major negative effects and protects against future mistakes if we add joins elsewhere.