### PR TITLE
Ensure paging links have `page` only one time in each link

### DIFF
--- a/app/controllers/concerns/paging_concern.rb
+++ b/app/controllers/concerns/paging_concern.rb
@@ -35,15 +35,13 @@ module PagingConcern
     links = {
       first: path_resolver.call(
         collection_type,
-        page: 1,
         format: format_type,
-        params: request.query_parameters
+        params: request.query_parameters.merge(page: 1)
       ),
       last: path_resolver.call(
         collection_type,
-        page: total_pages,
         format: format_type,
-        params: request.query_parameters
+        params: request.query_parameters.merge(page: total_pages)
       ),
       prev: nil,
       next: nil
@@ -51,17 +49,15 @@ module PagingConcern
     if page_number > 1
       links[:prev] = path_resolver.call(
         collection_type,
-        page: page_number - 1,
         format: format_type,
-        params: request.query_parameters
+        params: request.query_parameters.merge(page: page_number - 1)
       )
     end
     if page_number < total_pages
       links[:next] = path_resolver.call(
         collection_type,
-        page: page_number + 1,
         format: format_type,
-        params: request.query_parameters
+        params: request.query_parameters.merge(page: page_number + 1)
       )
     end
 

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -10,6 +10,15 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert body_json.key?('data'), 'Response should have a "data" property'
   end
 
+  # Regression
+  test 'should not include the `page` parameter multiple times in one paging link' do
+    # This error occurred when the requested URL already had a `page` param
+    get('/api/v0/pages?page=1')
+    body = JSON.parse(@response.body)
+    first_uri = URI.parse(body['links']['first'])
+    assert_no_match(/(^|&)page=.+?&page=/, first_uri.query, 'The `page` param occurred multiple times in the same URL')
+  end
+
   test 'can filter pages by site' do
     site = 'http://example.com/'
     get "/api/v0/pages/?site=#{URI.encode_www_form_component site}"


### PR DESCRIPTION
Fixes #111. I had thought Rails URL helpers would be smart enough to merge the `params` keyword argument with other keyword arguments that ultimately become params. They are not. Instead, explicitly merge `page` into the `params` argument so that it doesn’t get repeated.