### PR TITLE
HOTFIX: Allow token auth to fallthrough to basic auth

### DIFF
--- a/lib/jwt_tools/jwt_auth_strategy.rb
+++ b/lib/jwt_tools/jwt_auth_strategy.rb
@@ -5,12 +5,15 @@ module JwtTools
     end
 
     def authenticate!
-      Rails.logger.debug "Claim data: '#{claims}'"
-      return fail! unless claims
-      return fail! unless claims.key?('sub')
+      return pass unless claims && claims.key?('sub')
       user_id = claims['sub'].match(/^User:(\d+)$/).try(:[], 1)
-      return fail! unless user_id
-      success! User.find_by_id user_id
+      return pass unless user_id
+      user = User.find_by_id(user_id)
+      if user
+        success! user
+      else
+        fail!
+      end
     end
 
     protected


### PR DESCRIPTION
I had been under the impression that `fail!` only failed the current strategy, but instead it halts all authorization, which broke basic auth! Instead call `pass`, which falls through to the next strategy, unless we got a token with user info. Then fail! if the user doesn't exist.