### PR TITLE
Require authentication for all API requests.

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -13,3 +13,16 @@
 .swagger-ui .topbar {
   display: none;
 }
+
+#auth-notice {
+  background: #f6f6f6;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  color: #333;
+  margin: 0 20px;
+  padding: 0 1em;
+}
+
+#auth-notice .code-block {
+  padding: 0 1em;
+}

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -23,7 +23,7 @@ class Api::V0::ApiController < ApplicationController
   # This is different from Devise's authenticate_user! -- it does not redirect.
   def require_authentication!
     unless user_signed_in?
-      render_errors('You must be logged in to perform this action.', 401)
+      raise Api::AuthorizationError, 'You must be logged in to perform this action.'
     end
   end
 

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -1,6 +1,6 @@
 class Api::V0::ApiController < ApplicationController
   include PagingConcern
-  before_action :require_authentication!, only: [:create]
+  before_action :require_authentication!
   before_action :set_environment_header
 
   rescue_from StandardError, with: :render_errors if Rails.env.production? || Rails.env.test?

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -7,6 +7,7 @@ class Api::V0::ApiController < ApplicationController
   rescue_from Api::NotImplementedError, with: :render_errors
   rescue_from Api::InputError, with: :render_errors
   rescue_from Api::DynamicError, with: :render_errors
+  rescue_from Api::AuthorizationError, with: :render_errors
 
   rescue_from ActiveRecord::RecordInvalid, with: :render_errors
   rescue_from ActiveModel::ValidationError do |error|

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,6 +3,9 @@
   <%= stylesheet_link_tag('home', media: 'all') %>
 <% end %>
 
+<p>All endpoints currently require authenication.
+We plan to make some endpoints public in the future, but the timeline is not yet known.</p>
+
 <div id="swagger-ui"></div>
 
 <script src="<%= asset_path('home.js') %>"></script>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,8 +3,25 @@
   <%= stylesheet_link_tag('home', media: 'all') %>
 <% end %>
 
-<p>All endpoints currently require authenication.
-We plan to make some endpoints public in the future, but the timeline is not yet known.</p>
+<div id="auth-notice">
+  <p>
+    <strong>AUTHENTICATION:</strong> All endpoints currently require authenication.
+    We plan to make some endpoints public in the future, but the timeline is not yet known.
+  </p>
+  <p>
+    You can authenticate a request by providing an e-mail and password with <strong>HTTP Basic authentication</strong> or, if you are authorizing a session on behalf of a user, exchanging an e-mail and password for a session token by POSTing a JSON object that matches the following structure to <code>/users/sign_in</code>:
+  </p>
+  <pre class="code-block">{
+  "user": {
+    "email": "someone@example.com",
+    "password": "someones_password"
+  }
+}</pre>
+  <p>
+    Make sure to set the <code>Accept</code> HTTP header to <code>application/json</code>.
+    The token will be the <code>token</code> property in the response JSON.
+  </p>
+</div>
 
 <div id="swagger-ui"></div>
 

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -19,4 +19,10 @@ module Api
       super(message)
     end
   end
+
+  class AuthorizationError < StandardError
+    def status_code
+      401
+    end
+  end
 end

--- a/test/controllers/api/v0/changes_controller_test.rb
+++ b/test/controllers/api/v0/changes_controller_test.rb
@@ -1,8 +1,10 @@
 require 'test_helper'
 
 class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
   test 'can list changes' do
     page = pages(:home_page)
+    sign_in users(:alice)
     get(api_v0_page_changes_path(page))
 
     assert_response :success
@@ -15,6 +17,7 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
 
   test 'can get a single change by version IDs' do
     page = pages(:home_page)
+    sign_in users(:alice)
     from_version = versions(:page1_v1)
     to_version = versions(:page1_v2)
     get(api_v0_page_change_path(page, "#{from_version.id}..#{to_version.id}"))
@@ -30,6 +33,7 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
 
   test 'can filter by priority' do
     page = pages(:home_page)
+    sign_in users(:alice)
 
     get(api_v0_page_changes_path(page, priority: '(0.5,)'))
     assert_response :success
@@ -70,6 +74,7 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
 
   test 'can filter by significance' do
     page = pages(:home_page)
+    sign_in users(:alice)
 
     get(api_v0_page_changes_path(page, significance: '(0.5,)'))
     assert_response :success

--- a/test/controllers/api/v0/diff_controller_test.rb
+++ b/test/controllers/api/v0/diff_controller_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 require 'minitest/mock'
 
 class Api::V0::DiffControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
   test 'can diff two versions' do
+    sign_in users(:alice)
     differ = Differ::SimpleDiff.new('http://example.com')
     Differ.register(:special, differ)
 
@@ -20,6 +22,7 @@ class Api::V0::DiffControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'returns 501 (not implemented) error for unknown diff types' do
+    sign_in users(:alice)
     change = changes(:page1_change_1_2)
     get "/api/v0/pages/#{change.version.page.uuid}/changes/#{change.from_version.uuid}..#{change.version.uuid}/diff/who_knows"
 
