### PR TITLE
Sync Page title with most recently captured version

### DIFF
--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -75,7 +75,8 @@ class Api::V0::VersionsController < Api::V0::ApiController
       'uri',
       'version_hash',
       'source_type',
-      'source_metadata'
+      'source_metadata',
+      'title'
     ]
     params
       .require(:version)

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -70,6 +70,9 @@ class ImportVersionsJob < ApplicationJob
   end
 
   def version_for_record(record, existing_version = nil, update_behavior = 'replace')
+    # TODO: Remove line 74 below once full transition from 'page_title' to 'title'
+    # is complete
+    record['title'] = record['page_title'] if record.key?('page_title')
     disallowed = ['id', 'uuid', 'created_at', 'updated_at']
     allowed = Version.attribute_names - disallowed
 
@@ -104,7 +107,6 @@ class ImportVersionsJob < ApplicationJob
     end
     Page.find_by(search_options) || Page.create(
       url: record['page_url'],
-      title: record['page_title'],
       agency: record['site_agency'],
       site: record['site_name']
     )

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -45,8 +45,8 @@ class Page < ApplicationRecord
 
   def sync_titles(version)
     if version.title.present?
-      most_recent_capture_time = versions.limit(1).order(capture_time: :desc).pluck(:capture_time).first
-      self.title = version.title if most_recent_capture_time.nil? || most_recent_capture_time <= version.capture_time
+      most_recent_capture_time = latest.capture_time
+      update(title: version.title) if most_recent_capture_time.nil? || most_recent_capture_time <= version.capture_time
     end
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -4,8 +4,7 @@ class Page < ApplicationRecord
   has_many :versions,
     -> { order(capture_time: :desc) },
     foreign_key: 'page_uuid',
-    inverse_of: :page,
-    after_add: :sync_titles
+    inverse_of: :page
   has_one :latest,
     (lambda do
       # DISTINCT ON requires the first ORDER to be the distinct column(s)
@@ -40,13 +39,6 @@ class Page < ApplicationRecord
   def url_must_have_domain
     unless url.match?(/^([\w\+\-\.]+:\/\/)?[^\/]+\.[^\/]{2,}/)
       errors.add(:url, 'must have a domain')
-    end
-  end
-
-  def sync_titles(version)
-    if version.title.present?
-      most_recent_capture_time = latest.capture_time
-      update(title: version.title) if most_recent_capture_time.nil? || most_recent_capture_time <= version.capture_time
     end
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -8,7 +8,7 @@ class Version < ApplicationRecord
     class_name: 'Change',
     foreign_key: 'uuid_to'
 
-  after_save :sync_page_title
+  after_create :sync_page_title
 
   def previous
     self.page.versions.where('capture_time < ?', self.capture_time).first

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -8,11 +8,22 @@ class Version < ApplicationRecord
     class_name: 'Change',
     foreign_key: 'uuid_to'
 
+  after_save :sync_page_title
+
   def previous
     self.page.versions.where('capture_time < ?', self.capture_time).first
   end
 
   def change_from_previous
     Change.between(from: previous, to: self)
+  end
+
+  private
+
+  def sync_page_title
+    if title.present?
+      most_recent_capture_time = page.latest.capture_time
+      page.update(title: title) if most_recent_capture_time.nil? || most_recent_capture_time <= capture_time
+    end
   end
 end

--- a/db/migrate/20170909151007_add_title_to_versions.rb
+++ b/db/migrate/20170909151007_add_title_to_versions.rb
@@ -1,0 +1,5 @@
+class AddTitleToVersions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :versions, :title, :string
+  end
+end

--- a/db/migrate/20170909151007_add_title_to_versions.rb
+++ b/db/migrate/20170909151007_add_title_to_versions.rb
@@ -1,5 +1,8 @@
 class AddTitleToVersions < ActiveRecord::Migration[5.1]
   def change
     add_column :versions, :title, :string
+    Version.includes(:page).find_each do |v|
+      puts "Updated Version record with UUID #{v.uuid} to have title '#{v.title}'" if v.update(title: v.page.title)
+    end
   end
 end

--- a/db/migrate/20170909151007_add_title_to_versions.rb
+++ b/db/migrate/20170909151007_add_title_to_versions.rb
@@ -1,8 +1,20 @@
 class AddTitleToVersions < ActiveRecord::Migration[5.1]
   def change
     add_column :versions, :title, :string
-    Version.includes(:page).find_each do |v|
-      puts "Updated Version record with UUID #{v.uuid} to have title '#{v.title}'" if v.update(title: v.page.title)
+
+    reversible do |dir|
+      dir.up do
+        say_with_time("Copying titles from pages to versions") do
+          page_count = 0
+          version_count = 0
+          Page.includes(:versions).find_each do |page|
+            page_count += 1
+            version_count += page.versions.update_all(title: page.title)
+          end
+          say("#{page_count} pages assessed", :subitem)
+          say("#{version_count} versions updated", :subitem)
+        end
+      end
     end
   end
 end

--- a/db/migrate/20170909151007_add_title_to_versions.rb
+++ b/db/migrate/20170909151007_add_title_to_versions.rb
@@ -4,7 +4,7 @@ class AddTitleToVersions < ActiveRecord::Migration[5.1]
 
     reversible do |dir|
       dir.up do
-        say_with_time("Copying titles from pages to versions") do
+        say_with_time('Copying titles from pages to versions') do
           page_count = 0
           version_count = 0
           Page.includes(:versions).find_each do |page|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170801192038) do
