### PR TITLE
Make MAX_PAGE_SIZE configurable with ENV var

### DIFF
--- a/app/controllers/concerns/paging_concern.rb
+++ b/app/controllers/concerns/paging_concern.rb
@@ -2,7 +2,7 @@ module PagingConcern
   extend ActiveSupport::Concern
 
   DEFAULT_PAGE_SIZE = 100
-  MAX_PAGE_SIZE = 10_000
+  MAX_PAGE_SIZE = [ENV.fetch('MAX_COLLECTION_PAGE_SIZE', 10_000).to_i, 10].max
 
   protected
 


### PR DESCRIPTION
Use the `MAX_COLLECTION_PAGE_SIZE` environment variable to configure a different max size than the default (which is still 10,000).

Basically, 10,000 is too big for our current machines, but wasn’t sure hard-coding made sense if we can/will also put it on beefier hardware.