### PR TITLE
Add visual HTML diffs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,7 @@ export DIFFER_PAGEFREEZER=http://localhost:8888/pagefreezer
 export DIFFER_HTML_SOURCE=http://localhost:8888/html_source_diff
 export DIFFER_HTML_TEXT=http://localhost:8888/html_text_diff
 export DIFFER_SIDE_BY_SIDE_TEXT=http://localhost:8888/side_by_side_text
+export DIFFER_SIDE_BY_SIDE_TEXT=http://localhost:8888/html_visual_diff
 
 # Set a private RSA key to use for signing auth tokens
 # This MUST be replaced with a unique value in production!

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -6,6 +6,7 @@ class Api::V0::ApiController < ApplicationController
   rescue_from StandardError, with: :render_errors if Rails.env.production? || Rails.env.test?
   rescue_from Api::NotImplementedError, with: :render_errors
   rescue_from Api::InputError, with: :render_errors
+  rescue_from Api::DynamicError, with: :render_errors
 
   rescue_from ActiveRecord::RecordInvalid, with: :render_errors
   rescue_from ActiveModel::ValidationError do |error|

--- a/config/initializers/differ.rb
+++ b/config/initializers/differ.rb
@@ -1,32 +1,22 @@
 require_dependency 'differ/differ'
 require_dependency 'differ/simple_diff'
 
-if ENV['DIFFER_SOURCE']
-  Differ.register(:source, Differ::SimpleDiff.new(ENV['DIFFER_SOURCE']))
-end
-
-if ENV['DIFFER_LENGTH']
-  Differ.register(:length, Differ::SimpleDiff.new(ENV['DIFFER_LENGTH']))
-end
-
-if ENV['DIFFER_IDENTICAL_BYTES']
-  Differ.register(:identical_bytes,
-                  Differ::SimpleDiff.new(ENV['DIFFER_IDENTICAL_BYTES']))
-end
-
-if ENV['DIFFER_SIDE_BY_SIDE_TEXT']
-  Differ.register(:side_by_side_text,
-                  Differ::SimpleDiff.new(ENV['DIFFER_SIDE_BY_SIDE_TEXT']))
-end
-
-if ENV['DIFFER_PAGEFREEZER']
-  Differ.register(:pagefreezer, Differ::SimpleDiff.new(ENV['DIFFER_PAGEFREEZER']))
-end
-
-if ENV['DIFFER_HTML_SOURCE']
-  Differ.register(:html_source, Differ::SimpleDiff.new(ENV['DIFFER_HTML_SOURCE']))
-end
-
-if ENV['DIFFER_HTML_TEXT']
-  Differ.register(:html_text, Differ::SimpleDiff.new(ENV['DIFFER_HTML_TEXT']))
+# Automatically create SimpleDiff instances with the name of whatever is after
+# "DIFFER_" in the name of the following env vars.
+[
+  'DIFFER_SOURCE',
+  'DIFFER_LENGTH',
+  'DIFFER_IDENTICAL_BYTES',
+  'DIFFER_SIDE_BY_SIDE_TEXT',
+  'DIFFER_PAGEFREEZER',
+  'DIFFER_HTML_SOURCE',
+  'DIFFER_HTML_TEXT',
+  'DIFFER_HTML_VISUAL'
+].each do |env_var|
+  if ENV[env_var]
+    Differ.register(
+      env_var.gsub(/^DIFFER_/, '').downcase.to_sym,
+      Differ::SimpleDiff.new(ENV[env_var])
+    )
+  end
 end

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -10,4 +10,13 @@ module Api
       400
     end
   end
+
+  class DynamicError < StandardError
+    attr_accessor :status_code
+
+    def initialize(message, status_code)
+      @status_code = status_code
+      super(message)
+    end
+  end
 end

--- a/lib/differ/simple_diff.rb
+++ b/lib/differ/simple_diff.rb
@@ -17,11 +17,15 @@ module Differ
 
       # TODO: get our simple differ to return correct Content-Type header
       # and remove check for magical 'format' query arg
-      if response.request.format == :json || options['format'] == 'json'
-        JSON.parse(response.body)
-      else
-        response.body
-      end
+      body =
+        if response.request.format == :json || options['format'] == 'json'
+          JSON.parse(response.body)
+        else
+          response.body
+        end
+
+      raise Api::DynamicError.new(body, response.code) if response.code >= 400
+      body
     end
   end
 end


### PR DESCRIPTION
The core of adding another diff is pretty simple, but I did a bunch of extra cleanup while I was here:

- Initializing `SimpleDiff` instances had a lot of rote, duplicated code. It now creates differs based on the env var name, so just need to provide with a list of differ env vars to use and nothing more. (I didn’t feel confident in just accepting any old `DIFFER_*` env var yet, so you still have to provide a list of allowed ones.)

- I also had to fix up some things on the processing side to support this (edgi-govdata-archiving/web-monitoring-processing#90), which made me realize we don’t really handle errors from the differ well. I changed things so that we respond with an actual error and use the same status code as the differ responded with.