### PR TITLE
Big perf/memory improvements in pages controller

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Metrics/ParameterLists:
   Exclude:
     - 'lib/versionista_service/*'
 
+Metrics/CyclomaticComplexity:
+  Max: 12
+
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,11 +18,12 @@ gem 'rack-cors', :require => 'rack/cors'
 gem 'resque'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
+gem 'oj', '~> 3.3'
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.6'
+# gem 'jbuilder', '~> 2.6'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,9 +73,6 @@ GEM
     httparty (0.15.6)
       multi_xml (>= 0.5.2)
     i18n (0.8.6)
-    jbuilder (2.7.0)
-      activesupport (>= 4.2.0)
-      multi_json (>= 1.2)
     jmespath (1.3.1)
     json (2.1.0)
     jwt (1.5.6)
@@ -101,6 +98,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    oj (3.3.8)
     orm_adapter (0.5.0)
     parallel (1.12.0)
     parser (2.4.0.0)
@@ -238,10 +236,10 @@ DEPENDENCIES
   byebug
   devise
   httparty
-  jbuilder (~> 2.6)
   jwt (~> 1.5)
   listen (~> 3.1)
   newrelic_rpm
+  oj (~> 3.3)
   pg (~> 0.18)
   postmark-rails
   pry-rails

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -18,7 +18,7 @@ class Api::V0::PagesController < Api::V0::ApiController
     # built-in behavior to break, so we do it manually here. For more, see:
     #   - https://github.com/edgi-govdata-archiving/web-monitoring-db/pull/129
     #   - https://github.com/rails/rails/issues/30531
-    result_data, inclusion =
+    result_data =
       if should_include_versions
         # NOTE: need to get :updated_at here because it's used for ordering
         page_ids = pages.pluck(:uuid, :updated_at).collect {|data| data[0]}
@@ -26,17 +26,22 @@ class Api::V0::PagesController < Api::V0::ApiController
           .where(uuid: page_ids)
           .includes(:versions)
           .order('versions.capture_time DESC')
-        [results, :versions]
+        lightweight_query(results, :versions)
       elsif should_include_latest
-        [pages.includes(:latest), :latest]
+        # [pages.includes(:latest), :latest]
+        page_ids = pages.pluck(:uuid, :updated_at).collect {|data| data[0]}
+        results = Page
+          .where(uuid: page_ids)
+          .includes(:latest)
+        lightweight_query(results, :latest)
       else
-        [pages, nil]
+        lightweight_query(pages)
       end
 
-    render json: {
+    render json: Oj.dump({
       links: paging[:links],
       data: result_data
-    }, include: inclusion
+    }, mode: :strict)
   end
 
   def show
@@ -90,5 +95,171 @@ class Api::V0::PagesController < Api::V0::ApiController
 
     # If any queries create implicit joins, ensure we get a list of unique pages
     collection.distinct.order(updated_at: :desc)
