### PR TITLE
Stop exploding when posting empty annotations

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -40,7 +40,7 @@ class Annotation < ApplicationRecord
     return if value.nil?
 
     if !value.is_a?(Numeric)
-      errors.add(:annotaiton, ".#{property} must be a number")
+      errors.add(:annotation, ".#{property} must be a number")
     elsif !range.cover?(value)
       errors.add(:annotation, ".#{property} must be between #{range.begin} and #{range.end}")
     end

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -35,6 +35,12 @@ module Api
     end
   end
 
+  class UnprocessableError < ApiError
+    def status_code
+      422
+    end
+  end
+
   class MismatchedHashError < ApiError
     def status_code
       502

--- a/test/controllers/api/v0/annotations_controller_test.rb
+++ b/test/controllers/api/v0/annotations_controller_test.rb
@@ -249,4 +249,34 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
       name: 'Annotations'
     )
   end
+
+  test 'it rejects no POST body' do
+    page = pages(:home_page)
+
+    sign_in users(:alice)
+    post(
+      api_v0_page_change_annotations_path(page, "..#{page.versions[0].uuid}"),
+      headers: { 'Content-Type': 'application/json' },
+      params: ''
+    )
+
+    assert_response :bad_request
+    body = JSON.parse(@response.body)
+    assert(body.key?('errors'), 'Response should have an "errors" property')
+  end
+
+  test 'it rejects an empty annotation (i.e. `{}`)' do
+    page = pages(:home_page)
+
+    sign_in users(:alice)
+    post(
+      api_v0_page_change_annotations_path(page, "..#{page.versions[0].uuid}"),
+      headers: { 'Content-Type': 'application/json' },
+      params: '{}'
+    )
+
+    assert_response :unprocessable_entity
+    body = JSON.parse(@response.body)
+    assert(body.key?('errors'), 'Response should have an "errors" property')
+  end
 end


### PR DESCRIPTION
Fixes #113. We previously had oddball server errors for sending empty bodies or empty objects as annotations. This makes both of those cases `4xx` errors.

- Empty POST body: 400 (bad request)
- Empty annotation object: 422 (unprocessable entity)

The issue was originally noted in edgi-govdata-archiving/web-monitoring-ui#82. Based on that, I’m wondering if I should actually be accepting empty objects (but not empty bodies). The current code here just formalizes existing behaviors, where we rejected empty objects in one part of the code and then failed to handle it later. Now that POSTing a new annotation *replaces* your previous annotation (see #48), maybe we should allow empty objects.