### PR TITLE
Prefer `DATABASE_RDS` env var to `DATABASE_URL`

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -81,6 +81,7 @@ test:
 #
 production:
   <<: *default
-  database: web-monitoring-db_production
-  username: web-monitoring-db
-  password: <%= ENV['WEB-MONITORING-DB_DATABASE_PASSWORD'] %>
+  # database: web-monitoring-db_production
+  # username: web-monitoring-db
+  # password: <%= ENV['WEB-MONITORING-DB_DATABASE_PASSWORD'] %>
+  url: <%= ENV['DATABASE_RDS'] || ENV['DATABASE_URL'] %>


### PR DESCRIPTION
This is meant for production/staging only, to help us migrate in a reversible way to RDS.

Basically, if a `DATABASE_RDS` environment variable is present, use it instead of `DATABASE_URL`. This is because Heroku (where things are currently deployed), automatically manages `DATABASE_URL`, so we want to avoid messing with it.

This is part of #143.