+ActiveRecord::Schema.define(version: 20170909151007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,6 +104,7 @@ ActiveRecord::Schema.define(version: 20170801192038) do
     t.jsonb "source_metadata"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
     t.index ["capture_time"], name: "index_versions_on_capture_time"
     t.index ["page_uuid"], name: "index_versions_on_page_uuid"
     t.index ["version_hash"], name: "index_versions_on_version_hash"

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -20,7 +20,7 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
     import_data = [
       {
         page_url: 'http://testsite.com/',
-        page_title: 'Example Page',
+        title: 'Example Page',
         site_agency: 'The Federal Example Agency',
         site_name: 'Example Site',
         capture_time: '2017-05-01T12:33:01Z',
@@ -31,7 +31,7 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
       },
       {
         page_url: 'http://testsite.com/',
-        page_title: 'Example Page',
+        title: 'Example Page',
         site_agency: 'The Federal Example Agency',
         site_name: 'Example Site',
         capture_time: '2017-05-02T12:33:01Z',
@@ -64,10 +64,9 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
 
     pages = Page.where(url: 'http://testsite.com/')
     assert_equal 1, pages.length
+    assert_equal import_data[0][:title], pages[0].title
     assert_equal import_data[0][:site_agency], pages[0].agency
     assert_equal import_data[0][:site_name], pages[0].site
-    assert_equal import_data[0][:page_title], pages[0].latest.title
-    assert_nil pages[0].title
 
     versions = pages[0].versions
     assert_equal 2, versions.length

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -64,9 +64,10 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
 
     pages = Page.where(url: 'http://testsite.com/')
     assert_equal 1, pages.length
-    assert_equal import_data[0][:page_title], pages[0].title
     assert_equal import_data[0][:site_agency], pages[0].agency
     assert_equal import_data[0][:site_name], pages[0].site
+    assert_equal import_data[0][:page_title], pages[0].latest.title
+    assert_nil pages[0].title
 
     versions = pages[0].versions
     assert_equal 2, versions.length

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -19,13 +19,10 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title)
 
     page.versions.create(title: 'Newest Version', capture_time: '2017-03-05T00:00:00Z')
-    page.reload
     assert_equal('Newest Version', page.title, 'The page title should always sync against the title of the version with the most recent capture time')
-    refute(page.changed?, 'The page was left with unsaved changes')
+
     page.versions.create(title: 'Older Version', capture_time: '2017-03-01T00:00:00Z')
-    page.reload
     refute_equal('Older Version', page.title, 'The page title should not sync against the title of a newly created version with an older capture time')
-    refute(page.changed?, 'The page was left with unsaved changes')
   end
 
   test "page title should not sync with a version's title if it's nil or blank" do
@@ -33,12 +30,9 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title)
 
     page.versions.create(capture_time: '2017-03-05T00:00:00Z')
-    page.reload
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has a nil title')
-    refute(page.changed?, 'The page was left with unsaved changes')
+
     page.versions.create(title: '', capture_time: '2017-03-05T00:00:00Z')
-    page.reload
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has an empty title')
-    refute(page.changed?, 'The page was left with unsaved changes')
   end
 end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -13,4 +13,24 @@ class PageTest < ActiveSupport::TestCase
     page = Page.create(url: 'some/path/to/a/page')
     assert_not(page.valid?, 'The page should be invalid because it has no domain')
   end
+
+  test 'page title should sync with title from version with most recent capture time' do
+    page = pages(:home_page)
+    assert_equal('Page One', page.title)
+
+    page.versions.create(title: 'Newest Version', capture_time: '2017-03-05T00:00:00Z')
+    assert_equal('Newest Version', page.title, 'The page title should always sync against the title of the version with the most recent capture time')
+    page.versions.create(title: 'Older Version', capture_time: '2017-03-01T00:00:00Z')
+    refute_equal('Older Version', page.title, 'The page title should not sync against the title of a newly created version with an older capture time')
+  end
+
+  test "page title should not sync with a version's title if it's nil or blank" do
+    page = pages(:home_page)
+    assert_equal('Page One', page.title)
+
+    page.versions.create(capture_time: '2017-03-05T00:00:00Z')
+    assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has a nil title')
+    page.versions.create(title: '', capture_time: '2017-03-05T00:00:00Z')
+    assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has an empty title')
+  end
 end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -19,9 +19,13 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title)
 
     page.versions.create(title: 'Newest Version', capture_time: '2017-03-05T00:00:00Z')
