### PR TITLE
HOTFIX: query paging problems

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -65,7 +65,7 @@ class Api::V0::ApiController < ApplicationController
   end
 
   def parse_date!(date)
-    raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d\:\d\d(\:\d\d(\.\d+)?)?(Z|([+\-]\d{4})))?$/)
+    raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d\:\d\d(\:\d\d(\.\d+)?)?(Z|([+\-]\d\d:?\d\d)))?$/)
     DateTime.parse date
   rescue
     raise Api::InputError, "Invalid date: '#{date}'"

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -4,10 +4,8 @@ class Api::V0::PagesController < Api::V0::ApiController
     paging = pagination(query)
     pages = query.limit(paging[:page_items]).offset(paging[:offset])
 
-    # If we are including versions, sort the version list in-app here.
-    # Why is a bit complicated... when using limit/offset on queries that
-    # `include` associations (as we include `versions` here), it actually does
-    # TWO queries:
+    # When using limit/offset on queries that `include` associations (e.g.
+    # `versions` here), ActiveRecord actually does TWO queries:
     #   1. A query for only the IDs of the primary record type (e.g. pages).
     #      This ensures the limit/offset isn't mispositioned by extra rows
     #      created when joining to the versions table.
@@ -16,21 +14,34 @@ class Api::V0::PagesController < Api::V0::ApiController
     #      This gets us the actual data to instantiate models.
     #
     # HOWEVER! If ordering criteria includes fields from the associated records
-    # (e.g. versions), then they those fields have to be included in the first
-    # query, which means we potentially get the wrong primary record IDs (since
-    # the returned rows are now a pages + versions combo).
+    # (e.g. versions), then those fields have to be included in the first query,
+    # which means we potentially get the wrong primary record IDs (since the
+    # returned rows are now a pages + versions combo).
     #
-    # So my best solution here is to sort in-app :(
+    # To work around this, do a similar operation manually:
+    #   1. Do NOT `includes(:versions)` and do NOT include version sorting on
+    #      the first query where we get IDs so as not to trigger the two-query
+    #      behavior (otherwise it would query for a set of IDs in order to query
+    #      for the IDs we asked for).
+    #   2. Once we have IDs, query specifically for those IDs and then include
+    #      the associated version records and version ordering info. This does
+    #      not trigger the two-query behavior because there's no limit/offset.
+    #
+    # NOTE: there was a previous solution to this that manually ordered
+    # versions right here in Ruby. This approach results in the same number of
+    # SQL queries and gets results already in the right order, so should
+    # hopefully be more performant.
     result_data =
       if should_include_versions
-        pages.as_json(include: :versions).collect do |page|
-          page['versions'].sort! do |a, b|
-            a['capture_time'] <=> b['capture_time']
-          end
-          page
-        end
+        # NOTE: need to get :updated_at here because it's used for ordering
+        page_ids = pages.pluck(:uuid, :updated_at).collect {|data| data[0]}
+        results = query
+          .where(uuid: page_ids)
+          .includes(:versions)
+          .order('versions.capture_time')
+        results.as_json(include: :versions)
       else
-        pages.as_json(include: :latest)
+        pages.includes(:latest).as_json(include: :latest)
       end
 
     render json: {
@@ -83,13 +94,6 @@ class Api::V0::PagesController < Api::V0::ApiController
         collection = collection.where(url: query)
       end
     end
-
-    collection =
-      if should_include_versions
-        collection.includes(:versions)
-      else
-        collection.includes(:latest)
-      end
 
     # If any queries create implicit joins, ensure we get a list of unique pages
     collection.distinct.order(updated_at: :desc)


### PR DESCRIPTION
We previously did not include all the matching pages when paginating the results for a large query on a list of pages (two kinds of “pages” there, con't figure out a better way to phrase). This is because of some craziness with how ordering is handled when using limit/offset queries in ActiveRecord.

Specifically, ActiveRecord actually does _TWO_ queries when using `limit`/`offset` on queries that `include` associated records (e.g. version records that are associated with page records in this case):

1. A query for only the IDs of the primary record type (e.g. pages). This ensures the limit/offset isn't mispositioned by extra rows created when joining to the versions table.

    In our case, that might look like:

    ```sql
    SELECT DISTINCT
      "pages"."uuid",
      "pages"."updated_at" AS alias_0
    FROM "pages" INNER JOIN "versions" ON "versions"."page_uuid" = "pages"."uuid"
    WHERE
      (versions.capture_time >= '2017-08-28 16:00:00')
      AND (versions.capture_time <= '2017-09-05 04:00:00')
      AND "versions"."source_type" = $1
    ORDER BY "pages"."updated_at" DESC
    LIMIT 100 OFFSET 2700
    ```

2. A query for the joined primary and associated records (e.g. pages + versions) based on a list of primary record IDs from step 1 above. This gets us the actual data to instantiate models.

    Again, in our case, that might be like:

    ```sql
    SELECT
      "pages"."uuid" AS t0_r0,
      "pages"."url" AS t0_r1,
      "pages"."title" AS t0_r2,
      "pages"."agency" AS t0_r3,
      "pages"."site" AS t0_r4,
      "pages"."created_at" AS t0_r5,
      "pages"."updated_at" AS t0_r6,
      "versions"."uuid" AS t1_r0,
      "versions"."page_uuid" AS t1_r1,
      "versions"."capture_time" AS t1_r2,
      "versions"."uri" AS t1_r3,
      "versions"."version_hash" AS t1_r4,
      "versions"."source_type" AS t1_r5,
      "versions"."source_metadata" AS t1_r6,
      "versions"."created_at" AS t1_r7,
      "versions"."updated_at" AS t1_r8
    FROM "pages" INNER JOIN "versions" ON "versions"."page_uuid" = "pages"."uuid"
    WHERE
      (versions.capture_time >= '2017-08-28 16:00:00')
      AND (versions.capture_time <= '2017-09-05 04:00:00')
      AND "versions"."source_type" = 'versionista'
      -- Instead of LIMIT/OFFSET, use an explicit list of IDs we got from the first query here:
      AND "pages"."uuid" IN ('520af9c8-978f-4952-8d64-b33cb50eb3ba', '4437b41e-0ede-4d1f-a406-cca2c01d4170', ...)
      ORDER BY "pages"."updated_at" DESC
    ```

Unfortunately, if ordering criteria includes fields from the associated records (e.g. versions), then they those fields have to be included in the first query, which means we potentially get the wrong primary record IDs (since the returned rows are now a pages + versions combo).

E.g. we sort versions chronologically (`ORDER BY versions.capture_time ASC`). If that order clause is part of the ActiveRecord query, then `versions.capture_time` winds up getting included in the `SELECT DISTINCT` clause of the query in step (1), thereby screwing up the offsets because it’s no longer a simple, distinct list of pages.

This patch attempts to work around the issue by doing the same two steps ourselves.

This issue is noted in https://github.com/rails/rails/issues/28364, though it’s mixed-up with another, separate problem there.

Discovered this issue when attempting to query the DB for updates to create analyst CSVs (instead of directly scraping Versionista for those CSVs): edgi-govdata-archiving/web-monitoring-versionista-scraper#38.