### PR TITLE
Add API endpoints for change models

### DIFF
--- a/app/controllers/api/v0/annotations_controller.rb
+++ b/app/controllers/api/v0/annotations_controller.rb
@@ -56,23 +56,6 @@ class Api::V0::AnnotationsController < Api::V0::ApiController
   end
 
   def parent_change
-    @change ||= change_from_id(params[:change_id])
-  end
-
-  def change_from_id(change_id)
-    return nil if params[:change_id].blank?
-
-    if change_id.include?('..')
-      from_id, to_id = change_id.split('..')
-      if from_id.present?
-        Change.between(from: Version.find(from_id), to: Version.find(to_id))
-      else
-        Version.find(to_id).change_from_previous ||
-          (raise ActiveRecord::RecordNotFound, "There is no version prior to
-            #{to_id} to change from.")
-      end
-    else
-      Change.find(change_id)
-    end
+    @change ||= Change.find_by_api_id(params[:change_id])
   end
 end

--- a/app/controllers/api/v0/annotations_controller.rb
+++ b/app/controllers/api/v0/annotations_controller.rb
@@ -7,7 +7,10 @@ class Api::V0::AnnotationsController < Api::V0::ApiController
 
     render json: {
       links: paging[:links],
-      data: annotations.as_json(include: { author: { only: [:id, :email] } })
+      data: annotations.as_json(
+        include: { author: { only: [:id, :email] } },
+        except: :author_id
+      )
     }
   end
 
@@ -19,7 +22,10 @@ class Api::V0::AnnotationsController < Api::V0::ApiController
         version: api_v0_page_version_url(page, version),
         from_version: api_v0_page_version_url(page, @annotation.change.from_version)
       },
-      data: @annotation.as_json(include: { author: { only: [:id, :email] } })
+      data: @annotation.as_json(
+        include: { author: { only: [:id, :email] } },
+        except: :author_id
+      )
     }
   end
 

--- a/app/controllers/api/v0/annotations_controller.rb
+++ b/app/controllers/api/v0/annotations_controller.rb
@@ -56,14 +56,7 @@ class Api::V0::AnnotationsController < Api::V0::ApiController
   end
 
   def parent_change
-    @change ||=
-      if params[:change_id]
-        change_from_id(params[:change_id])
-      else
-        to_version = Version.find(params[:version_id])
-        to_version.change_from_previous ||
-          (raise ActiveRecord::RecordNotFound, "There is no version prior to #{to_version.uuid}. Annotations describe the change between versions, so this this version cannot be annotated.")
-      end
+    @change ||= change_from_id(params[:change_id])
   end
 
   def change_from_id(change_id)

--- a/app/controllers/api/v0/annotations_controller.rb
+++ b/app/controllers/api/v0/annotations_controller.rb
@@ -46,11 +46,9 @@ class Api::V0::AnnotationsController < Api::V0::ApiController
   protected
 
   def paging_path_for_annotation(*args)
-    args.last.merge!({
-      from_uuid: parent_change.from_version.id,
-      to_uuid: parent_change.version.id
-    })
-    api_v0_page_annotations_url(*args)
+    args.last[:change_id] =
+      "#{parent_change.from_version.id}..#{parent_change.version.id}"
+    api_v0_page_change_annotations_url(*args)
   end
 
   def set_annotation
@@ -58,16 +56,30 @@ class Api::V0::AnnotationsController < Api::V0::ApiController
   end
 
   def parent_change