+  end
+
+  # Get the results of an ActiveRecord query (and, optionally, one association)
+  # as a simple JSON-compatible structure without instantiating actual models.
+  # This is generally way fancier footwork that one should be performing and
+  # should only be used for extremely hot (in speed or memory) queries.
+  #
+  # It makes a number of assumptions about the structure of queries and only
+  # works with has_many and has_one associations (the association can also be
+  # nil). Those assumptions are generally reasonable, but are likely sensitive
+  # to underlying changes in ActiveRecord.
+  def lightweight_query(relation, association = nil)
+    reflection = relation.model._reflections.try(:[], association.to_s)
+
+    if !reflection || reflection.is_a?(ActiveRecord::Reflection::HasManyReflection)
+      lightweight_query_with_many(relation, reflection)
+    elsif reflection.is_a?(ActiveRecord::Reflection::HasOneReflection)
+      lightweight_query_with_one(relation, reflection)
+    else
+      raise StandardError, "lightweight query can only handle `has_one` and `has_many` associations, not #{reflection.class.name}"
+    end
+  end
+
+  # Perform a lightweight query with a has_many association (or no association)
+  def lightweight_query_with_many(relation, association_reflection)
+    primary_type = relation.model
+    names = primary_type.attribute_names
+    primary_names_length = names.length
+    association = association_reflection.try(:name)
+    names += association_reflection.klass.attribute_names if association_reflection
+
+    # Ensure primary records are all consecutive and not interleaved because of
+    # other orderings in the query.
+    relation.order_values.insert(
+      0,
+      "#{primary_type.table_name}.#{primary_type.primary_key} ASC"
+    )
+    raw = ActiveRecord::Base.connection.exec_query(relation.to_sql)
+
+    skip_length = raw.columns.find_index('t0_r0') || 0
+    primary_names_length += skip_length
+    names = (0...skip_length).to_a + names
+
+    parsers = raw.columns.collect do |column|
+      PrimitiveParser.for(raw.column_types[column])
+    end
+
+    last_id = nil
+    current_record = nil
+    results = []
+
+    raw.rows.each do |row|
+      if last_id != row[0]
+        current_record = {}
+        results << current_record
+        current_record[association] = [] if association
+      end
+
+      associated_record = {}
+
+      row.each_with_index do |value, index|
+        next if index < skip_length
+        next if index < primary_names_length && last_id == row[0]
+        target = index < primary_names_length ? current_record : associated_record
+        parser = parsers[index]
+
+        target[names[index]] = parser ? parser.deserialize(value) : value
+      end
+
+      current_record[association] << associated_record if association
+      last_id = row[0]
+    end
+
+    results
+  end
+
+  # Perform a lightweight query with a has_one association
+  def lightweight_query_with_one(relation, association_reflection)
+    raw = ActiveRecord::Base.connection.exec_query(relation.to_sql)
+    primary_type = relation.model
+    names = primary_type.attribute_names
+    names_length = names.length
+
+    parsers = raw.columns.collect do |column|
+      PrimitiveParser.for(raw.column_types[column])
+    end
+
+    last_id = nil
+    results = []
+    id_map = {}
+
+    raw.rows.each do |row|
+      next if last_id == row[0]
+
+      record = {}
+      results << record
+      last_id = row[0]
+      id_map[last_id] = record
+
+      row.each_with_index do |value, index|
+        next if index >= names_length
+        parser = parsers[index]
+
+        record[names[index]] = parser ? parser.deserialize(value) : value
+      end
+    end
+
+    # And now for the association
+    secondary_type = association_reflection.klass
+    secondary_query = secondary_type.where(
+      association_reflection.foreign_key => id_map.keys
+    )
+    if association_reflection.scope
+      secondary_query = secondary_query.merge(association_reflection.scope)
+    end
+    raw = ActiveRecord::Base.connection.exec_query(secondary_query.to_sql)
+    names = secondary_type.attribute_names
+    names_length = names.length
+
+    parsers = raw.columns.collect do |column|
+      PrimitiveParser.for(raw.column_types[column])
+    end
+
+    last_id = nil
+    raw.rows.each do |row|
+      next if last_id == row[0]
+
+      record = {}
+      last_id = row[0]
+
+      row.each_with_index do |value, index|
+        next if index >= names_length
+        parser = parsers[index]
+
+        record[names[index]] = parser ? parser.deserialize(value) : value
+        if record[names[index]].is_a? Time
+          record[names[index]] = record[names[index]].iso8601
+        end
+      end
+
+      id_map[record[association_reflection.foreign_key]][association_reflection.name] = record
+    end
+
+    results
+  end
+
+  # A simple wrapper for parsing data from the DB into a primitive,
+  # JSON-compatible type. Given a DB parser, it will deserialize with that
+  # parser and then further parse to a primitive.
+  class PrimitiveParser
+    def self.for(parser)
+      if parser.class.name.ends_with?('::DateTime')
+        new(parser)
+      elsif parser.class.name.starts_with?('ActiveRecord::ConnectionAdapters')
+        parser
+      end
+    end
+
+    def initialize(parser)
+      @parser = parser
+    end
+
+    def deserialize(value)
+      result = @parser.deserialize(value)
+      result.is_a?(Time) ? result.iso8601 : result
+    end
   end
 end

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -6,7 +6,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
 
     render json: {
       links: paging[:links],
-      data: versions.as_json
+      data: versions
     }
   end
 