@@ -27,6 +30,7 @@ class Api::V0::DiffControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'returns 400 error for versions with no content' do
+    sign_in users(:alice)
     change = changes(:page1_change_2_3)
     get "/api/v0/pages/#{change.version.page.uuid}/changes/#{change.from_version.uuid}..#{change.version.uuid}/diff/special"
     assert_response :bad_request

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -1,7 +1,9 @@
 require 'test_helper'
 
 class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
   test 'can list pages' do
+    sign_in users(:alice)
     get '/api/v0/pages/'
     assert_response :success
     assert_equal 'application/json', @response.content_type
@@ -13,6 +15,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   # Regression
   test 'should not include the `chunk` parameter multiple times in one paging link' do
     # This error occurred when the requested URL already had a `chunk` param
+    sign_in users(:alice)
     get('/api/v0/pages?chunk=1')
     body = JSON.parse(@response.body)
     first_uri = URI.parse(body['links']['first'])
@@ -20,6 +23,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should repect chunk_size pagination parameter' do
+    sign_in users(:alice)
     # one result per page ('chunk' to avoid ambiguity with Page model)
     get(api_v0_pages_path, params: { chunk: 1, chunk_size: 1 })
     body = JSON.parse(@response.body)
@@ -38,6 +42,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter pages by site' do
+    sign_in users(:alice)
     site = 'http://example.com/'
     get "/api/v0/pages/?site=#{URI.encode_www_form_component site}"
     body_json = JSON.parse @response.body
@@ -50,6 +55,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter pages by agency' do
+    sign_in users(:alice)
     agency = 'Department of Testing'
     get "/api/v0/pages/?agency=#{URI.encode_www_form_component agency}"
     body_json = JSON.parse @response.body
@@ -62,6 +68,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter pages by title' do
+    sign_in users(:alice)
     title = 'Page One'
     get api_v0_pages_path(title: title)
     body_json = JSON.parse @response.body
@@ -74,6 +81,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter pages by URL' do
+    sign_in users(:alice)
     url = 'http://example.com/'
     get "/api/v0/pages/?url=#{URI.encode_www_form_component url}"
     body_json = JSON.parse @response.body
@@ -88,6 +96,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter pages by URL with "*" wildcard' do
+    sign_in users(:alice)
     url = 'http://example.com/*'
     get "/api/v0/pages/?url=#{URI.encode_www_form_component url}"
     body_json = JSON.parse @response.body
@@ -102,6 +111,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter pages by version source_type' do
+    sign_in users(:alice)
     get api_v0_pages_path(source_type: 'pagefreezer')
     body = JSON.parse @response.body
     ids = body['data'].pluck 'uuid'
@@ -113,6 +123,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter pages by version hash' do
+    sign_in users(:alice)
     get api_v0_pages_path(hash: 'def')
     body = JSON.parse @response.body
     ids = body['data'].pluck 'uuid'
@@ -124,6 +135,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter pages by version capture_time' do
+    sign_in users(:alice)
     get api_v0_pages_url(
       capture_time: '2017-03-01T00:00:00Z..2017-03-01T12:00:00Z'
     )
@@ -137,6 +149,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes latest version if include_latest = true' do
+    sign_in users(:alice)
     get api_v0_pages_path(include_latest: true)
     body = JSON.parse @response.body
     results = body['data']
@@ -145,6 +158,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes versions if include_versions = true' do
+    sign_in users(:alice)
     get api_v0_pages_path(include_versions: true)
     body = JSON.parse @response.body
     results = body['data']
@@ -161,6 +175,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes only versions if include_versions = true and include_latest = true' do
+    sign_in users(:alice)
     get api_v0_pages_path(include_versions: true, include_latest: true)
     body = JSON.parse @response.body
     results = body['data']
