### PR TITLE
Do not include latest version on pages by default

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -27,8 +27,10 @@ class Api::V0::PagesController < Api::V0::ApiController
           .includes(:versions)
           .order('versions.capture_time')
         results.as_json(include: :versions)
-      else
+      elsif should_include_latest
         pages.includes(:latest).as_json(include: :latest)
+      else
+        pages.as_json
       end
 
     render json: {
@@ -52,6 +54,10 @@ class Api::V0::PagesController < Api::V0::ApiController
 
   def should_include_versions
     boolean_param :include_versions
+  end
+
+  def should_include_latest
+    !should_include_versions && boolean_param(:include_latest)
   end
 
   def page_collection


### PR DESCRIPTION
You must now use an `?include_latest` flag:

`GET /api/v0/pages?include_latest`

Note that if you use both `?include_latest&include_versions`, then `include_latest` is ignored.

Fixes #131.