### PR TITLE
Don't crash loading registration page

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,7 +6,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def new
     @invitation = current_invitation
     super do |user|
-      user.email = @invitation.email if @invitation.email.present?
+      user.email = @invitation.email if @invitation.try(:email).present?
     end
   end
 

--- a/test/controllers/users/registrations_controller_test.rb
+++ b/test/controllers/users/registrations_controller_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class Users::RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'should be able to view registration page' do
+    get new_user_registration_path
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Kinda dumb. It assumed the request would include an invite code (which URLs in invite e-mails do, but it is obviously possible to arrive here without one). Fixes #198.