### PR TITLE
HOTFIX: repair tests from bad merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,13 @@ This project wouldn’t exist without a lot of amazing people’s help. Thanks t
 | [💻](# "Code") | [Kate Donaldson](https://github.com/katelovescode) |
 | [📖](# "Documentation") | [Michael Hardy](https://github.com/michardy) |
 | [💻](# "Code") | [Kasper Holbek Jensen](https://github.com/kholbekj) |
+| [💻](# "Code") | [Shishir Joshi](https://github.com/shishir127) |
 | [💻](# "Code") [📖](# "Documentation") | [Krzysztof Madejski](https://github.com/KrzysztofMadejski) |
 | [📖](# "Documentation") [📋](# "Organizer") [📢](# "Talks") | [Matt Price](https://github.com/titaniumbones) |
 | [📋](# "Organizer") [🔍](# "Funding/Grant Finder") | [Toly Rinberg](https://github.com/trinberg) |
 | [🚇](# "Infrastructure")  | [Frederik Spang](https://github.com/frederikspang) |
 | [💻](# "Code") | [Max Tedford](https://github.com/maxtedford) |
 | [📖](# "Documentation") [📋](# "Organizer") | [Dawn Walker](https://github.com/dcwalk) |
-| [💻](# "Code") | [Shishir Joshi](https://github.com/shishir127) |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 (For a key to the contribution emoji or more info on this format, check out [“All Contributors.”](https://github.com/kentcdodds/all-contributors))

--- a/test/controllers/api/v0/annotations_controller_test.rb
+++ b/test/controllers/api/v0/annotations_controller_test.rb
@@ -168,6 +168,7 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can list annotations' do
+    sign_in users(:alice)
     page = pages(:home_page)
     change_id = page.versions[0].uuid
 

--- a/test/controllers/api/v0/changes_controller_test.rb
+++ b/test/controllers/api/v0/changes_controller_test.rb
@@ -115,6 +115,7 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'meta property should have a total_results field that contains total results across all chunks' do
+    sign_in users(:alice)
     page = pages(:home_page)
     get(api_v0_page_changes_path(page))
 

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -2,10 +2,12 @@ require 'test_helper'
 
 class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
+
   test 'cannot list pages without auth' do
     get '/api/v0/pages/'
     assert_response :unauthorized
   end
+
   test 'can list pages' do
     sign_in users(:alice)
     get '/api/v0/pages/'
@@ -351,6 +353,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'meta property should have a total_results field that contains total results across all chunks' do
+    sign_in users(:alice)
     get '/api/v0/pages/'
     assert_response :success
     assert_equal 'application/json', @response.content_type

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -191,6 +191,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'meta property should have a total_results field that contains total results across all chunks' do
+    sign_in users(:alice)
     page = pages(:home_page)
 
     get(api_v0_page_versions_url(page))


### PR DESCRIPTION
I didn’t pay close attention and didn’t realize how out of date #169 was, so merging broke tests. This fixes them.