### PR TITLE
Sort versions in /pages?include_versions in descending capture_time order.

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -25,7 +25,7 @@ class Api::V0::PagesController < Api::V0::ApiController
         results = query
           .where(uuid: page_ids)
           .includes(:versions)
-          .order('versions.capture_time')
+          .order('versions.capture_time DESC')
         results.as_json(include: :versions)
       elsif should_include_latest
         pages.includes(:latest).as_json(include: :latest)

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -165,7 +165,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, home_page['versions'].length, '"Home page" included too many versions'
   end
 
-  test 'Included versions should be in capture_time order' do
+  test 'Included versions should be in descending capture_time order' do
     # Add a version whose natural order and capture_time order are different
     latest_time = pages(:home_page).versions.first.capture_time
     pages(:home_page).versions.create(capture_time: latest_time - 1.day)
@@ -177,7 +177,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     )
     body = JSON.parse(@response.body)
     times = body['data'][0]['versions'].pluck('capture_time')
-    assert_ordered(times, name: 'Versions')
+    assert_ordered(times.reverse, name: 'Versions')
   end
 
   test 'include_versions can be "1"' do


### PR DESCRIPTION
Closes #118