+    page.reload
     assert_equal('Newest Version', page.title, 'The page title should always sync against the title of the version with the most recent capture time')
+    refute(page.changed?, 'The page was left with unsaved changes')
     page.versions.create(title: 'Older Version', capture_time: '2017-03-01T00:00:00Z')
+    page.reload
     refute_equal('Older Version', page.title, 'The page title should not sync against the title of a newly created version with an older capture time')
+    refute(page.changed?, 'The page was left with unsaved changes')
   end
 
   test "page title should not sync with a version's title if it's nil or blank" do
@@ -29,8 +33,12 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title)
 
     page.versions.create(capture_time: '2017-03-05T00:00:00Z')
+    page.reload
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has a nil title')
+    refute(page.changed?, 'The page was left with unsaved changes')
     page.versions.create(title: '', capture_time: '2017-03-05T00:00:00Z')
+    page.reload
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has an empty title')
+    refute(page.changed?, 'The page was left with unsaved changes')
   end
 end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -19,9 +19,10 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title)
 
     page.versions.create(title: 'Newest Version', capture_time: '2017-03-05T00:00:00Z')
+    refute(page.changed?, 'The page was left with unsaved changes')
     assert_equal('Newest Version', page.title, 'The page title should always sync against the title of the version with the most recent capture time')
-
     page.versions.create(title: 'Older Version', capture_time: '2017-03-01T00:00:00Z')
+    refute(page.changed?, 'The page was left with unsaved changes')
     refute_equal('Older Version', page.title, 'The page title should not sync against the title of a newly created version with an older capture time')
   end
 
@@ -30,9 +31,10 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title)
 
     page.versions.create(capture_time: '2017-03-05T00:00:00Z')
+    refute(page.changed?, 'The page was left with unsaved changes')
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has a nil title')
-
     page.versions.create(title: '', capture_time: '2017-03-05T00:00:00Z')
+    refute(page.changed?, 'The page was left with unsaved changes')
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has an empty title')
   end
 end


### PR DESCRIPTION
Resolves #59 

This work adds a `title` attribute to the `versions` table, and supplies an `after_add` callback to `Page` model, which sets the `Page`'s `title` attribute to match that of the `Version` with the most recent `capture_time`.

I'm not quite familiar enough with the application at this point to know intuitively whether the `title` attribute on a `Version` should include a validation for presence as a mandatory field, but my best judgement led me to forego that addition, and simpy match it to the `Page`'s implementation of the same field.

Please let me know if I've missed anything or if there's anything else I can do to help on this ticket! 😄 