### PR TITLE
WIP: Multiple sites and agencies per page

### DIFF
--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -1,0 +1,9 @@
+# Agency represents a government agency that maintains some web pages. It's
+# pretty simple and only has a "name" right now, but be more complex or link
+# to records in other remote databases later.
+class Agency < ApplicationRecord
+  include UuidPrimaryKey
+  has_and_belongs_to_many :pages,
+    foreign_key: 'agency_uuid',
+    association_foreign_key: 'page_uuid'
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -36,6 +36,32 @@ class Page < ApplicationRecord
     end
   end
 
+  def add_to_agency(agency)
+    agency = Agency.find_or_create_by(name: agency) unless agency.is_a?(Agency)
+    agencies.push(agency) unless agencies.include?(agency)
+    agency
+  end
+
+  def add_to_site(site, versionista_id: nil)
+    unless site.is_a?(Site)
+      if versionista_id
+        name = site
+        site = Site.find_by(versionista_id: versionista_id)
+        if site
+          site.update(name: name)
+        else
+          site = Site.find_or_create_by(name: name)
+          site.update(versionista_id: versionista_id)
+        end
+      else
+        site = Site.find_or_create_by(name: site)
+      end
+    end
+
+    sites.push(site) unless sites.include?(site)
+    site
+  end
+
   protected
 
   def normalize_url

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -17,6 +17,12 @@ class Page < ApplicationRecord
     end),
     foreign_key: 'page_uuid',
     class_name: 'Version'
+  has_and_belongs_to_many :agencies,
+    foreign_key: 'page_uuid',
+    association_foreign_key: 'agency_uuid'
+  has_and_belongs_to_many :sites,
+    foreign_key: 'page_uuid',
+    association_foreign_key: 'site_uuid'
 
   before_save :normalize_url
   validate :url_must_have_domain

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,0 +1,13 @@
+# Sites represent a group of pages. While the name might appear to imply it,
+# sites are not associated with a particular domain or URL; it's merely an
+# organizing tool.
+class Site < ApplicationRecord
+  include UuidPrimaryKey
+  has_and_belongs_to_many :pages,
+    foreign_key: 'site_uuid',
+    association_foreign_key: 'page_uuid'
+
+  # Sites also have a `versionista_id` field to help manage/deal with renamings
+  # in Versionista accounts that we import from. In the far future, we might
+  # remove this column.
+end

