### PR TITLE
Add rake task for copying data from remote DBs

### DIFF
--- a/lib/tasks/copy_data.rake
+++ b/lib/tasks/copy_data.rake
@@ -1,0 +1,36 @@
+desc 'Copy pages from another web-monitoring-db instance.'
+task :copy_page, [:url, :username, :password, :page_uuid] => [:environment] do |_t, args|
+  verbose = ENV['VERBOSE']
+
+  page_url = "#{args[:url]}/api/v0/pages/#{args[:page_uuid]}"
+  response = HTTParty.get(page_url, basic_auth: {
+    username: args[:username],
+    password: args[:password]
+  })
+
+  raise "Error getting data: #{response.body}" if response.code != 200
+
+  page_count = 0
+  version_count = 0
+
+  data = JSON.parse(response.body)['data']
+  page_data = data.clone
+  page_data.delete('versions')
+
+  page = Page.find_by(uuid: data['uuid'])
+  unless page
+    page = Page.create(page_data)
+    page_count += 1
+    puts "Copied page #{page.uuid}" if verbose
+  end
+
+  data['versions'].each do |version_data|
+    next if Version.find_by(uuid: version_data['uuid'])
+
+    page.versions.create(version_data)
+    version_count += 1
+    puts "  Copied version #{version_data['uuid']}" if verbose
+  end
+
+  puts "Copied #{page_count} pages and #{version_count} versions from #{args[:url]}"
+end


### PR DESCRIPTION
Had this sitting around from earlier in the week and it seemed like it might be pretty useful for pulling in real data to test with.

This uses the API to pull in pages and their versions from other databases (e.g. production or staging). They keep they same ID the had in the remote environment, so this can be really helpful for bringing in real data to test.

Right now, it only does one page at a time.

Usage:

```sh
rake copy_page['https://api.monitoring.envirodatagov.org','YOUR USERNAME','YOUR PASSWORD','ID OF PAGE TO COPY']
```

Or for more verbose logging:

```
VERBOSE=true copy_page['https://api.monitoring.envirodatagov.org','YOUR USERNAME','YOUR PASSWORD','ID OF PAGE TO COPY']
```