### PR TITLE
Remove uuid+site, add site-only index on pages

### DIFF
--- a/db/migrate/20171101214731_remove_page_uuid_site_index.rb
+++ b/db/migrate/20171101214731_remove_page_uuid_site_index.rb
@@ -1,0 +1,6 @@
+class RemovePageUuidSiteIndex < ActiveRecord::Migration[5.1]
+  def change
+    add_index :pages, :site
+    remove_index :pages, [:uuid, :site]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170914154249) do
+ActiveRecord::Schema.define(version: 20171101214731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,8 +70,8 @@ ActiveRecord::Schema.define(version: 20170914154249) do
     t.string "site"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["site"], name: "index_pages_on_site"
     t.index ["url"], name: "index_pages_on_url"
-    t.index ["uuid", "site"], name: "index_pages_on_uuid_and_site"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
I have no idea what possessed me to make a multi-column index like this, since we never do a query on `UUID` + `site`. Instead, just index `site`. Tried this out on staging and it seems to have made a reliable performance improvement.

(Also totally forgot to push this! It’s been sitting around for a while.)