--- a/db/migrate/20180121230313_create_sites_and_agencies.rb
+++ b/db/migrate/20180121230313_create_sites_and_agencies.rb
@@ -1,0 +1,39 @@
+class CreateSitesAndAgencies < ActiveRecord::Migration[5.1]
+  def change
+    create_table :sites, id: false do |t|
+      t.primary_key :uuid, :uuid
+      t.string :name, null: false
+      t.integer :versionista_id
+      t.index :name, unique: true
+      t.index :versionista_id, unique: true
+    end
+
+    create_table :pages_sites, id: false do |t|
+      # No way to use `belongs_to/references` to make a column named `*_uuid`
+      t.uuid :page_uuid, null: false
+      t.uuid :site_uuid, null: false
+      t.foreign_key :pages, column: :page_uuid, primary_key: 'uuid'
+      t.foreign_key :sites, column: :site_uuid, primary_key: 'uuid'
+      t.index :page_uuid
+      t.index :site_uuid
+      t.index [:page_uuid, :site_uuid], unique: true
+    end
+
+    create_table :agencies, id: false do |t|
+      t.primary_key :uuid, :uuid
+      t.string :name, null: false
+      t.index :name, unique: true
+    end
+
+    create_table :agencies_pages, id: false do |t|
+      # No way to use `belongs_to/references` to make a column named `*_uuid`
+      t.uuid :agency_uuid, null: false
+      t.uuid :page_uuid, null: false
+      t.foreign_key :agencies, column: :agency_uuid, primary_key: 'uuid'
+      t.foreign_key :pages, column: :page_uuid, primary_key: 'uuid'
+      t.index :agency_uuid
+      t.index :page_uuid
+      t.index [:agency_uuid, :page_uuid], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180121230313) do
+ActiveRecord::Schema.define(version: 20180121235109) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171101214731) do
+ActiveRecord::Schema.define(version: 20180121230313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
   enable_extension "pgcrypto"
+
+  create_table "agencies", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.index ["name"], name: "index_agencies_on_name", unique: true
+  end
+
+  create_table "agencies_pages", id: false, force: :cascade do |t|
+    t.uuid "agency_uuid", null: false
+    t.uuid "page_uuid", null: false
+    t.index ["agency_uuid", "page_uuid"], name: "index_agencies_pages_on_agency_uuid_and_page_uuid", unique: true
+    t.index ["agency_uuid"], name: "index_agencies_pages_on_agency_uuid"
+    t.index ["page_uuid"], name: "index_agencies_pages_on_page_uuid"
+  end
 
   create_table "annotations", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "change_uuid", null: false
@@ -74,6 +87,21 @@ ActiveRecord::Schema.define(version: 20171101214731) do
     t.index ["url"], name: "index_pages_on_url"
   end
 
+  create_table "pages_sites", id: false, force: :cascade do |t|
+    t.uuid "page_uuid", null: false
+    t.uuid "site_uuid", null: false
+    t.index ["page_uuid", "site_uuid"], name: "index_pages_sites_on_page_uuid_and_site_uuid", unique: true
+    t.index ["page_uuid"], name: "index_pages_sites_on_page_uuid"
+    t.index ["site_uuid"], name: "index_pages_sites_on_site_uuid"
+  end
+
+  create_table "sites", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "versionista_id"
+    t.index ["name"], name: "index_sites_on_name", unique: true
+    t.index ["versionista_id"], name: "index_sites_on_versionista_id", unique: true
+  end
+
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -111,11 +139,15 @@ ActiveRecord::Schema.define(version: 20171101214731) do
     t.index ["version_hash"], name: "index_versions_on_version_hash"
   end
 
+  add_foreign_key "agencies_pages", "agencies", column: "agency_uuid", primary_key: "uuid"
+  add_foreign_key "agencies_pages", "pages", column: "page_uuid", primary_key: "uuid"
   add_foreign_key "annotations", "users", column: "author_id"
   add_foreign_key "changes", "versions", column: "uuid_from", primary_key: "uuid"
   add_foreign_key "changes", "versions", column: "uuid_to", primary_key: "uuid"
   add_foreign_key "imports", "users"
   add_foreign_key "invitations", "users", column: "issuer_id"
   add_foreign_key "invitations", "users", column: "redeemer_id"
+  add_foreign_key "pages_sites", "pages", column: "page_uuid", primary_key: "uuid"
+  add_foreign_key "pages_sites", "sites", column: "site_uuid", primary_key: "uuid"
   add_foreign_key "versions", "pages", column: "page_uuid", primary_key: "uuid"
 end

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -17,6 +17,7 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can import data' do
+    skip 'Import no longer sets agency/site, but new fields are not yet in API'
     import_data = [
       {
         page_url: 'http://testsite.com/',

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -17,7 +17,6 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can import data' do
-    skip 'Import no longer sets agency/site, but new fields are not yet in API'
     import_data = [
       {
         page_url: 'http://testsite.com/',
@@ -66,8 +65,8 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
     pages = Page.where(url: 'http://testsite.com/')
     assert_equal 1, pages.length
     assert_equal import_data[0][:title], pages[0].title
-    assert_equal import_data[0][:site_agency], pages[0].agency
-    assert_equal import_data[0][:site_name], pages[0].site
+    assert_not_nil pages[0].agencies.find_by(name: import_data[0][:site_agency])
+    assert_not_nil pages[0].sites.find_by(name: import_data[0][:site_name])
 
     versions = pages[0].versions
     assert_equal 2, versions.length

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -366,7 +366,8 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
 
       assert_equal(
         actual_page.latest.capture_time.iso8601,
-        found_page['latest']['capture_time']
+        # Trim potential sub-second precision depending on serialization method
+        found_page['latest']['capture_time'].sub(/\.\d+/, '')
       )
     end
   end

--- a/test/fixtures/agencies.yml
+++ b/test/fixtures/agencies.yml
@@ -1,0 +1,5 @@
+epa:
+  name: EPA
+
+doi:
+  name: DOI

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -1,0 +1,6 @@
+all_epa:
+  name: EPA - epa.gov
+  versionista_id: 5
+
+epa_compliance:
+  name: EPA - epa.gov/compliance

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -37,4 +37,67 @@ class PageTest < ActiveSupport::TestCase
     refute(page.changed?, 'The page was left with unsaved changes')
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has an empty title')
   end
+
+  test 'can add a page to many agency models' do
+    pages(:home_page).add_to_agency(agencies(:epa))
+    pages(:home_page).add_to_agency(agencies(:doi))
+    assert pages(:home_page).agencies.find(agencies(:epa).uuid)
+    assert pages(:home_page).agencies.find(agencies(:doi).uuid)
+  end
+
+  test 'can add a page to an agency by name' do
+    pages(:home_page).add_to_agency('EPA')
+    assert pages(:home_page).agencies.find(agencies(:epa).uuid)
+  end
+
+  test 'adding a page to an unknown agency creates that agency' do
+    pages(:home_page).add_to_agency('Department of Unicorns')
+    unicorns = Agency.find_by!(name: 'Department of Unicorns')
+    assert pages(:home_page).agencies.include?(unicorns)
+  end
+
+  test 'adding a page to an agency repeatedly does not cause errors or duplicates' do
+    pages(:home_page).add_to_agency('EPA')
+    pages(:home_page).add_to_agency(agencies(:epa))
+
+    assert_equal(1, pages(:home_page).agencies.count)
+  end
+
+  test 'can add a page to many site models' do
+    pages(:home_page).add_to_site(sites(:all_epa))
+    pages(:home_page).add_to_site(sites(:epa_compliance))
+    assert pages(:home_page).sites.find(sites(:all_epa).uuid)
+    assert pages(:home_page).sites.find(sites(:epa_compliance).uuid)
+  end
+
+  test 'can add a page to a site by name' do
+    pages(:home_page).add_to_site('EPA - epa.gov')
+    assert pages(:home_page).sites.find(sites(:all_epa).uuid)
+  end
+
+  test 'adding a page to an unknown site creates that site' do
+    pages(:home_page).add_to_site('Unicorns.gov Site')
+    unicorns = Site.find_by!(name: 'Unicorns.gov Site')
+    assert pages(:home_page).sites.include?(unicorns)
+  end
+
+  test 'adding a page to a site repeatedly does not cause errors or duplicates' do
+    pages(:home_page).add_to_site('EPA - epa.gov')
+    pages(:home_page).add_to_site(sites(:all_epa))
+
+    assert_equal(1, pages(:home_page).sites.count)
+  end
+
+  test 'can add a page to a site by versionista ID' do
+    pages(:home_page).add_to_site('Magical River Protectors', versionista_id: 5)
+    assert pages(:home_page).sites.include?(sites(:all_epa))
+    assert_equal('Magical River Protectors', sites(:all_epa).name, 'Site name was not updated')
+  end
+
+  test 'add a page to a site by an unknown versionista ID creates the site' do
+    pages(:home_page).add_to_site('Magical River Protectors', versionista_id: 10)
+    river_protectors = Site.find_by!(versionista_id: 10)
+    assert_equal('Magical River Protectors', river_protectors.name, 'New site did not have a name')
+    assert pages(:home_page).sites.include?(river_protectors)
+  end
 end


### PR DESCRIPTION
**Work in progress; do not merge!**

I got three quarters of the way through writing a tags implementation before feedback from @trinberg suggested that tags might not actually be the best solution for modeling sites and agencies. Instead, I went back to the drawing board and just added a more straightforward set of two new models (Site and Agency) than each have an N:M relationship with Page.

Agency may as well be a simple tag since it only has a name, but this affords us room to add more metadata later. Site takes advantage of this and adds a concept of `versionista_id` (which we’ll hopefully remove in the future) that helps us handle sites being renamed in Versionista.

Still to do:

- [x] Add Agency and Site models
- [x] Add migration to move existing agency/site data to new models
- [x] Support new sites/agencies in imports
- [ ] Support multiple sites/agencies per record in imports
- [x] Support new sites/agencies in page results
- [ ] Support conditional queries on sites/agencies (e.g. `/api/v0/pages?agency=EPA`)

Fixes #24.