### PR TITLE
Switch to using aws-sdk-s3 instead of full aws-sdk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 ruby '2.4.1'
 
-gem 'aws-sdk', '~> 2.9'
+gem 'aws-sdk-s3', '~> 1.8'
 gem 'devise'
 gem 'httparty'
 gem 'jwt', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,13 +42,18 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.4.0)
-    aws-sdk (2.10.122)
-      aws-sdk-resources (= 2.10.122)
-    aws-sdk-core (2.10.122)
+    aws-partitions (1.57.0)
+    aws-sdk-core (3.14.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.122)
-      aws-sdk-core (= 2.10.122)
+    aws-sdk-kms (1.4.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.8.0)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.2)
     bcrypt (3.1.11)
     bindex (0.5.0)
@@ -246,7 +251,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk (~> 2.9)
+  aws-sdk-s3 (~> 1.8)
   byebug
   devise
   dotenv-rails

--- a/lib/file_storage/s3.rb
+++ b/lib/file_storage/s3.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 module FileStorage
   class S3


### PR DESCRIPTION
AWS has recently modularized the SDK gem so there is now one gem per service. Upgrading to V3 of the SDK is *huge*, so it's probably the right time to switch to a more trim and direct dependency on the S3 gem, which the only one we use. (Note that the major version for the full SDK gem is now 3.x, but the individual service gems are all new and at 1.x.)

This is an alternative to/replacement of #215.