### PR TITLE
Query Versions by `source_metadata` fields

### DIFF
--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -91,6 +91,12 @@ class Api::V0::VersionsController < Api::V0::ApiController
       source_type: params[:source_type]
     }.compact)
 
+    if params[:source_metadata].respond_to?(:each)
+      params[:source_metadata].each do |key, value|
+        collection = collection.where('source_metadata->>? = ?', key, value)
+      end
+    end
+
     where_in_range_param(collection, :capture_time, &method(:parse_date!))
   end
 end

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -154,6 +154,17 @@ paths:
             time..time such as 2017-04-01T10:00Z..2017-04-01T12:00Z
           required: false
           type: string
+        - name: source_metadata[:key]
+          in: query
+          description: >-
+            Filter results by a given `key` in the `source_metadata` field. You
+            can include this parameter multiple times to filter by more than
+            one `key`. *Note that this field is not indexed, so these queries
+            can be slow.* Examples:
+
+            - `/api/v0/versions?source_metadata[version_id]=12345678`
+
+            - `/api/v0/versions?source_metadata[account]=versionista1&source_metadata[has_content]=true`
       responses:
         '200':
           description: successful operation
@@ -473,6 +484,17 @@ paths:
           description: Filter by version_hash.
           required: false
           type: string
+        - name: source_metadata[:key]
+          in: query
+          description: >-
+            Filter results by a given `key` in the `source_metadata` field. You
+            can include this parameter multiple times to filter by more than
+            one `key`. *Note that this field is not indexed, so these queries
+            can be slow.* Examples:
+
+            - `/api/v0/versions?source_metadata[version_id]=12345678`
+
+            - `/api/v0/versions?source_metadata[account]=versionista1&source_metadata[has_content]=true`
       responses:
         '200':
           description: successful operation

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -158,4 +158,21 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     assert(body.key?('links'), 'Response should have a "links" property')
     assert(body.key?('data'), 'Response should have a "data" property')
   end
+
+  test 'can query by source_metadata fields' do
+    version = versions(:page1_v1)
+    get api_v0_versions_path(params: {
+      source_metadata: { version_id: version.source_metadata['version_id'] }
+    })
+
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    ids = body['data'].collect {|v| v['source_metadata']['version_id']}.uniq
+    assert_equal(1, ids.length, 'Only one version ID should be included in results')
+    assert_equal(
+      version.source_metadata['version_id'],
+      ids[0],
+      'The returned version did not have a matching ID'
+    )
+  end
 end

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -28,18 +28,17 @@ page2_v1:
   capture_time: '2017-03-01T00:00:00Z'
   version_hash: 'def'
   source_type: 'versionista'
-  source_metadata: >
-    {
-      account: 'test@example.com',
-      site_id: 1,
-      page_id: 12,
-      version_id: 121,
-      page_url: 'http://versionista.com/1/12/',
-      diff_with_previous_url: 'http://versionista.com/1/12/121/',
-      diff_with_first_url: nil,
-      diff_length: nil,
-      diff_hash: nil
-    }
+  source_metadata: {
+    account: 'test@example.com',
+    site_id: 1,
+    page_id: 12,
+    version_id: 121,
+    page_url: 'http://versionista.com/1/12/',
+    diff_with_previous_url: 'http://versionista.com/1/12/121/',
+    diff_with_first_url: nil,
+    diff_length: nil,
+    diff_hash: nil
+  }
 
 page1_v2:
   page: home_page
@@ -47,18 +46,17 @@ page1_v2:
   capture_time: '2017-03-02T00:00:00Z'
   version_hash: 'ghi'
   source_type: 'versionista'
-  source_metadata: >
-    {
-      account: 'test@example.com',
-      site_id: 1,
-      page_id: 11,
-      version_id: 112,
-      page_url: 'http://versionista.com/1/11/',
-      diff_with_previous_url: 'http://versionista.com/1/11/112/',
-      diff_with_first_url: nil,
-      diff_length: 1234678,
-      diff_hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
-    }
+  source_metadata: {
+    account: 'test@example.com',
+    site_id: 1,
+    page_id: 11,
+    version_id: 112,
+    page_url: 'http://versionista.com/1/11/',
+    diff_with_previous_url: 'http://versionista.com/1/11/112/',
+    diff_with_first_url: nil,
+    diff_length: 1234678,
+    diff_hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+  }
 
 page2_v2:
   page: sub_page
@@ -66,49 +64,46 @@ page2_v2:
   capture_time: '2017-03-02T00:00:00Z'
   version_hash: 'jkl'
   source_type: 'versionista'
-  source_metadata: >
-    {
-      account: 'test@example.com',
-      site_id: 1,
-      page_id: 12,
-      version_id: 122,
-      page_url: 'http://versionista.com/1/12/',
-      diff_with_previous_url: 'http://versionista.com/1/12/122/',
-      diff_with_first_url: nil,
-      diff_length: 1234678,
-      diff_hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
-    }
+  source_metadata: {
+    account: 'test@example.com',
+    site_id: 1,
+    page_id: 12,
+    version_id: 122,
+    page_url: 'http://versionista.com/1/12/',
+    diff_with_previous_url: 'http://versionista.com/1/12/122/',
+    diff_with_first_url: nil,
+    diff_length: 1234678,
+    diff_hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+  }
 
 page1_v3:
   page: home_page
   capture_time: '2017-03-03T00:00:00Z'
   version_hash: 'mno'
   source_type: 'versionista'
-  source_metadata: >
-    {
-      account: 'test@example.com',
-      site_id: 1,
-      page_id: 11,
-      version_id: 113,
-      page_url: 'http://versionista.com/1/11/',
-      diff_with_previous_url: 'http://versionista.com/1/11/113/',
-      diff_with_first_url: nil,
-      diff_length: 1234672,
-      diff_hash: '749ab2c0d06c42ae3b841b79e79875f02b3a042e43c92378cd28bd444c04d284'
-    }
+  source_metadata: {
+    account: 'test@example.com',
+    site_id: 1,
+    page_id: 11,
+    version_id: 113,
+    page_url: 'http://versionista.com/1/11/',
+    diff_with_previous_url: 'http://versionista.com/1/11/113/',
+    diff_with_first_url: nil,
+    diff_length: 1234672,
+    diff_hash: '749ab2c0d06c42ae3b841b79e79875f02b3a042e43c92378cd28bd444c04d284'
+  }
 
 page1_v4:
   page: home_page
   capture_time: '2017-03-04T00:00:00Z'
   version_hash: 'pqr'
   source_type: 'pagefreezer'
-  source_metadata: >
-    {
-      account: 'test@example.com',
-      site_id: 1,
-      page_id: 11,
-      version_id: 114
-    }
+  source_metadata: {
+    account: 'test@example.com',
+    site_id: 1,
+    page_id: 11,
+    version_id: 114
+  }
 
 page1_v5:
   page: home_page


### PR DESCRIPTION
This adds the ability to query Versions by fields in `source_metadata`, e.g:

- `/api/v0/versions?source_type=versionista&source_metadata[version_id]=12345678` to get the version with the Versionista ID `12345678`.
- `/api/v0/versions?source_type=versionista&source_metadata[errorCode]=404` to get all Versionista-tracked versions where the page went missing
- `/api/v0/versions?source_type=versionista&source_metadata[page_id]=987654&source_metadata[errorCode]=404` to get versions where a specific Versionista-tracked page went missing

This should help with processing scripts and tools @janakrajchadha is working on.

Fixes #123.