@@ -172,6 +187,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'Only includes versions that match query when include_versions = true' do
+    sign_in users(:alice)
     get api_v0_pages_path(
       capture_time: '2017-03-01T00:00:00Z..2017-03-01T12:00:00Z',
       include_versions: true
@@ -184,6 +200,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'Included versions should be in descending capture_time order' do
+    sign_in users(:alice)
     # Add a version whose natural order and capture_time order are different
     latest_time = pages(:home_page).versions.first.capture_time
     pages(:home_page).versions.create(capture_time: latest_time - 1.day)
@@ -199,6 +216,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions can be "1"' do
+    sign_in users(:alice)
     get api_v0_pages_path(include_versions: 1)
     body = JSON.parse @response.body
     results = body['data']
@@ -206,6 +224,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions can be "t"' do
+    sign_in users(:alice)
     get api_v0_pages_path(include_versions: 't')
     body = JSON.parse @response.body
     results = body['data']
@@ -213,6 +232,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions can be value-less (e.g. "pages?include_versions")' do
+    sign_in users(:alice)
     get "#{api_v0_pages_path}?include_versions"
     body = JSON.parse @response.body
     results = body['data']
@@ -220,6 +240,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions cannot be an empty string (e.g. "pages?include_versions")' do
+    sign_in users(:alice)
     get "#{api_v0_pages_path}?include_versions="
     body = JSON.parse @response.body
     results = body['data']
@@ -227,11 +248,13 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes environment in header of response' do
+    sign_in users(:alice)
     get '/api/v0/pages/'
     assert_equal('test', @response.get_header('X-Environment'))
   end
 
   test 'does not return duplicate records when querying by version-specific parameters' do
+    sign_in users(:alice)
     get api_v0_pages_path(source_type: 'versionista')
     body = JSON.parse(@response.body)
 
@@ -240,6 +263,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can retrieve a single page' do
+    sign_in users(:alice)
     get api_v0_page_path(pages(:home_page))
     assert_response(:success)
     assert_equal('application/json', @response.content_type)
@@ -248,6 +272,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes all pages when include_versions is true' do
+    sign_in users(:alice)
     # This is a regression test for an issue where limit/offset queries for
     # paging wind up taking into account page-version combinations, not just
     # pages, so the actual page records on a given result page may not match up
@@ -291,6 +316,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
 
   test 'the latest version is actually the latest' do
     # Add some versions out of order
+    sign_in users(:alice)
     page = Page.first
     page.versions.create(capture_time: DateTime.now - 5.days)
     page.versions.create(capture_time: DateTime.now)

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
+  test 'cannot list pages without auth' do
+    get '/api/v0/pages/'
+    assert_response :unauthorized
+  end
   test 'can list pages' do
     sign_in users(:alice)
     get '/api/v0/pages/'

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -4,6 +4,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   test 'can list versions' do
+    sign_in users(:alice)
     get(api_v0_page_versions_url(pages(:home_page)))
     assert_response(:success)
     assert_equal('application/json', @response.content_type)
@@ -14,6 +15,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can list versions independent of pages' do
+    sign_in users(:alice)
     get api_v0_versions_url
     assert_response(:success)
     body_json = JSON.parse(@response.body)
@@ -22,6 +24,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can post a new version' do
+    sign_in users(:alice)
     skip
     # page = pages(:home_page)
     # post(api_v0_page_versions_url(page), params: {
@@ -49,6 +52,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter versions by hash' do
+    sign_in users(:alice)
     target = versions(:page1_v1)
     get api_v0_page_versions_url(pages(:home_page), hash: target.version_hash)
     body_json = JSON.parse @response.body
@@ -59,6 +63,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter versions by exact date' do
+    sign_in users(:alice)
     get api_v0_page_versions_url(
       pages(:home_page),
       capture_time: '2017-03-01T00:00:00Z'
@@ -73,6 +78,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'returns meaningful error for bad dates' do
+    sign_in users(:alice)
     get api_v0_page_versions_url(
       pages(:home_page),
       capture_time: 'ugh'
@@ -86,6 +92,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter versions by date range' do
+    sign_in users(:alice)
     get api_v0_page_versions_url(
       pages(:home_page),
       capture_time: '2017-03-01T00:00:00Z..2017-03-01T12:00:00Z'
@@ -100,6 +107,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter versions captured before a date' do
+    sign_in users(:alice)
     get api_v0_page_versions_url(
       pages(:home_page),
       capture_time: '..2017-03-01T12:00:00Z'
@@ -114,6 +122,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter versions captured after a date' do
+    sign_in users(:alice)
     get api_v0_page_versions_url(
       pages(:home_page),
       capture_time: '2017-03-01T12:00:00Z..'
@@ -128,6 +137,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'returns meaningful error for bad date ranges' do
+    sign_in users(:alice)
     get api_v0_page_versions_url(
       pages(:home_page),
       capture_time: 'ugh..2017-03-04'
@@ -141,6 +151,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can filter versions by source_type' do
+    sign_in users(:alice)
     get api_v0_page_versions_url(pages(:home_page), source_type: 'pagefreezer')
 
     body_json = JSON.parse @response.body
@@ -150,6 +161,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can retrieve a single version' do
+    sign_in users(:alice)
     version = versions(:page1_v1)
     get api_v0_page_version_path(version.page, version)
     assert_response(:success)
@@ -160,6 +172,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can query by source_metadata fields' do
+    sign_in users(:alice)
     version = versions(:page1_v1)
     get api_v0_versions_path(params: {
       source_metadata: { version_id: version.source_metadata['version_id'] }


### PR DESCRIPTION
Closes #122

As noted in #122, we should note in the API documentation
that authentication is required. @Mr0grog, di you have in mind
an overall statement about this at the top, a change to swagger.yml,
or both?