### PR TITLE
Remove use of `type: shell` in Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
           command: |
             bundle exec rake db:create
             bundle exec rake db:schema:load
-      - type: shell
-        command: bundle exec rake test
-      - type: shell
-        command: bundle exec rubocop
+      - run:
+          name: Tests
+          command: bundle exec rake test
+      - run:
+          name: Code linting
+          command: bundle exec rubocop


### PR DESCRIPTION
Turns out `type: shell` is incorrect syntax and the CircleCI docs are a little spotty. More details: https://discuss.circleci.com/t/is-there-a-difference-between-run-vs-type-shell-steps/17022