### PR TITLE
HOTFIX: Always query changes based on ID attributes

### DIFF
--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -16,7 +16,10 @@ class Change < ApplicationRecord
 
   def self.between(from:, to:, create: false)
     return nil if from.nil? || to.nil?
-    change_definition = { from_version: from, version: to }
+    change_definition = {
+      uuid_from: from.is_a?(Version) ? from.uuid : from,
+      uuid_to: to.is_a?(Version) ? to.uuid : to
+    }
     instantiator = create ? :create : :new
     self.where(change_definition).first ||
       self.send(instantiator, change_definition)

--- a/test/models/change_test.rb
+++ b/test/models/change_test.rb
@@ -1,6 +1,80 @@
 require 'test_helper'
 
 class ChangeTest < ActiveSupport::TestCase
+  test 'between should find a change based on two versions' do
+    from_version = versions(:page1_v1)
+    to_version = versions(:page1_v2)
+    found = Change.between(from: from_version, to: to_version)
+
+    assert(found.is_a?(Change), 'It did not return a Change')
+    assert(found.persisted?, 'The returned change did not already exist')
+    assert_equal(from_version.id, found.from_version.id, 'It has the wrong `from_version`')
+    assert_equal(to_version.id, found.version.id, 'It has the wrong `version`')
+  end
+
+  test 'between should find a change based on two IDs' do
+    from_version = versions(:page1_v1)
+    to_version = versions(:page1_v2)
+    found = Change.between(from: from_version.id, to: to_version.id)
+
+    assert(found.is_a?(Change), 'It did not return a Change')
+    assert(found.persisted?, 'The returned change did not already exist')
+    assert_equal(from_version.id, found.from_version.id, 'It has the wrong `from_version`')
+    assert_equal(to_version.id, found.version.id, 'It has the wrong `version`')
+  end
+
+  test 'between should instantiate a change based on two versions if a matching change does not already exist' do
+    from_version = versions(:page1_v3)
+    to_version = versions(:page1_v4)
+    found = Change.between(from: from_version, to: to_version)
+
+    assert(found.is_a?(Change), 'It did not return a Change')
+    assert_not(found.persisted?, 'The returned change did not already exist')
+    assert_equal(from_version.id, found.from_version.id, 'It has the wrong `from_version`')
+    assert_equal(to_version.id, found.version.id, 'It has the wrong `version`')
+  end
+
+  test 'between should instantiate a change based on two IDs if a matching change does not exist' do
+    from_version = versions(:page1_v3)
+    to_version = versions(:page1_v4)
+    found = Change.between(from: from_version.id, to: to_version.id)
+
+    assert(found.is_a?(Change), 'It did not return a Change')
+    assert_not(found.persisted?, 'The returned change did not already exist')
+    assert_equal(from_version.id, found.from_version.id, 'It has the wrong `from_version`')
+    assert_equal(to_version.id, found.version.id, 'It has the wrong `version`')
+  end
+
+  test 'between should create and persist a change if requested' do
+    from_version = versions(:page1_v3)
+    to_version = versions(:page1_v4)
+    found = Change.between(from: from_version, to: to_version, create: true)
+
+    assert(found.is_a?(Change), 'It did not return a Change')
+    assert(found.persisted?, 'The returned change was not persisted')
+    assert_equal(from_version.id, found.from_version.id, 'It has the wrong `from_version`')
+    assert_equal(to_version.id, found.version.id, 'It has the wrong `version`')
+  end
+
+  test 'find_by_api_id should work with IDs like `{from_id}..{to_id}`' do
+    from_version = versions(:page1_v1)
+    to_version = versions(:page1_v2)
+    found = Change.find_by_api_id("#{from_version.id}..#{to_version.id}")
+
+    assert(found.is_a?(Change), 'It did not return a Change')
+    assert_equal(from_version.id, found.from_version.id, 'It has the wrong `from_version`')
+    assert_equal(to_version.id, found.version.id, 'It has the wrong `version`')
+  end
+
+  test 'find_by_api_id should work with actual change IDs' do
+    change = changes(:page1_change_1_2)
+    found = Change.find_by_api_id(change.id)
+
+    assert(found.is_a?(Change), 'It did not return a Change')
+    assert_equal(change.from_version.id, found.from_version.id, 'It has the wrong `from_version`')
+    assert_equal(change.version.id, found.version.id, 'It has the wrong `version`')
+  end
+
   test 'annotate should create an annotation' do
     change = versions(:page2_v2).change_from_previous
     change.annotate({ test_field: 'test_value' }, users(:alice))


### PR DESCRIPTION
ActiveRecord's `where` method can transparently take an ID or instance for collection attributes, but the `create` and `new` methods cannot. We used to rely on the former behavior, but that would break when new instances were needed. Now we explicitly ensure we have an ID and always use the ID attributes rather than the collection attributes.