@@ -17,7 +17,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
         page: api_v0_page_url(@version.page),
         previous: @version.previous && api_v0_page_version_url(@version.page, @version.previous)
       },
-      data: @version.as_json
+      data: @version
     }
   end
 

--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -1,0 +1,19 @@
+require 'oj'
+
+Oj.optimize_rails()
+
+# This is just the classes the above is supposed to do by default (plus our Page
+# and Version models), but explicitly specifying it does make a difference.
+Oj::Rails.optimize(
+  Array,
+  BigDecimal,
+  Float,
+  Hash,
+  Range,
+  Regexp,
+  Time,
+  ActiveSupport::TimeWithZone,
+  ActionController::Parameters,
+  Page,
+  Version
+)

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -313,7 +313,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
       skip unless actual_page.latest
 
       assert_equal(
-        actual_page.latest.capture_time.as_json,
+        actual_page.latest.capture_time.iso8601,
         found_page['latest']['capture_time']
       )
     end


### PR DESCRIPTION
Generally addresses #154.

This started out with some simple profiling and the addition of `Oj`, a faster JSON (de)serializer. That had a nice speed boost of just under 2x, so then I went a little nuts to bring memory way down (4-5x) reduction) and speed way up (about 5x). I don’t know that I’d recommend this approach for general use, but the page-related queries are *really* hot and desperately need all the optimization they can get, so I felt it made sense here.

In the following comparisons, “base” is the current, standard, Rails-y approach, while “Oj” is simply adding Oj (and restructuring slightly to get better use of it) in [the first commit](https://github.com/edgi-govdata-archiving/web-monitoring-db/commit/ed179545f7cf0e56ac50bad5b2d3d2377278ddb4), and “nutty optimizations” is [the second commit](https://github.com/edgi-govdata-archiving/web-monitoring-db/commit/db8a454003410d84203028f81bfd6aeb9491a625), where I went off the deep end and ditched ActiveRecord models entirely. I also made times slightly less precise (seconds instead of milliseconds) because that gave us a small but meaningful boost. “Precise time” is with millisecond precision.

(Local, production-mode) Performance on `GET /api/v0/pages`

| Approach            | Allocated Bytes | Allocated Objects | Retained Bytes | Retained Objects | Avg. Time (ms) |
| ------------------- | --------------: | ----------------: | -------------: | ---------------: | -------------: |
| Base                | 1,746,940       | 25,773            | 41,260         | 98               | 30.0 |
| Oj                  | 997,007         | 12,449            | 41,218         | 98               | 25.3 |
| Nutty Optimizations | 466,209         | 5,999             | 40,598         | 98               | 11.0 |

(Local, production-mode) Performance on `GET /api/v0/pages?include_versions`

| Approach                           | Allocated Bytes | Allocated Objects | Retained Bytes | Retained Objects | Avg. Time (ms) |
| ---------------------------------- | --------------: | ----------------: | -------------: | ---------------: | -------------: |
| Base                               |      36,800,463 |           510,597 |        811,382 | 99 | 454.4 |
| Oj                                 |      17,740,168 |           199,862 |        811,340 | 99 | 273.4 |
| Nutty Optimizations                |       7,916,625 |            92,617 |        800,324 | 99 |  91.3 |
| Nutty Optimizations - precise time |       8,380,853 |           100,714 |        811,120 | 99 | 109.1 |

It’s important to note that this is performance on my relatively speedy, memory-filled, and unburdened local machine (though in production mode). Our servers (especially staging) are waaaaaay slower and lower memory; they regularly get into the 10s response range and often exhaust their memory on `?include_versions` queries, which is why this is important.

And here are some super-ugly flame charts to demonstrate how this plays out in terms of stack:

![flame-charts](https://user-images.githubusercontent.com/74178/31604382-f1e0d43c-b217-11e7-945a-5e5e9870fd25.png)

(Remember that the width of each of these represents the length of a single request, not absolute time. To compare absolute time, shrink each of them to ~50% of the width of the one above.)