### PR TITLE
Add a “default” differ type using `DIFFER_DEFAULT`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,13 +39,7 @@ ALLOWED_ARCHIVE_HOSTS='https://edgi-versionista-archive.s3.amazonaws.com/ https:
 # If you are developing this web-monitoring-db Rails app + wm-differ-differ locally,
 # then settings below are the default settings. If you are running against a
 # production deployment, change 'localhost:8888' to the production URL.
-DIFFER_LENGTH=http://localhost:8888/length
-DIFFER_IDENTICAL_BYTES=http://localhost:8888/identical_bytes
-DIFFER_PAGEFREEZER=http://localhost:8888/pagefreezer
-DIFFER_HTML_SOURCE=http://localhost:8888/html_source_diff
-DIFFER_HTML_TEXT=http://localhost:8888/html_text_diff
-DIFFER_SIDE_BY_SIDE_TEXT=http://localhost:8888/side_by_side_text
-DIFFER_HTML_VISUAL=http://localhost:8888/html_visual_diff
+DIFFER_DEFAULT=http://localhost:8888
 
 # Set a private RSA key to use for signing auth tokens
 # This MUST be replaced with a unique value in production!

--- a/config/initializers/differ.rb
+++ b/config/initializers/differ.rb
@@ -3,20 +3,19 @@ require_dependency 'differ/simple_diff'
 
 # Automatically create SimpleDiff instances with the name of whatever is after
 # "DIFFER_" in the name of the following env vars.
-[
-  'DIFFER_SOURCE',
-  'DIFFER_LENGTH',
-  'DIFFER_IDENTICAL_BYTES',
-  'DIFFER_SIDE_BY_SIDE_TEXT',
-  'DIFFER_PAGEFREEZER',
-  'DIFFER_HTML_SOURCE',
-  'DIFFER_HTML_TEXT',
-  'DIFFER_HTML_VISUAL'
-].each do |env_var|
-  if ENV[env_var]
+ENV.each do |key, value|
+  if key == 'DIFFER_DEFAULT'
+    # The differ registered with a nil key is actually constructor arguments,
+    # not a differ instance.
+    Differ.register(nil, value)
+  elsif key.start_with?('DIFFER_')
     Differ.register(
-      env_var.gsub(/^DIFFER_/, '').downcase.to_sym,
-      Differ::SimpleDiff.new(ENV[env_var])
+      key.gsub(/^DIFFER_/, '').downcase.to_sym,
+      Differ::SimpleDiff.new(value)
     )
   end
+end
+
+unless Differ.for_type(nil)
+  Rails.logger.warn('No default differ registered for unknown types! To register a default, set the DIFFER_DEFAULT environment variable.')
 end

--- a/lib/differ/differ.rb
+++ b/lib/differ/differ.rb
@@ -1,5 +1,7 @@
 module Differ
-  # Register a differ instance to be used for a given diff type
+  # Register a differ instance to be used for a given diff type. If `type` is
+  # nil, the differ will be treated as the constructor arguments for a differ
+  # to use when no matching diff type is found for registry lookups.
   def self.register(type, differ)
     @type_map ||= {}.with_indifferent_access
     @type_map[type] = differ
@@ -7,11 +9,17 @@ module Differ
 
   # Retrieve the differ associated with a given diff type
   def self.for_type(type)
-    @type_map ? @type_map[type] : nil
+    @type_map && @type_map[type] || default_for_type(type)
   end
 
   def self.for_type!(type)
     for_type(type) || (raise Api::NotImplementedError,
       "There is no registered differ for '#{type}'")
+  end
+
+  # If configured, create a default/fallback differ for a given type.
+  def self.default_for_type(type)
+    default_url = @type_map && @type_map[nil]
+    default_url ? SimpleDiff.new(default_url, type) : nil
   end
 end


### PR DESCRIPTION
The value of the `DIFFER_DEFAULT` environment variable will be used as the URL for a new SimpleDiff instance if no diff has been registered for a requested diff type. You can still keep explicitly registered differs via any environment variables named `DIFFER_*`; they’ll be matched before falling back to creating a default differ. This way, we can keep current configurations in place until the UI has updated to request the correct diff names (DB’s names don't quite match Processing’s names; see https://github.com/edgi-govdata-archiving/web-monitoring-processing/pull/133).

This also tightens up error handling of responses from the differ (since we’ll see them more often now). We should get on edgi-govdata-archiving/web-monitoring-processing#121 to make this better still.

Fixes #180 and #182.