### PR TITLE
HOTFIX: single-page GET was broken

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -17,7 +17,7 @@ class Api::V0::PagesController < Api::V0::ApiController
   def show
     page = Page.find(params[:id])
     render json: {
-      data: page.as_json(include: { versions: { methods: :current_annotation } })
+      data: page.as_json(include: [:versions])
     }
   end
 

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -192,4 +192,12 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     page_ids = body['data'].pluck('uuid')
     assert_equal(page_ids.uniq, page_ids, 'The same page was returned multiple times')
   end
+
+  test 'can retrieve a single page' do
+    get api_v0_page_path(pages(:home_page))
+    assert_response(:success)
+    assert_equal('application/json', @response.content_type)
+    body = JSON.parse(@response.body)
+    assert(body.key?('data'), 'Response should have a "data" property')
+  end
 end

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -148,4 +148,14 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal ['pagefreezer'], types, 'Got versions with wrong source_type'
   end
+
+  test 'can retrieve a single version' do
+    version = versions(:page1_v1)
+    get api_v0_page_version_path(version.page, version)
+    assert_response(:success)
+    assert_equal('application/json', @response.content_type)
+    body = JSON.parse(@response.body)
+    assert(body.key?('links'), 'Response should have a "links" property')
+    assert(body.key?('data'), 'Response should have a "data" property')
+  end
 end


### PR DESCRIPTION
There was a leftover call to Version#current_annotation, which was removed. Also added a basic test for this endpoint, which I'm surprised I had failed to add before :(