### PR TITLE
Make diff endpoint's `data` the raw diff data

### DIFF
--- a/app/controllers/api/v0/diff_controller.rb
+++ b/app/controllers/api/v0/diff_controller.rb
@@ -3,13 +3,15 @@ class Api::V0::DiffController < Api::V0::ApiController
     ensure_diffable
 
     render json: {
-      data: {
-        page_id: change.version.page.uuid,
-        from_version_id: change.from_version.uuid,
-        to_version_id: change.version.uuid,
-        diff_service: params[:type],
-        content: raw_diff
-      }
+      links: {
+        page: api_v0_page_url(change.version.page),
+        from_version: api_v0_version_url(change.from_version),
+        to_version: api_v0_version_url(change.version)
+      },
+      meta: {
+        requested_type: params[:type]
+      },
+      data: raw_diff
     }
   end
 

--- a/test/controllers/api/v0/diff_controller_test.rb
+++ b/test/controllers/api/v0/diff_controller_test.rb
@@ -3,6 +3,15 @@ require 'minitest/mock'
 
 class Api::V0::DiffControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
+
+  setup do
+    @original_default_differ = Differ.for_type(nil)
+  end
+
+  teardown do
+    Differ.register(nil, @original_default_differ)
+  end
+
   test 'can diff two versions' do
     sign_in users(:alice)
     differ = Differ::SimpleDiff.new('http://example.com')
@@ -18,10 +27,12 @@ class Api::V0::DiffControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'application/json', @response.content_type
     body = JSON.parse @response.body
     assert body.key?('data'), 'Response should have a "data" property'
-    assert_equal 'Diff!', body['data']['content']
+    assert_equal 'Diff!', body['data']
   end
 
-  test 'returns 501 (not implemented) error for unknown diff types' do
+  test 'returns 501 (not implemented) error for unknown diff types when no default differ is configured' do
+    Differ.register(nil, nil)
+
     sign_in users(:alice)
     change = changes(:page1_change_1_2)
     get "/api/v0/pages/#{change.version.page.uuid}/changes/#{change.from_version.uuid}..#{change.version.uuid}/diff/who_knows"

--- a/test/lib/differ/differ_test.rb
+++ b/test/lib/differ/differ_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Differ::DifferTest < ActiveSupport::TestCase
+  setup do
+    @original_default_differ = Differ.for_type(nil)
+  end
+
+  teardown do
+    Differ.register(nil, @original_default_differ)
+  end
+
+  test 'it creates a new default differ if an unknown type is requested' do
+    Differ.register(nil, 'http://testdiff.com')
+    change = changes(:page1_change_1_2)
+
+    expected_request = stub_request(:any, 'http://testdiff.com/unknown_type')
+      .with(query: {
+        'a' => change.from_version.uri,
+        'a_hash' => change.from_version.version_hash,
+        'b' => change.version.uri,
+        'b_hash' => change.version.version_hash
+      })
+      .to_return(body: 'DIFF!', status: 200)
+
+    diff = Differ.for_type('unknown_type').diff(change)
+    assert_requested expected_request
+    assert_equal 'DIFF!', diff
+  end
+end


### PR DESCRIPTION
The idea here is that all the metadata and extra info the DB server provides should be in the standard `links` and `meta` sections of the response, while `data` should just be exactly what you'd get if you called the diff server directly. Makes a lot more sense in hindsight.

If we ever do decide to expose the differ publicly or if we write other tools that access the differ internally, this helps ensure the interface is standard and code can be shared. It also hopefully forces us to put things more in the right place.

Fixes #181.

**NOTE: Do not merge yet. This will be a breaking change for the UI, so it needs updates to be deployed first. There are a lot of things in flight there, so I think this will be easier if we hold off just a bit on merging.**