### PR TITLE
Fill `diff_service_version` from `diff.version`

### DIFF
--- a/app/controllers/api/v0/diff_controller.rb
+++ b/app/controllers/api/v0/diff_controller.rb
@@ -2,14 +2,16 @@ class Api::V0::DiffController < Api::V0::ApiController
   def show
     ensure_diffable
 
+    content = raw_diff
+
     render json: {
       data: {
         page_id: change.version.page.uuid,
         from_version_id: change.from_version.uuid,
         to_version_id: change.version.uuid,
         diff_service: params[:type],
-        diff_service_version: '?',
-        content: raw_diff
+        diff_service_version: content.is_a?(Hash) && content['version'] || '?',
+        content: content
       }
     }
   end

--- a/test/controllers/api/v0/diff_controller_test.rb
+++ b/test/controllers/api/v0/diff_controller_test.rb
@@ -2,13 +2,15 @@ require 'test_helper'
 require 'minitest/mock'
 
 class Api::V0::DiffControllerTest < ActionDispatch::IntegrationTest
-  test 'can diff two versions' do
-    differ = Differ::SimpleDiff.new('http://example.com')
-    Differ.register(:special, differ)
+  setup do
+    @differ = Differ::SimpleDiff.new('http://example.com')
+    Differ.register(:special, @differ)
+  end
 
+  test 'can diff two versions' do
     change = changes(:page1_change_1_2)
 
-    differ.stub(:diff, 'Diff!') do
+    @differ.stub(:diff, 'Diff!') do
       get "/api/v0/pages/#{change.version.page.uuid}/changes/#{change.from_version.uuid}..#{change.version.uuid}/diff/special"
     end
 
@@ -30,5 +32,23 @@ class Api::V0::DiffControllerTest < ActionDispatch::IntegrationTest
     change = changes(:page1_change_2_3)
     get "/api/v0/pages/#{change.version.page.uuid}/changes/#{change.from_version.uuid}..#{change.version.uuid}/diff/special"
     assert_response :bad_request
+  end
+
+  test 'fills in `diff_service_version` when the diff has a `version` field' do
+    change = changes(:page1_change_1_2)
+    raw_diff = {
+      'diff' => [[0, 'some'], [1, 'content']],
+      'version' => '1.0'
+    }
+
+    @differ.stub(:diff, raw_diff) do
+      get "/api/v0/pages/#{change.version.page.uuid}/changes/#{change.from_version.uuid}..#{change.version.uuid}/diff/special"
+    end
+
+    assert_response(:success)
+    assert_equal('application/json', @response.content_type)
+    body = JSON.parse(@response.body)
+    assert(body.key?('data'), 'Response should have a "data" property')
+    assert_equal('1.0', body['data']['diff_service_version'])
   end
 end


### PR DESCRIPTION
Fixes #137.

Note this doesn't address any of the lingering questions from #137. We should work those out and, if needed, add some more commits here before merging.