### PR TITLE
Use the validated `chunk_size` in paging links

### DIFF
--- a/app/controllers/concerns/paging_concern.rb
+++ b/app/controllers/concerns/paging_concern.rb
@@ -36,12 +36,14 @@ module PagingConcern
       first: path_resolver.call(
         collection_type,
         format: format_type,
-        params: request.query_parameters.merge(chunk: 1)
+        params: request.query_parameters.merge(chunk: 1,
+                                               chunk_size: chunk_size)
       ),
       last: path_resolver.call(
         collection_type,
         format: format_type,
-        params: request.query_parameters.merge(chunk: total_chunks)
+        params: request.query_parameters.merge(chunk: total_chunks,
+                                               chunk_size: chunk_size)
       ),
       prev: nil,
       next: nil


### PR DESCRIPTION
Don't just inherit the requested `chunk_size` for paging links; use the fixed validated version so that links are correct. Fixes #177.