### PR TITLE
HOTFIX: Reflect origin header for CORS auth

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module WebpageVersionsDb
       end
 
       allow do
-        origins '*'
+        origins /.*/
         resource '*', :headers => :any, :methods => [:get, :post, :options], :if => is_admin_url
       end
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,9 @@ module WebpageVersionsDb
       end
 
       allow do
+        # Use this instead of `origins '*'` because we need to allow auth.
+        # FIXME: We should come back and re-evaluate if we can change client
+        # behavior to work with `origins '*'`
         origins /.*/
         resource '*', :headers => :any, :methods => [:get, :post, :options], :if => is_admin_url
       end


### PR DESCRIPTION
Looks like I broke remote authentication in e70230a. An upgrade to rack-cors changed the behavior of `origins '*'` such that it now does not reflect the request's origin and instead actually sends '*' for the allowed origins header. That means authentication on our requests fails :(

See this change in rack-cors: cyu/rack-cors#142

We needed this behavior initially because it seemed like `Authorization` headers in our requests were getting stripped, but it seems like this may no longer be true (or, more likely, I mis-diagnosed the issue originally). That needs more testing, though. For now, force rack-cors to return to its earlier behavior.