-    unless @change
-      to_version = Version.find(params[:to_uuid] || params[:version_id])
-      @change =
-        if params[:from_uuid].present?
-          Change.between(from: Version.find(params[:from_uuid]), to: to_version)
-        else
-          to_version.change_from_previous ||
-            (raise ActiveRecord::RecordNotFound, "There is no version prior to #{to_version.uuid}. Annotations describe the change between versions, so this this version cannot be annotated.")
-        end
+    @change ||=
+      if params[:change_id]
+        change_from_id(params[:change_id])
+      else
+        to_version = Version.find(params[:version_id])
+        to_version.change_from_previous ||
+          (raise ActiveRecord::RecordNotFound, "There is no version prior to #{to_version.uuid}. Annotations describe the change between versions, so this this version cannot be annotated.")
+      end
+  end
+
+  def change_from_id(change_id)
+    return nil if params[:change_id].blank?
+
+    if change_id.include?('..')
+      from_id, to_id = change_id.split('..')
+      if from_id.present?
+        Change.between(from: Version.find(from_id), to: Version.find(to_id))
+      else
+        Version.find(to_id).change_from_previous ||
+          (raise ActiveRecord::RecordNotFound, "There is no version prior to
+            #{to_id} to change from.")
+      end
+    else
+      Change.find(change_id)
     end
-    @change
   end
 end

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -89,6 +89,7 @@ class Api::V0::ApiController < ApplicationController
     end
   end
 
+  # TODO: use new NumericInterval class for unbounded [date] ranges
   def where_in_range_param(collection, name, attribute = nil, &parse)
     return collection unless params[name]
 

--- a/app/controllers/api/v0/changes_controller.rb
+++ b/app/controllers/api/v0/changes_controller.rb
@@ -42,25 +42,14 @@ class Api::V0::ChangesController < Api::V0::ApiController
 
   def changes_collection
     collection = Change
-    where_numeric_range_params(collection, :priority)
-  end
 
-  def where_numeric_range_params(collection, attribute)
-    gt_param = :"#{attribute}_gt"
-    gte_param = :"#{attribute}_gte"
-    lt_param = :"#{attribute}_lt"
-    lte_param = :"#{attribute}_lte"
-
-    if params[gt_param]
-      collection = collection.where("#{attribute} > ?", params[gt_param])
-    elsif params[gte_param]
-      collection = collection.where("#{attribute} >= ?", params[gte_param])
-    end
-
-    if params[lt_param]
-      collection = collection.where("#{attribute} < ?", params[lt_param])
-    elsif params[lte_param]
-      collection = collection.where("#{attribute} <= ?", params[lte_param])
+    if params[:priority]
+      collection =
+        if params[:priority].match?(/^\d/)
+          collection.where(priority: Float(params[:priority]))
+        else
+          collection.where_in_interval(:priority, params[:priority])
+        end
     end
 
     collection

--- a/app/controllers/api/v0/changes_controller.rb
+++ b/app/controllers/api/v0/changes_controller.rb
@@ -1,0 +1,80 @@
+class Api::V0::ChangesController < Api::V0::ApiController
+  def index
+    query = change_collection
+    paging = pagination(query)
+    changes = query.limit(paging[:page_items]).offset(paging[:offset])
+
+    render json: {
+      links: paging[:links],
+      data: changes.as_json(methods: :current_annotation)
+    }
+  end
+
+  def show
+    render json: {
+      links: {
+        page: api_v0_page_url(page),
+        from_version: api_v0_page_version_url(page, change.from_version),
+        to_version: api_v0_page_version_url(page, change.version)
+      },
+      data: change.as_json(methods: :current_annotation)
+    }
+  end
+
+  protected
+
+  def page
+    return nil unless params.key? :page_id
+    @page ||= Page.find(params[:page_id])
+  end
+
+  def change
+    @change ||=
+      if params[:id].include?('..')
+        from_id, to_id = params[:id].split('..')
+        if from_id.present?
+          Change.between(from: Version.find(from_id), to: Version.find(to_id))
+        else
+          Version.find(to_id).change_from_previous ||
+            (raise ActiveRecord::RecordNotFound, "There is no version prior to
+              #{to_id} to change from.")
+        end
+      else
+        Change.find(params[:id])
+      end
+  end
+
+  def paging_path_for_change(*args)
+    if change
+      api_v0_page_change_url(*args)
+    else
+      api_v0_page_changes_url(*args)
+    end
+  end
+
+  def changes_collection
+    collection = Change
+    where_numeric_range_params(collection, :priority)
+  end
+
+  def where_numeric_range_params(collection, attribute)
+    gt_param = :"#{attribute}_gt"
+    gte_param = :"#{attribute}_gte"
+    lt_param = :"#{attribute}_lt"
+    lte_param = :"#{attribute}_lte"
+
+    if params[gt_param]
+      collection = collection.where("#{attribute} > ?", params[gt_param])
+    elsif params[gte_param]
+      collection = collection.where("#{attribute} >= ?", params[gte_param])
+    end
+
+    if params[lt_param]
+      collection = collection.where("#{attribute} < ?", params[lt_param])
+    elsif params[lte_param]
+      collection = collection.where("#{attribute} <= ?", params[lte_param])
+    end
+
+    collection
+  end
+end

--- a/app/controllers/api/v0/changes_controller.rb
+++ b/app/controllers/api/v0/changes_controller.rb
@@ -1,6 +1,6 @@
 class Api::V0::ChangesController < Api::V0::ApiController
   def index
-    query = change_collection
+    query = changes_collection
     paging = pagination(query)
     changes = query.limit(paging[:page_items]).offset(paging[:offset])
 

--- a/app/controllers/api/v0/changes_controller.rb
+++ b/app/controllers/api/v0/changes_controller.rb
@@ -29,19 +29,7 @@ class Api::V0::ChangesController < Api::V0::ApiController
   end
 
   def change
-    @change ||=
-      if params[:id].include?('..')
-        from_id, to_id = params[:id].split('..')
-        if from_id.present?
-          Change.between(from: Version.find(from_id), to: Version.find(to_id))
-        else
-          Version.find(to_id).change_from_previous ||
-            (raise ActiveRecord::RecordNotFound, "There is no version prior to
-              #{to_id} to change from.")
-        end
-      else
-        Change.find(params[:id])
-      end
+    @change ||= Change.find_by_api_id(params[:id])
   end
 
   def paging_path_for_change(*args)

--- a/app/controllers/api/v0/diff_controller.rb
+++ b/app/controllers/api/v0/diff_controller.rb
@@ -21,19 +21,7 @@ class Api::V0::DiffController < Api::V0::ApiController
   end
 
   def change
-    @change ||=
-      if params[:id].include?('..')
-        from_id, to_id = params[:id].split('..')
-        if from_id.present?
-          Change.between(from: Version.find(from_id), to: Version.find(to_id))
-        else
-          Version.find(to_id).change_from_previous ||
-            (raise ActiveRecord::RecordNotFound, "There is no version prior to
-              #{to_id} to change from.")
-        end
-      else
-        Change.find(params[:id])
-      end
+    @change ||= Change.find_by_api_id(params[:id])
   end
 
   def ensure_diffable

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -6,7 +6,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
 
     render json: {
       links: paging[:links],
-      data: versions.as_json(methods: :current_annotation)
+      data: versions.as_json
     }
   end
 
@@ -17,7 +17,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
         page: api_v0_page_url(@version.page),
         previous: @version.previous && api_v0_page_version_url(@version.page, @version.previous)
       },
-      data: @version.as_json(methods: :current_annotation)
+      data: @version.as_json
     }
   end
 

--- a/app/lib/numeric_interval.rb
+++ b/app/lib/numeric_interval.rb
@@ -1,0 +1,37 @@
+class NumericInterval
+  attr_reader :start
+  attr_reader :start_open
+  attr_reader :end
+  attr_reader :end_open
+
+  def initialize(string_interval)
+    components = string_interval.match(/^\s*(\[|\()?\s*(\d*(?:\.\d+)?)\s*(?:,|\.\.)\s*(\d*(?:\.\d+)?)\s*(\]|\))?\s*$/)
+    raise ArgumentError, "Invalid interval format: '#{string_interval}'" unless components
+    @start = components[2].present? ? components[2].to_f : nil
+    @end = components[3].present? ? components[3].to_f : nil
+    @start_open = components[1] == '('
+    @end_open = components[4] == ')'
+    raise ArgumentError, 'An interval must have at least a start or end.' unless @start || @end
+    raise ArgumentError, 'The start of an interval must be less than its end' if @start && @end && @start >= @end
+  end
+
+  def to_s
+    start_token = start_open ? '(' : '['
+    end_token = end_token ? ')' : ']'
+    "#{start_token}#{start},#{self.end}#{end_token}"
+  end
+
+  def include?(value)
+    if start
+      return false if value < start
+      return false if value == start && start_open
+    end
+
+    if self.end
+      return false if value > self.end
+      return false if value == self.end && end_open
+    end
+
+    true
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -21,4 +21,30 @@ class ApplicationRecord < ActiveRecord::Base
 
     result
   end
+
+  def self.where_in_interval(attribute, interval)
+    unless attribute.to_s.match?(/^[\w\-]*$/)
+      raise ArgumentError, "Attribute '#{attribute}' is not a safe column name"
+    end
+
+    if interval.is_a?(String)
+      interval = NumericInterval.new(interval)
+    elsif !interval.is_a?(NumericInterval)
+      raise ArgumentError, '`interval` must be a NumericInterval or string'
+    end
+
+    result = self
+
+    if interval.start
+      comparison = interval.start_open ? '>' : '>='
+      result = result.where("#{attribute} #{comparison} ?", interval.start)
+    end
+
+    if interval.end
+      comparison = interval.end_open ? '<' : '<='
+      result = result.where("#{attribute} #{comparison} ?", interval.end)
+    end
+
+    result
+  end
 end

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -21,7 +21,7 @@ class Change < ApplicationRecord
     if api_id.include?('..')
       from_id, to_id = api_id.split('..')
       if from_id.present?
-        Change.between(from: Version.find(from_id), to: Version.find(to_id))
+        Change.between(from: from_id, to: to_id)
       else
         Version.find(to_id).change_from_previous ||
           (raise ActiveRecord::RecordNotFound, "There is no version prior to

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -15,14 +15,4 @@ class Version < ApplicationRecord
   def change_from_previous
     Change.between(from: previous, to: self)
   end
-
-  def current_annotation
-    change = self.change_from_previous
-    change && change.current_annotation
-  end
-
-  def annotations
-    change = self.change_from_previous
-    change ? change.annotations : []
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,15 +17,14 @@ Rails.application.routes.draw do
           resources :annotations, only: [:index, :show, :create]
         end
 
-        resources :annotations,
-          path: 'changes/:from_uuid..:to_uuid/annotations',
-          from_uuid: /[^.\/]*/, # allow :from_uuid to be an empty string
-          only: [:index, :show, :create]
-
-        member do
-          get 'changes/:from_uuid..:to_uuid/diff/:type',
-            to: 'diff#show',
-            from_uuid: /[^.\/]*/ # allow :from_uuid to be an empty string
+        resources :changes,
+          # Allow :id to be ":from_uuid..:to_uuid" or just ":change_id"
+          constraints: { id: /(?:[\w\-]*\.\.[\w\-]+)|(?:[^\.\/]+)/ },
+          only: [:index, :show] do
+            resources :annotations, only: [:index, :show, :create]
+            member do
+              get 'diff/:type', to: 'diff#show'
+            end
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,10 +13,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v0 do
       resources :pages, only: [:index, :show], format: :json do
-        resources :versions, only: [:index, :show, :create] do
-          resources :annotations, only: [:index, :show, :create]
-        end
-
+        resources :versions, only: [:index, :show, :create]
         resources :changes,
           # Allow :id to be ":from_uuid..:to_uuid" or just ":change_id"
           constraints: { id: /(?:[\w\-]*\.\.[\w\-]+)|(?:[^\.\/]+)/ },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -218,6 +218,78 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/SingleVersion'
+  '/pages/{page_id}/changes':
+    get:
+      tags:
+        - changes
+      summary: List Changes between two Versions on a page
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page whose Change this is
+          required: true
+          type: string
+          format: uuid4
+        - name: page
+          in: query
+          description: pagination parameter
+          required: false
+          type: integer
+          default: 1
+        - name: priority_[gt|gte]
+          in: query
+          description: Only include changes with a `priority` greater than (or greater than or equal to) this value.
+          required: false
+          type: float
+        - name: priority_[lt|lte]
+          in: query
+          description: Only include changes with a `priority` less than (or less than or equal to) this value.
+          required: false
+          type: float
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/PageOfChanges'
+  '/pages/{page_id}/changes/{from_version}..{to_version}':
+    get:
+      tags:
+        - changes
+      summary: Get a Change between two Versions
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page whose Change this is
+          required: true
+          type: string
+          format: uuid4
+        - name: from_version
+          in: path
+          description: ID of the "before" Version. If omitted, it will be treated as the version immediately prior to `to_version`.
+          required: false
+          type: string
+          format: uuid4
+        - name: to_version
+          in: path
+          description: ID of the "after" Version
+          required: true
+          type: string
+          format: uuid4
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleChange'
   '/pages/{page_id}/changes/{from_version}..{to_version}/annotations':
     get:
       tags:
@@ -475,6 +547,29 @@ definitions:
         format: datetime
       latest:
         $ref: '#/definitions/Version'
+  Change:
+    type: object
+    properties:
+      uuid:
+        type: string
+        format: uuid4
+      uuid_from:
+        type: string
+        format: uuid4
+      uuid_to:
+        type: string
+        format: uuid4
+      priority:
+        type: number
+        format: float
+      current_annotation:
+        type: object
+      created_at:
+        type: string
+        format: datetime
+      updated_at:
+        type: string
+        format: datetime
   Annotation:
     type: object
     properties:
@@ -537,6 +632,45 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Version'
+      links:
+        type: object
+        properties:
+          first:
+            type: string
+            format: uri
+          last:
+            type: string
+            format: uri
+          prev:
+            type: string
+            format: uri
+          next:
+            type: string
+            format: uri
+  SingleChange:
+    type: object
+    properties:
+      data:
+        $ref: '#/definitions/Change'
+      links:
+        type: object
+        properties:
+          page:
+            type: string
+            format: uri
+          from_version:
+            type: string
+            format: uri
+          to_version:
+            type: string
+            format: uri
+  PageOfChanges:
+    type: object
+    properties:
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Change'
       links:
         type: object
         properties:

--- a/test/controllers/api/v0/annotations_controller_test.rb
+++ b/test/controllers/api/v0/annotations_controller_test.rb
@@ -9,7 +9,7 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in users(:alice)
     post(
-      api_v0_page_version_annotations_path(page, page.versions[0]),
+      api_v0_page_change_annotations_path(page, "..#{page.versions[0].uuid}"),
       as: :json,
       params: annotation
     )
@@ -29,17 +29,17 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in users(:alice)
     post(
-      api_v0_page_version_annotations_path(page, page.versions[0]),
+      api_v0_page_change_annotations_path(page, "..#{page.versions[0].uuid}"),
       as: :json,
       params: annotation1
     )
     sign_in users(:alice)
     post(
-      api_v0_page_version_annotations_path(page, page.versions[0]),
+      api_v0_page_change_annotations_path(page, "..#{page.versions[0].uuid}"),
       as: :json,
       params: annotation2
     )
-    get(api_v0_page_version_annotations_path(page, page.versions[0]))
+    get(api_v0_page_change_annotations_path(page, "..#{page.versions[0].uuid}"))
 
     assert_response :success
     body = JSON.parse @response.body
@@ -54,19 +54,19 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in users(:alice)
     post(
-      api_v0_page_version_annotations_path(page, page.versions[0]),
+      api_v0_page_change_annotations_path(page, "..#{page.versions[0].uuid}"),
       as: :json,
       params: annotation1
     )
 
     sign_in users(:admin_user)
     post(
-      api_v0_page_version_annotations_path(page, page.versions[0]),
+      api_v0_page_change_annotations_path(page, "..#{page.versions[0].uuid}"),
       as: :json,
       params: annotation2
     )
 
-    get(api_v0_page_version_annotations_path(page, page.versions[0]))
+    get(api_v0_page_change_annotations_path(page, "..#{page.versions[0].uuid}"))
 
     assert_response :success
     body = JSON.parse @response.body

--- a/test/controllers/api/v0/changes_controller_test.rb
+++ b/test/controllers/api/v0/changes_controller_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
+  test 'can list changes' do
+    page = pages(:home_page)
+    get(api_v0_page_changes_path(page))
+
+    assert_response :success
+    assert_equal 'application/json', @response.content_type
+    body = JSON.parse @response.body
+    assert body.key?('links'), 'Response should have a "links" property'
+    assert body.key?('data'), 'Response should have a "data" property'
+    assert(body['data'].is_a?(Array), 'Data should be an array')
+  end
+
+  test 'can get a single change by version IDs' do
+    page = pages(:home_page)
+    from_version = versions(:page1_v1)
+    to_version = versions(:page1_v2)
+    get(api_v0_page_change_path(page, "#{from_version.id}..#{to_version.id}"))
+
+    assert_response :success
+    assert_equal 'application/json', @response.content_type
+    body = JSON.parse @response.body
+    assert body.key?('links'), 'Response should have a "links" property'
+    assert body.key?('data'), 'Response should have a "data" property'
+    assert_equal(from_version.id, body['data']['uuid_from'], 'Response has wrong "from" version')
+    assert_equal(to_version.id, body['data']['uuid_to'], 'Response has wrong "to" version')
+  end
+
+  test 'can filter by priority' do
+    page = pages(:home_page)
+
+    get(api_v0_page_changes_path(page, priority_gt: 0.5))
+    assert_response :success
+    body = JSON.parse @response.body
+    assert(body['data'].length.positive?, 'Did not get any changes back')
+    body['data'].each do |change|
+      priority = change['priority']
+      assert(priority > 0.5, "Got a priority not > 0.5: #{priority} (from #{change['uuid']})")
+    end
+
+    get(api_v0_page_changes_path(page, priority_gte: 0.75))
+    assert_response :success
+    body = JSON.parse @response.body
+    assert(body['data'].length.positive?, 'Did not get any changes back')
+    body['data'].each do |change|
+      priority = change['priority']
+      assert(priority >= 0.75, "Got a priority not >= 0.75: #{priority} (from #{change['uuid']})")
+    end
+
+    get(api_v0_page_changes_path(page, priority_lt: 0.75))
+    assert_response :success
+    body = JSON.parse @response.body
+    assert(body['data'].length.positive?, 'Did not get any changes back')
+    body['data'].each do |change|
+      priority = change['priority']
+      assert(priority < 0.75, "Got a priority not < 0.5: #{priority} (from #{change['uuid']})")
+    end
+
+    get(api_v0_page_changes_path(page, priority_lte: 0.5))
+    assert_response :success
+    body = JSON.parse @response.body
+    assert(body['data'].length.positive?, 'Did not get any changes back')
+    body['data'].each do |change|
+      priority = change['priority']
+      assert(priority <= 0.5, "Got a priority not <= 0.5: #{priority} (from #{change['uuid']})")
+    end
+  end
+end

--- a/test/controllers/api/v0/changes_controller_test.rb
+++ b/test/controllers/api/v0/changes_controller_test.rb
@@ -31,7 +31,7 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
   test 'can filter by priority' do
     page = pages(:home_page)
 
-    get(api_v0_page_changes_path(page, priority_gt: 0.5))
+    get(api_v0_page_changes_path(page, priority: '(0.5,)'))
     assert_response :success
     body = JSON.parse @response.body
     assert(body['data'].length.positive?, 'Did not get any changes back')
@@ -40,7 +40,7 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
       assert(priority > 0.5, "Got a priority not > 0.5: #{priority} (from #{change['uuid']})")
     end
 
-    get(api_v0_page_changes_path(page, priority_gte: 0.75))
+    get(api_v0_page_changes_path(page, priority: '[0.75,]'))
     assert_response :success
     body = JSON.parse @response.body
     assert(body['data'].length.positive?, 'Did not get any changes back')
@@ -49,7 +49,7 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
       assert(priority >= 0.75, "Got a priority not >= 0.75: #{priority} (from #{change['uuid']})")
     end
 
-    get(api_v0_page_changes_path(page, priority_lt: 0.75))
+    get(api_v0_page_changes_path(page, priority: '(,0.75)'))
     assert_response :success
     body = JSON.parse @response.body
     assert(body['data'].length.positive?, 'Did not get any changes back')
@@ -58,7 +58,7 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
       assert(priority < 0.75, "Got a priority not < 0.5: #{priority} (from #{change['uuid']})")
     end
 
-    get(api_v0_page_changes_path(page, priority_lte: 0.5))
+    get(api_v0_page_changes_path(page, priority: '[,0.5]'))
     assert_response :success
     body = JSON.parse @response.body
     assert(body['data'].length.positive?, 'Did not get any changes back')

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -148,40 +148,4 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal ['pagefreezer'], types, 'Got versions with wrong source_type'
   end
-
-  test 'can annotate versions' do
-    version = versions(:page1_v2)
-
-    sign_in users(:alice)
-    post(
-      api_v0_page_version_annotations_url(pages(:home_page), version),
-      as: :json,
-      params: { something: 'some value' }
-    )
-
-    assert_response(:success)
-
-    body = JSON.parse @response.body
-    annotation_id = body['data']['uuid']
-    ids = version.change_from_previous.annotations.pluck(:uuid)
-    assert_includes(ids, annotation_id, 'Annotation was not added to version')
-    assert_equal(
-      'some value',
-      version.current_annotation['something'],
-      'Annotation was not incorporated into "current_annotaiton"'
-    )
-  end
-
-  test 'cannot annotate the first version of a page' do
-    version = versions(:page1_v1)
-
-    sign_in users(:alice)
-    post(
-      api_v0_page_version_annotations_url(pages(:home_page), version),
-      as: :json,
-      params: { something: 'some value' }
-    )
-
-    assert_response(:not_found)
-  end
 end

--- a/test/fixtures/changes.yml
+++ b/test/fixtures/changes.yml
@@ -1,7 +1,7 @@
 page1_change_1_2:
   from_version: page1_v1
   version: page1_v2
-  priority: 0.5
+  priority: 0.75
 
 page1_change_2_3:
   from_version: page1_v2

--- a/test/lib/numeric_interval_test.rb
+++ b/test/lib/numeric_interval_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class NumericIntervalTest < ActiveSupport::TestCase
+  test 'it parses closed intervals' do
+    interval = NumericInterval.new('[1.1,2]')
+    assert_equal(1.1, interval.start, 'Incorrect start value')
+    assert_equal(2, interval.end, 'Incorrect end value')
+    assert(!interval.start_open, 'Incorrect start_open value')
+    assert(!interval.end_open, 'Incorrect end_open value')
+  end
+
+  test 'it parses open intervals' do
+    interval = NumericInterval.new('(1.1,2)')
+    assert_equal(1.1, interval.start, 'Incorrect start value')
+    assert_equal(2, interval.end, 'Incorrect end value')
+    assert(interval.start_open, 'Incorrect start_open value')
+    assert(interval.end_open, 'Incorrect end_open value')
+  end
+
+  test 'it parses intervals with no start boundary' do
+    interval = NumericInterval.new('(,2)')
+    assert_nil(interval.start, 'Incorrect start value')
+    assert_equal(2, interval.end, 'Incorrect end value')
+    assert(interval.start_open, 'Incorrect start_open value')
+    assert(interval.end_open, 'Incorrect end_open value')
+  end
+
+  test 'it parses intervals with no end boundary' do
+    interval = NumericInterval.new('(1.1,)')
+    assert_equal(1.1, interval.start, 'Incorrect start value')
+    assert_nil(interval.end, 'Incorrect end value')
+    assert(interval.start_open, 'Incorrect start_open value')
+    assert(interval.end_open, 'Incorrect end_open value')
+  end
+
+  test 'it handles spaces in between' do
+    interval = NumericInterval.new('(1.1, 2)')
+    assert_equal(1.1, interval.start, 'Incorrect start value')
+    assert_equal(2, interval.end, 'Incorrect end value')
+    assert(interval.start_open, 'Incorrect start_open value')
+    assert(interval.end_open, 'Incorrect end_open value')
+  end
+
+  test 'it handles spaces around the outside' do
+    interval = NumericInterval.new(' (1.1, 2) ')
+    assert_equal(1.1, interval.start, 'Incorrect start value')
+    assert_equal(2, interval.end, 'Incorrect end value')
+    assert(interval.start_open, 'Incorrect start_open value')
+    assert(interval.end_open, 'Incorrect end_open value')
+  end
+
+  test 'it can be serialized' do
+    interval = NumericInterval.new('(1.1, 2]')
+    assert_equal('(1.1,2.0]', interval.to_s, 'Incorrect result for #to_s')
+  end
+
+  test 'it does not accept start >= end' do
+    assert_raises(ArgumentError) {NumericInterval.new('[2,2]')}
+    assert_raises(ArgumentError) {NumericInterval.new('[2,1]')}
+  end
+
+  test 'it does not accept no bounds at all' do
+    assert_raises(ArgumentError) {NumericInterval.new('[,]')}
+  end
+end


### PR DESCRIPTION
Adds two routes (which one might have guessed at before but used to be 404s):

- `GET /api/v0/pages/{page_id}/changes` - list changes (ordered by `to_version`, then `from_version`)

    This also supports the query args:

    - `priority_gt` OR `priority_gte` - gets changes with a priority greater than (or equal to) the given value
    - `priority_lt` OR `priority_lte` - gets changes with a priority less than (or equal to) the given value

- `GET /api/v0/pages/{page_id}/changes/{from_version_id}..{to_version_id}` - a single change

And removes all annotation-related stuff from the version routes:

- Remove `GET /api/v0/pages/{page_id}/versions/{version_id}/annotations`
- Remove `POST /api/v0/pages/{page_id}/versions/{version_id}/annotations`
- Remove `GET /api/v0/pages/{page_id}/versions/{version_id}/annotations/{annotation_id}`
- Remove `current_annotation` from Version object

Fixes #101.