### PR TITLE
Remove `diff_service_version` in diff response

### DIFF
--- a/app/controllers/api/v0/diff_controller.rb
+++ b/app/controllers/api/v0/diff_controller.rb
@@ -8,7 +8,6 @@ class Api::V0::DiffController < Api::V0::ApiController
         from_version_id: change.from_version.uuid,
         to_version_id: change.version.uuid,
         diff_service: params[:type],
-        diff_service_version: '?',
         content: raw_diff
       }
     }


### PR DESCRIPTION
Pretty much what it says on the tin. Instead of filling in `diff_service_version`, we are removing it and differs themselves are responsible for including a `version` property in their response to the API, which will simply parrot it back out to the client in the `content` property.

Fixes #137.