### PR TITLE
Add import flag to replace or merge existing versions

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,8 +1,23 @@
 class Import < ApplicationRecord
   belongs_to :user
   enum status: [:pending, :processing, :complete]
+  enum update_behavior: [:skip, :replace, :merge], _suffix: :existing_records
   validates :file, presence: true
   after_initialize :ensure_processing_errors
+
+  def self.create_with_data(attributes, data)
+    create(attributes.merge(file: create_data_file(data)))
+  end
+
+  def self.create_data_file(data)
+    file_key = SecureRandom.uuid
+    FileStorage.default.save_file(file_key, data)
+    file_key
+  end
+
+  def load_data
+    FileStorage.default.get_file(file)
+  end
 
   protected
 

--- a/db/migrate/20170801192038_add_update_behavior_to_import.rb
+++ b/db/migrate/20170801192038_add_update_behavior_to_import.rb
@@ -1,0 +1,5 @@
+class AddUpdateBehaviorToImport < ActiveRecord::Migration[5.1]
+  def change
+    add_column(:imports, :update_behavior, :integer, default: 0, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170717072416) do
+ActiveRecord::Schema.define(version: 20170801192038) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 20170717072416) do
     t.jsonb "processing_errors"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "update_behavior", default: 0, null: false
     t.index ["user_id"], name: "index_imports_on_user_id"
   end
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -510,6 +510,21 @@ paths:
         - application/json
       produces:
         - application/json
+      parameters:
+        - name: update
+          in: query
+          type: string
+          enum:
+            - skip
+            - replace
+            - merge
+          default: skip
+          required: false
+          description: >
+            Specifies how versions that are already in the database (i.e. versions with the same `capture_time` and `source_type`) should be handled.
+              * `skip` (default value) Don’t import the version or modify the existing database entry
+              * `replace` Replace the existing database entry with the imported one
+              * `merge` Similar to `replace`, but merges the values in `source_metadata`
       responses:
         '200':
           description: successful operation

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -7,10 +7,13 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
   # These tests get network privileges (for now)
   def setup
     WebMock.allow_net_connect!
+    @original_allowed_hosts = Archiver.allowed_hosts
+    Archiver.allowed_hosts = ['https://test-bucket.s3.amazonaws.com']
   end
 
   def teardown
     WebMock.disable_net_connect!
+    Archiver.allowed_hosts = @original_allowed_hosts
   end
 
   test 'can import data' do
@@ -67,5 +70,105 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
 
     versions = pages[0].versions
     assert_equal 2, versions.length
+  end
+
+  test 'does not add or modify a version if it already exists' do
+    page_versions_count = pages(:home_page).versions.count
+    original_data = versions(:page1_v1).as_json
+    import_data = [
+      {
+        page_url: pages(:home_page).url,
+        page_title: pages(:home_page).title,
+        site_agency: 'The Federal Example Agency',
+        site_name: pages(:home_page).site,
+        capture_time: versions(:page1_v1).capture_time,
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+        version_hash: 'INVALID_HASH',
+        source_type: versions(:page1_v1).source_type,
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path,
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+
+    page = Page.find(pages(:home_page).uuid)
+    version = Version.find(versions(:page1_v1).uuid)
+    assert_equal(page_versions_count, page.versions.count)
+    assert_equal(original_data['version_hash'], version.version_hash, 'version_hash was changed')
+    assert_equal(original_data['source_metadata'], version.source_metadata, 'source_metadata was changed')
+  end
+
+  test 'replaces an existing version if requested' do
+    page_versions_count = pages(:home_page).versions.count
+    import_data = [
+      {
+        page_url: pages(:home_page).url,
+        page_title: pages(:home_page).title,
+        site_agency: 'The Federal Example Agency',
+        site_name: pages(:home_page).site,
+        capture_time: versions(:page1_v1).capture_time,
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+        version_hash: 'INVALID_HASH',
+        source_type: versions(:page1_v1).source_type,
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path(params: { update: 'replace' }),
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+    page = Page.find(pages(:home_page).uuid)
+    version = Version.find(versions(:page1_v1).uuid)
+    assert_equal(page_versions_count, page.versions.count)
+    assert_equal('INVALID_HASH', version.version_hash, 'version_hash was not changed')
+    assert_equal({ 'test_meta' => 'data' }, version.source_metadata, 'source_metadata was not replaced')
+  end
+
+  test 'merges an existing version if requested' do
+    page_versions_count = pages(:home_page).versions.count
+    original_data = versions(:page1_v1).as_json
+    import_data = [
+      {
+        page_url: pages(:home_page).url,
+        page_title: pages(:home_page).title,
+        site_agency: 'The Federal Example Agency',
+        site_name: pages(:home_page).site,
+        capture_time: versions(:page1_v1).capture_time,
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+        version_hash: 'INVALID_HASH',
+        source_type: versions(:page1_v1).source_type,
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path(params: { update: 'merge' }),
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+    page = Page.find(pages(:home_page).uuid)
+    version = Version.find(versions(:page1_v1).uuid)
+    assert_equal(page_versions_count, page.versions.count)
+    assert_equal('INVALID_HASH', version.version_hash, 'version_hash was not changed')
+    expected_meta = original_data['source_metadata'].merge('test_meta' => 'data')
+    assert_equal(expected_meta, version.source_metadata, 'source_metadata was not merged')
   end
 end

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -10,18 +10,17 @@ page1_v1:
   capture_time: '2017-03-01T00:00:00Z'
   version_hash: 'abc'
   source_type: 'versionista'
-  source_metadata: >
-    {
-      account: 'test@example.com',
-      site_id: 1,
-      page_id: 11,
-      version_id: 111,
-      page_url: 'http://versionista.com/1/11/',
-      diff_with_previous_url: 'http://versionista.com/1/11/111/',
-      diff_with_first_url: null,
-      diff_length: null,
-      diff_hash: null
-    }
+  source_metadata: {
+    account: 'test@example.com',
+    site_id: 1,
+    page_id: 11,
+    version_id: 111,
+    page_url: 'http://versionista.com/1/11/',
+    diff_with_previous_url: 'http://versionista.com/1/11/111/',
+    diff_with_first_url: null,
+    diff_length: null,
+    diff_hash: null
+  }
 
 page2_v1:
   page: sub_page

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -109,3 +109,15 @@ page1_v4:
       page_id: 11,
       version_id: 114
     }
+
+page1_v5:
+  page: home_page
+  uri: https://test-bucket.s3.amazonaws.com/page1_v5.html
+  capture_time: '2017-03-05T00:00:00Z'
+  version_hash: 'stu'
+  source_type: 'pagefreezer'
+  source_metadata:
+    account: 'test@example.com'
+    site_id: 1
+    page_id: 11
+    version_id: 115

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -1,0 +1,107 @@
+require 'test_helper'
+
+class ImportVersionsJobTest < ActiveJob::TestCase
+  def setup
+    @original_allowed_hosts = Archiver.allowed_hosts
+    Archiver.allowed_hosts = ['https://test-bucket.s3.amazonaws.com']
+  end
+
+  def teardown
+    Archiver.allowed_hosts = @original_allowed_hosts
+  end
+
+  test 'does not add or modify a version if it already exists' do
+    page_versions_count = pages(:home_page).versions.count
+    original_data = versions(:page1_v1).as_json
+
+    import = Import.create_with_data(
+      {
+        user: users(:alice)
+      },
+      [
+        {
+          page_url: pages(:home_page).url,
+          page_title: pages(:home_page).title,
+          site_agency: 'The Federal Example Agency',
+          site_name: pages(:home_page).site,
+          capture_time: versions(:page1_v1).capture_time,
+          uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+          version_hash: 'INVALID_HASH',
+          source_type: versions(:page1_v1).source_type,
+          source_metadata: { test_meta: 'data' }
+        }
+      ].map(&:to_json).join("\n")
+    )
+    ImportVersionsJob.perform_now(import)
+
+    assert_equal(page_versions_count, pages(:home_page).versions.count)
+    assert_equal(original_data['version_hash'], versions(:page1_v1).version_hash, 'version_hash was changed')
+    assert_equal(original_data['source_metadata'], versions(:page1_v1).source_metadata, 'source_metadata was changed')
+  end
+
+  test 'replaces an existing version if requested' do
+    page_versions_count = pages(:home_page).versions.count
+
+    import = Import.create_with_data(
+      {
+        user: users(:alice),
+        update_behavior: :replace
+      },
+      [
+        {
+          page_url: pages(:home_page).url,
+          page_title: pages(:home_page).title,
+          site_agency: 'The Federal Example Agency',
+          site_name: pages(:home_page).site,
+          capture_time: versions(:page1_v1).capture_time,
+          uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+          version_hash: 'INVALID_HASH',
+          source_type: versions(:page1_v1).source_type,
+          source_metadata: { test_meta: 'data' }
+        }
+      ].map(&:to_json).join("\n")
+    )
+    ImportVersionsJob.perform_now(import)
+
+    page = Page.find(pages(:home_page).uuid)
+    version = Version.find(versions(:page1_v1).uuid)
+    assert_equal([], import.processing_errors, 'There were processing errors')
+    assert_equal(page_versions_count, page.versions.count)
+    assert_equal('INVALID_HASH', version.version_hash, 'version_hash was not changed')
+    assert_equal({ 'test_meta' => 'data' }, version.source_metadata, 'source_metadata was not replaced')
+  end
+
+  test 'merges with an existing version if requested' do
+    page_versions_count = pages(:home_page).versions.count
+    original_meta = versions(:page1_v1).source_metadata
+
+    import = Import.create_with_data(
+      {
+        user: users(:alice),
+        update_behavior: :merge
+      },
+      [
+        {
+          page_url: pages(:home_page).url,
+          page_title: pages(:home_page).title,
+          site_agency: 'The Federal Example Agency',
+          site_name: pages(:home_page).site,
+          capture_time: versions(:page1_v1).capture_time,
+          uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+          version_hash: 'INVALID_HASH',
+          source_type: versions(:page1_v1).source_type,
+          source_metadata: { test_meta: 'data' }
+        }
+      ].map(&:to_json).join("\n")
+    )
+    ImportVersionsJob.perform_now(import)
+
+    page = Page.find(pages(:home_page).uuid)
+    version = Version.find(versions(:page1_v1).uuid)
+    assert_equal([], import.processing_errors, 'There were processing errors')
+    assert_equal(page_versions_count, page.versions.count)
+    assert_equal('INVALID_HASH', version.version_hash, 'version_hash was not changed')
+    expected_meta = original_meta.merge('test_meta' => 'data')
+    assert_equal(expected_meta, version.source_metadata, 'source_metadata was not merged')
+  end
+end

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -53,10 +53,10 @@ class ImportVersionsJobTest < ActiveJob::TestCase
           page_title: pages(:home_page).title,
           site_agency: 'The Federal Example Agency',
           site_name: pages(:home_page).site,
-          capture_time: versions(:page1_v1).capture_time,
-          uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+          capture_time: versions(:page1_v5).capture_time,
+          # NOTE: `uri` is left out intentionally; it should get set to nil
           version_hash: 'INVALID_HASH',
-          source_type: versions(:page1_v1).source_type,
+          source_type: versions(:page1_v5).source_type,
           source_metadata: { test_meta: 'data' }
         }
       ].map(&:to_json).join("\n")
@@ -64,16 +64,18 @@ class ImportVersionsJobTest < ActiveJob::TestCase
     ImportVersionsJob.perform_now(import)
 
     page = Page.find(pages(:home_page).uuid)
-    version = Version.find(versions(:page1_v1).uuid)
+    version = Version.find(versions(:page1_v5).uuid)
     assert_equal([], import.processing_errors, 'There were processing errors')
-    assert_equal(page_versions_count, page.versions.count)
+    assert_equal(page_versions_count, page.versions.count, 'A new version was added')
+    assert_nil(version.uri, 'uri was not changed')
     assert_equal('INVALID_HASH', version.version_hash, 'version_hash was not changed')
     assert_equal({ 'test_meta' => 'data' }, version.source_metadata, 'source_metadata was not replaced')
   end
 
   test 'merges with an existing version if requested' do
     page_versions_count = pages(:home_page).versions.count
-    original_meta = versions(:page1_v1).source_metadata
+    original_uri = versions(:page1_v5).uri
+    original_meta = versions(:page1_v5).source_metadata
 
     import = Import.create_with_data(
       {
@@ -86,10 +88,10 @@ class ImportVersionsJobTest < ActiveJob::TestCase
           page_title: pages(:home_page).title,
           site_agency: 'The Federal Example Agency',
           site_name: pages(:home_page).site,
-          capture_time: versions(:page1_v1).capture_time,
-          uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+          capture_time: versions(:page1_v5).capture_time,
+          # NOTE: uri is intentionally left out; it should not get set to nil
           version_hash: 'INVALID_HASH',
-          source_type: versions(:page1_v1).source_type,
+          source_type: versions(:page1_v5).source_type,
           source_metadata: { test_meta: 'data' }
         }
       ].map(&:to_json).join("\n")
@@ -97,9 +99,10 @@ class ImportVersionsJobTest < ActiveJob::TestCase
     ImportVersionsJob.perform_now(import)
 
     page = Page.find(pages(:home_page).uuid)
-    version = Version.find(versions(:page1_v1).uuid)
+    version = Version.find(versions(:page1_v5).uuid)
     assert_equal([], import.processing_errors, 'There were processing errors')
-    assert_equal(page_versions_count, page.versions.count)
+    assert_equal(page_versions_count, page.versions.count, 'A new version was added')
+    assert_equal(original_uri, version.uri, 'uri was changed')
     assert_equal('INVALID_HASH', version.version_hash, 'version_hash was not changed')
     expected_meta = original_meta.merge('test_meta' => 'data')
     assert_equal(expected_meta, version.source_metadata, 'source_metadata was not merged')

--- a/test/models/import_test.rb
+++ b/test/models/import_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class ImportTest < ActiveSupport::TestCase
+  test 'import models can be created with data and retrieve it' do
+    data = 'TEST DATA'
+    import = Import.create_with_data({ user: users(:alice) }, data)
+    assert(import.present?, 'Import instance did not have a file attribute')
+    assert_equal(data, import.load_data, 'Retrieved data did not match stored data')
+  end
+end


### PR DESCRIPTION
Imports previously skipped versions that were already in the database (i.e. versions that have matching `capture_time` and `source_type` fields). In order to update bad imports, we need to be able to touch existing versions.

If you import as before, the behavior stays the same. However, if you provide the `update` query arg, you can customize how existing versions are handled:

- `?update=replace` Replaces all content in the existing version with new content
- `?update=merge` Merges the source_metadata fields (and replaces everything else)

Fixes #115