### PR TITLE
Replace agency → maintainers & site → tags

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,8 @@ Metrics/ParameterLists:
 
 Metrics/CyclomaticComplexity:
   Max: 12
+  Exclude:
+    - 'app/controllers/api/v0/pages_controller.rb'
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -19,6 +19,8 @@ Lint/ParenthesesAsGroupedExpression:
 # Offense count: 16
 Metrics/AbcSize:
   Max: 77
+  Exclude:
+    - 'app/controllers/api/v0/pages_controller.rb'
 
 # Offense count: 5
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -38,11 +40,13 @@ Metrics/LineLength:
 # Offense count: 28
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 78
+  Max: 80
 
 # Offense count: 4
 Metrics/PerceivedComplexity:
   Max: 12
+  Exclude:
+    - 'app/controllers/api/v0/pages_controller.rb'
 
 # Offense count: 7
 # Cop supports --auto-correct.

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -4,11 +4,7 @@ class Api::V0::ApiController < ApplicationController
   before_action :set_environment_header
 
   rescue_from StandardError, with: :render_errors if Rails.env.production?
-  rescue_from Api::NotImplementedError, with: :render_errors
-  rescue_from Api::InputError, with: :render_errors
-  rescue_from Api::DynamicError, with: :render_errors
-  rescue_from Api::AuthorizationError, with: :render_errors
-  rescue_from Api::ResourceExistsError, with: :render_errors
+  rescue_from Api::ApiError, with: :render_errors
 
   rescue_from ActiveRecord::RecordInvalid, with: :render_errors
   rescue_from ActiveModel::ValidationError do |error|

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -3,7 +3,7 @@ class Api::V0::ApiController < ApplicationController
   before_action :require_authentication!
   before_action :set_environment_header
 
-  rescue_from StandardError, with: :render_errors if Rails.env.production? || Rails.env.test?
+  rescue_from StandardError, with: :render_errors if Rails.env.production?
   rescue_from Api::NotImplementedError, with: :render_errors
   rescue_from Api::InputError, with: :render_errors
   rescue_from Api::DynamicError, with: :render_errors

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -8,6 +8,7 @@ class Api::V0::ApiController < ApplicationController
   rescue_from Api::InputError, with: :render_errors
   rescue_from Api::DynamicError, with: :render_errors
   rescue_from Api::AuthorizationError, with: :render_errors
+  rescue_from Api::ResourceExistsError, with: :render_errors
 
   rescue_from ActiveRecord::RecordInvalid, with: :render_errors
   rescue_from ActiveModel::ValidationError do |error|

--- a/app/controllers/api/v0/maintainers_controller.rb
+++ b/app/controllers/api/v0/maintainers_controller.rb
@@ -25,6 +25,48 @@ class Api::V0::MaintainersController < Api::V0::ApiController
     }
   end
 
+  def create
+    data = JSON.parse(request.body.read)
+    if data['uuid'].nil? && data['name'].nil?
+      raise Api::InputError, 'You must specify either a `uuid` or `name` for the maintainer to add.'
+    end
+
+    @maintainer =
+      if page
+        if data['uuid']
+          page.add_maintainer(Maintainer.find(data['uuid']))
+        else
+          maintainer = page.add_maintainer(data['name'])
+          if data.key?('parent_uuid')
+            maintainer.update!(parent_uuid: data['parent_uuid'])
+          end
+          maintainer
+        end
+      else
+        maintainer = Maintainer.find_or_create_by(name: data['name'])
+        if data.key?('parent_uuid')
+          maintainer.update!(parent_uuid: data['parent_uuid'])
+        end
+        maintainer
+      end
+    show
+  end
+
+  def update
+    @maintainer = (page ? page.maintainers : Maintainer).find(params[:id])
+    data = JSON.parse(request.body.read).select do |key|
+      ['name', 'parent_uuid'].include?(key)
+    end
+    @maintainer.update!(data)
+    show
+  end
+
+  def destroy
+    # NOTE: this assumes you can only get here in the context of a page
+    page.remove_maintainer(Maintainer.find(params[:id]))
+    redirect_to(api_v0_page_maintainers_url(page))
+  end
+
   protected
 
   def paging_path_for(_model_type, *args)

--- a/app/controllers/api/v0/maintainers_controller.rb
+++ b/app/controllers/api/v0/maintainers_controller.rb
@@ -1,0 +1,61 @@
+class Api::V0::MaintainersController < Api::V0::ApiController
+  def index
+    query = maintainer_collection
+    paging = pagination(query)
+    maintainers = query.limit(paging[:chunk_size]).offset(paging[:offset])
+
+    render json: {
+      links: paging[:links],
+      meta: { total_results: paging[:total_items] },
+      data: maintainers
+    }
+  end
+
+  def show
+    @maintainer ||= Maintainer.find(params[:id])
+    parent_url =
+      if @maintainer.parent_uuid
+        api_v0_maintainer_url(@maintainer.parent_uuid)
+      else
+        nil
+      end
+
+    render json: {
+      links: {
+        parent: parent_url,
+        children: api_v0_maintainers_url(params: { parent: @maintainer.uuid }),
+      },
+      data: @maintainer
+    }
+  end
+
+  protected
+
+  def paging_path_for(model_type, *args)
+    if page
+      api_v0_page_maintainers_url(*args)
+    else
+      api_v0_maintainers_url(*args)
+    end
+  end
+
+  def page
+    return nil unless params.key? :page_id
+    @page ||= Page.find(params[:page_id])
+  end
+
+  def maintainer_collection
+    collection = page ? page.maintainerships.joins(:maintainer) : Maintainer
+
+    if params.key?(:parent)
+      if page
+        collection = collection
+          .merge(Maintainer.where(parent_uuid: params[:parent]))
+      else
+        collection = collection.where(parent_uuid: params[:parent])
+      end
+    end
+
+    collection.order(created_at: :asc)
+  end
+end

--- a/app/controllers/api/v0/maintainers_controller.rb
+++ b/app/controllers/api/v0/maintainers_controller.rb
@@ -13,17 +13,13 @@ class Api::V0::MaintainersController < Api::V0::ApiController
 
   def show
     @maintainer ||= Maintainer.find(params[:id])
-    parent_url =
-      if @maintainer.parent_uuid
-        api_v0_maintainer_url(@maintainer.parent_uuid)
-      else
-        nil
-      end
+    parent_url = @maintainer.parent_uuid &&
+                 api_v0_maintainer_url(@maintainer.parent_uuid)
 
     render json: {
       links: {
         parent: parent_url,
-        children: api_v0_maintainers_url(params: { parent: @maintainer.uuid }),
+        children: api_v0_maintainers_url(params: { parent: @maintainer.uuid })
       },
       data: @maintainer
     }
@@ -31,7 +27,7 @@ class Api::V0::MaintainersController < Api::V0::ApiController
 
   protected
 
-  def paging_path_for(model_type, *args)
+  def paging_path_for(_model_type, *args)
     if page
       api_v0_page_maintainers_url(*args)
     else
@@ -48,12 +44,12 @@ class Api::V0::MaintainersController < Api::V0::ApiController
     collection = page ? page.maintainerships.joins(:maintainer) : Maintainer
 
     if params.key?(:parent)
-      if page
-        collection = collection
-          .merge(Maintainer.where(parent_uuid: params[:parent]))
-      else
-        collection = collection.where(parent_uuid: params[:parent])
-      end
+      collection =
+        if page
+          collection.merge(Maintainer.where(parent_uuid: params[:parent]))
+        else
+          collection.where(parent_uuid: params[:parent])
+        end
     end
 
     collection.order(created_at: :asc)

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -149,18 +149,14 @@ class Api::V0::PagesController < Api::V0::ApiController
   def format_page_json(page)
     page['maintainers'] = page.delete('maintainerships').collect do |item|
       item['maintainer']
-        .reject {|k, v| k == 'created_at' || k == 'updated_at'}
-        .merge({
-          'assigned_at' => item['created_at']
-        })
+        .reject {|k, _| k == 'created_at' || k == 'updated_at'}
+        .merge('assigned_at' => item['created_at'])
     end
 
     page['tags'] = page.delete('taggings').collect do |item|
       item['tag']
-        .reject {|k, v| k == 'created_at' || k == 'updated_at'}
-        .merge({
-          'assigned_at' => item['created_at']
-        })
+        .reject {|k, _| k == 'created_at' || k == 'updated_at'}
+        .merge('assigned_at' => item['created_at'])
     end
   end
 
@@ -281,10 +277,7 @@ class Api::V0::PagesController < Api::V0::ApiController
       end
     end
 
-    if block_given?
-      results.collect {|record| yield record}
-    end
-
+    results.collect {|record| yield record} if block_given?
     results
   end
 

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -26,14 +26,21 @@ class Api::V0::PagesController < Api::V0::ApiController
           .where(uuid: page_ids)
           .includes(:versions)
           .order('versions.capture_time DESC')
-        lightweight_query(results, :versions)
+        lightweight_query(results)
       elsif should_include_latest
-        # [pages.includes(:latest), :latest]
         page_ids = pages.pluck(:uuid, :updated_at).collect {|data| data[0]}
-        results = Page
+
+        # Filters from the original query should *not* affect what's "latest",
+        # (though they do affect which *pages* get included) so we build a
+        # whole new query from scratch here.
+        # NOTE: lightweight_query can't handle the series of N queries this
+        # actually generates, but the result set is not as insanely huge as
+        # when versions are included, so it's ok to just use ActiveRecord here.
+        Page
           .where(uuid: page_ids)
-          .includes(:latest)
-        lightweight_query(results, :latest)
+          .order(updated_at: :desc)
+          .includes(:latest, :maintainers)
+          .as_json(include: [:latest, :maintainers])
       else
         lightweight_query(pages)
       end
@@ -42,14 +49,14 @@ class Api::V0::PagesController < Api::V0::ApiController
       links: paging[:links],
       meta: { total_results: paging[:total_items] },
       data: result_data
-    }, mode: :strict)
+    }, mode: should_include_latest ? :rails : :strict)
   end
 
   def show
     page = Page.find(params[:id])
     render json: {
       data: page
-    }, include: [:versions]
+    }, include: [:versions, :maintainers]
   end
 
   protected
@@ -68,6 +75,11 @@ class Api::V0::PagesController < Api::V0::ApiController
 
   def page_collection
     collection = Page.where(params.permit(:agency, :site, :title))
+    # NOTE: You *can't* use left_outer_joins here because ActiveRecord screws
+    # up and tries to join the tables *twice* in the query. I think this is
+    # probably because it is a has_and_belongs_to_many, but have not had time
+    # to break down exactly what is going wrong. In any case, `includes` works.
+    collection = collection.eager_load(:maintainers)
 
     collection = where_in_range_param(
       collection,
@@ -78,7 +90,7 @@ class Api::V0::PagesController < Api::V0::ApiController
 
     version_params = params.permit(:hash, :source_type)
     if version_params.present?
-      collection = collection.joins(:versions).where(versions: {
+      collection = collection.left_outer_joins(:versions).where(versions: {
         version_hash: params[:hash],
         source_type: params[:source_type]
       }.compact)
@@ -98,145 +110,82 @@ class Api::V0::PagesController < Api::V0::ApiController
     collection.distinct.order(updated_at: :desc)
   end
 
-  # Get the results of an ActiveRecord query (and, optionally, one association)
-  # as a simple JSON-compatible structure without instantiating actual models.
-  # This is generally way fancier footwork that one should be performing and
-  # should only be used for extremely hot (in speed or memory) queries.
+  # Get the results of an ActiveRecord query as a simple JSON-compatible
+  # structure without instantiating actual models. This is generally way
+  # fancier footwork that one should be performing and should only be used for
+  # extremely hot (in speed or memory) queries.
   #
   # It makes a number of assumptions about the structure of queries and only
-  # works with has_many and has_one associations (the association can also be
-  # nil). Those assumptions are generally reasonable, but are likely sensitive
-  # to underlying changes in ActiveRecord.
-  def lightweight_query(relation, association = nil)
-    reflection = relation.model._reflections.try(:[], association.to_s)
-
-    if !reflection || reflection.is_a?(ActiveRecord::Reflection::HasManyReflection)
-      lightweight_query_with_many(relation, reflection)
-    elsif reflection.is_a?(ActiveRecord::Reflection::HasOneReflection)
-      lightweight_query_with_one(relation, reflection)
-    else
-      raise StandardError, "lightweight query can only handle `has_one` and `has_many` associations, not #{reflection.class.name}"
-    end
-  end
-
-  # Perform a lightweight query with a has_many association (or no association)
-  def lightweight_query_with_many(relation, association_reflection)
+  # works with some kinds of associations. Queries with associations that
+  # require more than one actual SQL call are not supported. This is also
+  # likely sensitive to underlying changes in ActiveRecord.
+  def lightweight_query(relation)
     primary_type = relation.model
-    names = primary_type.attribute_names
-    primary_names_length = names.length
-    association = association_reflection.try(:name)
-    names += association_reflection.klass.attribute_names if association_reflection
+    # Hold information about associations in arrays indexed by the association
+    # for later quick lookup when working with segments of each result row.
+    associations = (relation.eager_load_values + relation.includes_values).collect(&:to_s)
+    reflections = associations.collect {|association| primary_type._reflections.try(:[], association)}
+    association_names = [nil] + associations
+    types = [primary_type] + reflections.collect(&:klass)
+    attribute_names = types.collect(&:attribute_names)
 
     # Ensure primary records are all consecutive and not interleaved because of
     # other orderings in the query.
-    relation.order_values.insert(
-      0,
-      "#{primary_type.table_name}.#{primary_type.primary_key} ASC"
-    )
+    unless relation.order_values.frozen?
+      relation.order_values.insert(
+        0,
+        "#{primary_type.table_name}.#{primary_type.primary_key} ASC"
+      )
+    end
     raw = ActiveRecord::Base.connection.exec_query(relation.to_sql)
 
-    skip_length = raw.columns.find_index('t0_r0') || 0
-    primary_names_length += skip_length
-    names = (0...skip_length).to_a + names
-
     parsers = raw.columns.collect do |column|
       PrimitiveParser.for(raw.column_types[column])
     end
 
-    last_id = nil
-    current_record = nil
+    # List of final resulting hashes for each primary model
     results = []
+    # Hashes that map IDs to previously built objects for each association
+    object_maps = association_names.collect {|_| {}}
+    # A cached range for iterating throw associations on each row
+    model_range = 0...association_names.count
 
     raw.rows.each do |row|
-      if last_id != row[0]
-        current_record = {}
-        results << current_record
-        current_record[association] = [] if association
-      end
+      primary_record = nil
+      column_index = 0
+      model_range.each do |model_index|
+        model_id = row[column_index]
+        record = object_maps[model_index][model_id]
+        record_is_new = record.nil?
 
-      associated_record = {}
+        # Create and read record data or skip ahead if we already have a copy
+        if record
+          column_index += attribute_names[model_index].count
+        else
+          record = {}
+          object_maps[model_index][model_id] = record
 
-      row.each_with_index do |value, index|
-        next if index < skip_length
-        next if index < primary_names_length && last_id == row[0]
-        target = index < primary_names_length ? current_record : associated_record
-        parser = parsers[index]
+          attribute_names[model_index].each do |name|
+            value = row[column_index]
+            parser = parsers[column_index]
+            record[name] = parser ? parser.deserialize(value) : value
+            column_index += 1
+          end
+        end
 
-        target[names[index]] = parser ? parser.deserialize(value) : value
-      end
-
-      current_record[association] << associated_record if association
-      last_id = row[0]
-    end
-
-    results
-  end
-
-  # Perform a lightweight query with a has_one association
-  def lightweight_query_with_one(relation, association_reflection)
-    raw = ActiveRecord::Base.connection.exec_query(relation.to_sql)
-    primary_type = relation.model
-    names = primary_type.attribute_names
-    names_length = names.length
-
-    parsers = raw.columns.collect do |column|
-      PrimitiveParser.for(raw.column_types[column])
-    end
-
-    last_id = nil
-    results = []
-    id_map = {}
-
-    raw.rows.each do |row|
-      next if last_id == row[0]
-
-      record = {}
-      results << record
-      last_id = row[0]
-      id_map[last_id] = record
-
-      row.each_with_index do |value, index|
-        next if index >= names_length
-        parser = parsers[index]
-
-        record[names[index]] = parser ? parser.deserialize(value) : value
-      end
-    end
-
-    # And now for the association
-    secondary_type = association_reflection.klass
-    secondary_query = secondary_type.where(
-      association_reflection.foreign_key => id_map.keys
-    )
-    if association_reflection.scope
-      secondary_query = secondary_query.merge(association_reflection.scope)
-    end
-    raw = ActiveRecord::Base.connection.exec_query(secondary_query.to_sql)
-    names = secondary_type.attribute_names
-    names_length = names.length
-
-    parsers = raw.columns.collect do |column|
-      PrimitiveParser.for(raw.column_types[column])
-    end
-
-    last_id = nil
-    raw.rows.each do |row|
-      next if last_id == row[0]
-
-      record = {}
-      last_id = row[0]
-
-      row.each_with_index do |value, index|
-        next if index >= names_length
-        parser = parsers[index]
-
-        record[names[index]] = parser ? parser.deserialize(value) : value
-        if record[names[index]].is_a? Time
-          record[names[index]] = record[names[index]].iso8601
+        # Add the record to the right association/list
+        if model_index.zero?
+          primary_record = record
+          results << record if record_is_new
+        elsif reflections[model_index - 1].is_a?(ActiveRecord::Reflection::HasOneReflection)
+          field_name = association_names[model_index]
+          primary_record[field_name] = record
+        else
+          field_name = association_names[model_index]
+          field = (primary_record[field_name] ||= [])
+          field << record unless model_id.nil? || field.include?(record)
         end
       end
-
-      id_map[record[association_reflection.foreign_key]][association_reflection.name] = record
     end
 
     results

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -39,8 +39,8 @@ class Api::V0::PagesController < Api::V0::ApiController
         Page
           .where(uuid: page_ids)
           .order(updated_at: :desc)
-          .includes(:latest, :maintainers)
-          .as_json(include: [:latest, :maintainers])
+          .includes(:latest, :maintainers, :tags)
+          .as_json(include: [:latest, :maintainers, :tags])
       else
         lightweight_query(pages)
       end
@@ -56,7 +56,7 @@ class Api::V0::PagesController < Api::V0::ApiController
     page = Page.find(params[:id])
     render json: {
       data: page
-    }, include: [:versions, :maintainers]
+    }, include: [:versions, :maintainers, :tags]
   end
 
   protected
@@ -79,7 +79,7 @@ class Api::V0::PagesController < Api::V0::ApiController
     # up and tries to join the tables *twice* in the query. I think this is
     # probably because it is a has_and_belongs_to_many, but have not had time
     # to break down exactly what is going wrong. In any case, `includes` works.
-    collection = collection.eager_load(:maintainers)
+    collection = collection.eager_load(:maintainers, :tags)
 
     collection = where_in_range_param(
       collection,

--- a/app/controllers/api/v0/tags_controller.rb
+++ b/app/controllers/api/v0/tags_controller.rb
@@ -1,0 +1,41 @@
+class Api::V0::TagsController < Api::V0::ApiController
+  def index
+    query = tag_collection
+    paging = pagination(query)
+    tags = query.limit(paging[:chunk_size]).offset(paging[:offset])
+
+    render json: {
+      links: paging[:links],
+      meta: { total_results: paging[:total_items] },
+      data: tags
+    }
+  end
+
+  def show
+    @tag ||= Tag.find(params[:id])
+
+    render json: {
+      data: @tag
+    }
+  end
+
+  protected
+
+  def paging_path_for(model_type, *args)
+    if page
+      api_v0_page_tags_url(*args)
+    else
+      api_v0_tags_url(*args)
+    end
+  end
+
+  def page
+    return nil unless params.key? :page_id
+    @page ||= Page.find(params[:page_id])
+  end
+
+  def tag_collection
+    collection = page ? page.taggings.joins(:tag) : Tag
+    collection.order(created_at: :asc)
+  end
+end

--- a/app/controllers/api/v0/tags_controller.rb
+++ b/app/controllers/api/v0/tags_controller.rb
@@ -21,7 +21,7 @@ class Api::V0::TagsController < Api::V0::ApiController
 
   protected
 
-  def paging_path_for(model_type, *args)
+  def paging_path_for(_model_type, *args)
     if page
       api_v0_page_tags_url(*args)
     else

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -7,10 +7,7 @@ module Taggable
   end
 
   def add_tag(tag)
-    unless tag.is_a?(Tag)
-      tag = Tag.find_or_create_by(name: tag.strip)
-    end
-
+    tag = Tag.find_or_create_by(name: tag.strip) unless tag.is_a?(Tag)
     tags.push(tag) unless tags.include?(tag)
     tag
   end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -1,0 +1,31 @@
+module Taggable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :taggings, as: :taggable, foreign_key: 'taggable_uuid'
+    has_many :tags, through: :taggings
+  end
+
+  def add_tag(tag)
+    unless tag.is_a?(Tag)
+      tag = Tag.find_or_create_by(name: tag.strip)
+    end
+
+    tags.push(tag) unless tags.include?(tag)
+    tag
+  end
+
+  def untag(tag)
+    attached_tag =
+      if tag.is_a?(Tag)
+        tags.find_by(uuid: tag.uuid)
+      else
+        tags.find_by(name: tag.strip)
+      end
+    tags.delete(attached_tag) if attached_tag
+  end
+
+  def tag_names
+    tags.collect(&:name)
+  end
+end

--- a/app/models/maintainer.rb
+++ b/app/models/maintainer.rb
@@ -1,0 +1,20 @@
+# Maintainer represents an organization that maintains some web pages. It has
+# a name and an optional link to a parent maintainer so there can be a
+# hierarchical relationship (e.g. an office of a department of an organization)
+class Maintainer < ApplicationRecord
+  include UuidPrimaryKey
+
+  has_many :maintainerships, foreign_key: :maintainer_uuid
+  has_many :pages, through: :maintainerships
+
+  belongs_to :parent,
+    class_name: 'Maintainer',
+    foreign_key: :parent_uuid,
+    optional: true,
+    inverse_of: :children
+
+  has_many :children,
+    class_name: 'Maintainer',
+    foreign_key: :parent_uuid,
+    inverse_of: :parent
+end

--- a/app/models/maintainership.rb
+++ b/app/models/maintainership.rb
@@ -1,0 +1,4 @@
+class Maintainership < ApplicationRecord
+  belongs_to :maintainer, foreign_key: :maintainer_uuid
+  belongs_to :page, foreign_key: :page_uuid
+end

--- a/app/models/maintainership.rb
+++ b/app/models/maintainership.rb
@@ -4,12 +4,12 @@ class Maintainership < ApplicationRecord
 
   # A smarter implementation might support all the normal options, but we
   # don't have any other use cases right now, so maybe not worth the effort.
-  def as_json(options={})
+  def as_json(_options = {})
     {
       'uuid' => maintainer_uuid,
       'name' => maintainer.name,
       'assigned_at' => created_at,
-      'parent_uuid' => maintainer.parent_uuid,
+      'parent_uuid' => maintainer.parent_uuid
     }
   end
 end

--- a/app/models/maintainership.rb
+++ b/app/models/maintainership.rb
@@ -1,4 +1,15 @@
 class Maintainership < ApplicationRecord
   belongs_to :maintainer, foreign_key: :maintainer_uuid
   belongs_to :page, foreign_key: :page_uuid
+
+  # A smarter implementation might support all the normal options, but we
+  # don't have any other use cases right now, so maybe not worth the effort.
+  def as_json(options={})
+    {
+      'uuid' => maintainer_uuid,
+      'name' => maintainer.name,
+      'assigned_at' => created_at,
+      'parent_uuid' => maintainer.parent_uuid,
+    }
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -18,6 +18,9 @@ class Page < ApplicationRecord
     foreign_key: 'page_uuid',
     class_name: 'Version'
 
+  has_many :maintainerships, foreign_key: :page_uuid
+  has_many :maintainers, through: :maintainerships
+
   before_save :normalize_url
   validate :url_must_have_domain
 
@@ -28,6 +31,25 @@ class Page < ApplicationRecord
     else
       "http://#{url}"
     end
+  end
+
+  def add_maintainer(maintainer)
+    unless maintainer.is_a?(Maintainer)
+      maintainer = Maintainer.find_or_create_by(name: maintainer)
+    end
+
+    maintainers.push(maintainer) unless maintainers.include?(maintainer)
+    maintainer
+  end
+
+  def remove_maintainer(maintainer)
+    attached_maintainer =
+      if maintainer.is_a?(Tag)
+        maintainers.find_by(uuid: maintainer.uuid)
+      else
+        maintainers.find_by(name: maintainer.strip)
+      end
+    maintainers.delete(attached_maintainer) if attached_maintainer
   end
 
   protected

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,5 +1,6 @@
 class Page < ApplicationRecord
   include UuidPrimaryKey
+  include Taggable
 
   has_many :versions,
     -> { order(capture_time: :desc) },

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -53,13 +53,13 @@ class Page < ApplicationRecord
     maintainers.delete(attached_maintainer) if attached_maintainer
   end
 
-  def as_json(options={})
+  def as_json(options = {})
     # Tags and Maintainers get a special JSON representation
     custom_options = options.clone
     includes = custom_options[:include]
-    associations = {maintainers: false, tags: false}
+    associations = { maintainers: false, tags: false }
 
-    if includes == :tags || includes == :maintainers
+    if [:maintainers, :tags].include?(includes)
       associations[includes] = true
       custom_options.delete(:include)
     elsif includes.is_a?(Enumerable)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -45,7 +45,7 @@ class Page < ApplicationRecord
 
   def remove_maintainer(maintainer)
     attached_maintainer =
-      if maintainer.is_a?(Tag)
+      if maintainer.is_a?(Maintainer)
         maintainers.find_by(uuid: maintainer.uuid)
       else
         maintainers.find_by(name: maintainer.strip)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,5 @@
+class Tag < ApplicationRecord
+  include UuidPrimaryKey
+  has_many :taggings, foreign_key: :tag_uuid
+  has_many :pages, through: :taggings, source: :taggable, source_type: :Page
+end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -4,11 +4,11 @@ class Tagging < ApplicationRecord
 
   # A smarter implementation might support all the normal options, but we
   # don't have any other use cases right now, so maybe not worth the effort.
-  def as_json(options={})
+  def as_json(_options = {})
     {
       'uuid' => tag_uuid,
       'name' => tag.name,
-      'assigned_at' => created_at,
+      'assigned_at' => created_at
     }
   end
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,4 +1,14 @@
 class Tagging < ApplicationRecord
   belongs_to :taggable, polymorphic: true, foreign_key: :taggable_uuid
   belongs_to :tag, inverse_of: :taggings, foreign_key: :tag_uuid
+
+  # A smarter implementation might support all the normal options, but we
+  # don't have any other use cases right now, so maybe not worth the effort.
+  def as_json(options={})
+    {
+      'uuid' => tag_uuid,
+      'name' => tag.name,
+      'assigned_at' => created_at,
+    }
+  end
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,4 @@
+class Tagging < ApplicationRecord
+  belongs_to :taggable, polymorphic: true, foreign_key: :taggable_uuid
+  belongs_to :tag, inverse_of: :taggings, foreign_key: :tag_uuid
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,11 +24,13 @@ Rails.application.routes.draw do
             end
         end
         resources :maintainers, only: [:index], format: :json
+        resources :tags, only: [:index], format: :json
       end
 
       resources :versions, only: [:index, :show], format: :json
       resources :imports, only: [:create, :show], format: :json
       resources :maintainers, only: [:index, :show], format: :json
+      resources :tags, only: [:index, :show], format: :json
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,13 +23,13 @@ Rails.application.routes.draw do
               get 'diff/:type', to: 'diff#show'
             end
         end
-        resources :maintainers, only: [:index], format: :json
+        resources :maintainers, except: [:new, :edit], format: :json
         resources :tags, except: [:new, :edit], format: :json
       end
 
       resources :versions, only: [:index, :show], format: :json
       resources :imports, only: [:create, :show], format: :json
-      resources :maintainers, only: [:index, :show], format: :json
+      resources :maintainers, except: [:new, :edit, :destroy], format: :json
       resources :tags, except: [:new, :edit, :destroy], format: :json
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,10 +23,12 @@ Rails.application.routes.draw do
               get 'diff/:type', to: 'diff#show'
             end
         end
+        resources :maintainers, only: [:index], format: :json
       end
 
       resources :versions, only: [:index, :show], format: :json
       resources :imports, only: [:create, :show], format: :json
+      resources :maintainers, only: [:index, :show], format: :json
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,13 +24,13 @@ Rails.application.routes.draw do
             end
         end
         resources :maintainers, only: [:index], format: :json
-        resources :tags, only: [:index], format: :json
+        resources :tags, except: [:new, :edit], format: :json
       end
 
       resources :versions, only: [:index, :show], format: :json
       resources :imports, only: [:create, :show], format: :json
       resources :maintainers, only: [:index, :show], format: :json
-      resources :tags, only: [:index, :show], format: :json
+      resources :tags, except: [:new, :edit, :destroy], format: :json
     end
   end
 

--- a/db/migrate/20180128062846_create_maintainers.rb
+++ b/db/migrate/20180128062846_create_maintainers.rb
@@ -1,0 +1,27 @@
+class CreateMaintainers < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension :citext
+
+    create_table :maintainers, id: false do |t|
+      t.primary_key :uuid, :uuid
+      t.citext :name, null: false
+      t.uuid :parent_uuid
+      t.timestamps
+
+      t.index :name, unique: true
+    end
+
+    create_table :maintainerships, id: false do |t|
+      # No way to use `belongs_to/references` to make a column named `*_uuid`
+      t.uuid :maintainer_uuid, null: false
+      t.foreign_key :maintainers, column: :maintainer_uuid, primary_key: 'uuid'
+      t.uuid :page_uuid, null: false
+      t.foreign_key :pages, column: :page_uuid, primary_key: 'uuid'
+      t.datetime :created_at, null: false
+
+      t.index :maintainer_uuid
+      t.index :page_uuid
+      t.index [:maintainer_uuid, :page_uuid], unique: true
+    end
+  end
+end

--- a/db/migrate/20180207031149_create_tags.rb
+++ b/db/migrate/20180207031149_create_tags.rb
@@ -1,0 +1,28 @@
+class CreateTags < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension :citext
+
+    create_table :tags, id: false do |t|
+      t.primary_key :uuid, :uuid
+      t.citext :name, null: false
+      t.timestamps
+
+      t.index :name, unique: true
+    end
+
+    create_table :taggings, id: false do |t|
+      # No way to use `belongs_to/references` to make a column named `*_uuid`
+
+      # Polymorphic associations are an ID + a string column
+      t.uuid :taggable_uuid, null: false, index: true
+      t.string :taggable_type
+
+      t.uuid :tag_uuid, null: false, index: true
+      t.foreign_key :tags, column: :tag_uuid, primary_key: 'uuid'
+
+      t.datetime :created_at, null: false
+
+      t.index [:taggable_uuid, :tag_uuid], unique: true
+    end
+  end
+end

--- a/db/migrate/20180207061655_copy_agency_and_site_fields_to_associated_models.rb
+++ b/db/migrate/20180207061655_copy_agency_and_site_fields_to_associated_models.rb
@@ -1,0 +1,24 @@
+class CopyAgencyAndSiteFieldsToAssociatedModels < ActiveRecord::Migration[5.1]
+  def up
+    iterate_batches(Page.order(created_at: :asc)) do |page|
+      page.add_maintainer(page.agency) unless page.agency.blank?
+      page.add_tag("site:#{page.site}") unless page.site.blank?
+    end
+  end
+
+  def down
+    # We didn't remove site/page fields, so nothing to do here
+  end
+
+  # Kind of like find_each, but allows for ordered queries. We need this since
+  # a) UUIDs are not really ordered and b) we are still live inserting data.
+  def iterate_batches(collection, batch_size: 1000)
+    offset = 0
+    loop do
+      items = collection.limit(batch_size).offset(offset)
+      items.each {|item| yield item}
+      break if items.count.zero?
+      offset += batch_size
+    end
+  end
+end

--- a/db/migrate/20180212043742_dedupe_pages_with_multiple_agencies_or_sites.rb
+++ b/db/migrate/20180212043742_dedupe_pages_with_multiple_agencies_or_sites.rb
@@ -1,0 +1,45 @@
+class DedupePagesWithMultipleAgenciesOrSites < ActiveRecord::Migration[5.1]
+  # Find all pages sharing the same URL and de-duplicate them by copying the
+  # maintainers, tags, and versions of all subsequent pages onto the one that
+  # was created first.
+  def up
+    total_deletions = 0
+
+    Page.group(:url).having('count(*) > 1').count.each_key do |url|
+      say("Deduplicating pages for '#{url}'")
+
+      canonical_page = nil
+      deletable = []
+      pages = Page.where(url: url)
+        .eager_load(:maintainers, :tags)
+        .order(created_at: :asc)
+
+      pages.each do |page|
+        if canonical_page.nil?
+          canonical_page = page
+        else
+          page.maintainers.each {|item| canonical_page.add_maintainer(item)}
+          page.maintainers.clear
+
+          page.tags.each {|item| canonical_page.add_tag(item)}
+          page.tags.clear
+
+          page.versions.update_all(page_uuid: canonical_page.uuid)
+          deletable << page.uuid
+        end
+      end
+
+      Page.where(uuid: deletable).delete_all
+      say("Deleted #{deletable.length} pages.", true)
+
+      total_deletions += deletable.length
+    end
+
+    say("Deleted #{total_deletions} pages in total.")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+      'This migration removed information and cannot be reversed.'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180207061655) do
+ActiveRecord::Schema.define(version: 20180212043742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "uuid-ossp"
-  enable_extension "pgcrypto"
   enable_extension "citext"
+  enable_extension "pgcrypto"
+  enable_extension "uuid-ossp"
 
   create_table "annotations", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "change_uuid", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180128062846) do
+ActiveRecord::Schema.define(version: 20180207031149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,23 @@ ActiveRecord::Schema.define(version: 20180128062846) do
     t.index ["url"], name: "index_pages_on_url"
   end
 
+  create_table "taggings", id: false, force: :cascade do |t|
+    t.uuid "taggable_uuid", null: false
+    t.string "taggable_type"
+    t.uuid "tag_uuid", null: false
+    t.datetime "created_at", null: false
+    t.index ["tag_uuid"], name: "index_taggings_on_tag_uuid"
+    t.index ["taggable_uuid", "tag_uuid"], name: "index_taggings_on_taggable_uuid_and_tag_uuid", unique: true
+    t.index ["taggable_uuid"], name: "index_taggings_on_taggable_uuid"
+  end
+
+  create_table "tags", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.citext "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -137,5 +154,6 @@ ActiveRecord::Schema.define(version: 20180128062846) do
   add_foreign_key "invitations", "users", column: "redeemer_id"
   add_foreign_key "maintainerships", "maintainers", column: "maintainer_uuid", primary_key: "uuid"
   add_foreign_key "maintainerships", "pages", column: "page_uuid", primary_key: "uuid"
+  add_foreign_key "taggings", "tags", column: "tag_uuid", primary_key: "uuid"
   add_foreign_key "versions", "pages", column: "page_uuid", primary_key: "uuid"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180207031149) do
+ActiveRecord::Schema.define(version: 20180207061655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171101214731) do
+ActiveRecord::Schema.define(version: 20180128062846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
   enable_extension "pgcrypto"
+  enable_extension "citext"
 
   create_table "annotations", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "change_uuid", null: false
@@ -61,6 +62,23 @@ ActiveRecord::Schema.define(version: 20171101214731) do
     t.index ["code"], name: "index_invitations_on_code"
     t.index ["issuer_id"], name: "index_invitations_on_issuer_id"
     t.index ["redeemer_id"], name: "index_invitations_on_redeemer_id"
+  end
+
+  create_table "maintainers", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.citext "name", null: false
+    t.uuid "parent_uuid"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_maintainers_on_name", unique: true
+  end
+
+  create_table "maintainerships", id: false, force: :cascade do |t|
+    t.uuid "maintainer_uuid", null: false
+    t.uuid "page_uuid", null: false
+    t.datetime "created_at", null: false
+    t.index ["maintainer_uuid", "page_uuid"], name: "index_maintainerships_on_maintainer_uuid_and_page_uuid", unique: true
+    t.index ["maintainer_uuid"], name: "index_maintainerships_on_maintainer_uuid"
+    t.index ["page_uuid"], name: "index_maintainerships_on_page_uuid"
   end
 
   create_table "pages", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -117,5 +135,7 @@ ActiveRecord::Schema.define(version: 20171101214731) do
   add_foreign_key "imports", "users"
   add_foreign_key "invitations", "users", column: "issuer_id"
   add_foreign_key "invitations", "users", column: "redeemer_id"
+  add_foreign_key "maintainerships", "maintainers", column: "maintainer_uuid", primary_key: "uuid"
+  add_foreign_key "maintainerships", "pages", column: "page_uuid", primary_key: "uuid"
   add_foreign_key "versions", "pages", column: "page_uuid", primary_key: "uuid"
 end

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -1,17 +1,20 @@
 module Api
-  class NotImplementedError < StandardError
+  class ApiError < StandardError
+  end
+
+  class NotImplementedError < ApiError
     def status_code
       501
     end
   end
 
-  class InputError < StandardError
+  class InputError < ApiError
     def status_code
       400
     end
   end
 
-  class DynamicError < StandardError
+  class DynamicError < ApiError
     attr_accessor :status_code
 
     def initialize(message, status_code)
@@ -20,13 +23,13 @@ module Api
     end
   end
 
-  class AuthorizationError < StandardError
+  class AuthorizationError < ApiError
     def status_code
       401
     end
   end
 
-  class ResourceExistsError < StandardError
+  class ResourceExistsError < ApiError
     def status_code
       409
     end

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -25,4 +25,10 @@ module Api
       401
     end
   end
+
+  class ResourceExistsError < StandardError
+    def status_code
+      409
+    end
+  end
 end

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -596,7 +596,9 @@ paths:
       tags:
         - pages and versions
       summary: Get all the maintainers of a specific Page
-      description: ''
+      description: >
+        Maintainers are individuals or organizations who manage
+        or publish a Page.
       consumes:
         - application/json
       produces:
@@ -978,7 +980,9 @@ paths:
       tags:
         - maintainers
       summary: Get all maintainers
-      description: ''
+      description: >
+        Maintainers are individuals or organizations who manage
+        or publish a Page.
       consumes:
         - application/json
       produces:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -96,10 +96,10 @@ paths:
         - name: capture_time
           type: string
           in: query
-          description: >-
+          description: >
             Only retrieve pages with versions captured during this time frame. Should be in the format `{start date}..{end date}`, where dates are ISO 8601 formatted. Either date can be left out to make the query open-ended.
 
-            **Examples:**
+            **Examples…**
 
             - `capture_time=2017-02-01..2017-03-01` for all of February
 
@@ -108,6 +108,39 @@ paths:
             - `capture_time=2017-02-01..` for all versions from February on
 
             - `capture_time=..2017-02-01` for all versions before February
+        - name: 'maintainers[]'
+          type: string
+          in: query
+          description: >
+            Only retreive pages with maintainers whose `name`
+            matches the value of this field. You can repeat
+            this parameter multiple times to match more than one
+            maintainer, e.g…
+
+                ?maintainers[]=EPA&maintainers[]=DOE
+
+            The values here are not case-sensitive. Repeated
+            matches are a *UNION* or *OR* style grouping; that
+            is, you get all pages that have any of the maintainers
+            requested, not only pages that have all of the
+            maintainers listed.
+
+        - name: 'tags[]'
+          type: string
+          in: query
+          description: >
+            Only retreive pages with tags whose `name`
+            matches the value of this field. You can repeat
+            this parameter multiple times to match more than one
+            tag, e.g…
+
+                ?tags[]=site:EPA&tags[]=frequently_updated
+
+            The values here are not case-sensitive. Repeated
+            matches are a *UNION* or *OR* style grouping; that
+            is, you get all pages that have any of the tags
+            requested, not only pages that have all of the
+            tags listed.
 
       responses:
         '200':
@@ -1224,6 +1257,14 @@ definitions:
         format: datetime
       latest:
         $ref: '#/definitions/Version'
+      maintainers:
+        type: array
+        items:
+          $ref: '#/definitions/Maintainership'
+      tags:
+        type: array
+        items:
+          $ref: '#/definitions/Tagging'
   Change:
     type: object
     properties:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -175,11 +175,11 @@ paths:
         - name: source_metadata[:key]
           type: string
           in: query
-          description: >-
+          description: >
             Filter results by a given `key` in the `source_metadata` field. You
             can include this parameter multiple times to filter by more than
             one `key`. *Note that this field is not indexed, so these queries
-            can be slow.* Examples:
+            can be slow.* Examples…
 
             - `/api/v0/versions?source_metadata[version_id]=12345678`
 
@@ -201,6 +201,12 @@ paths:
       produces:
         - application/json
       parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to return
+          required: true
+          type: string
+          format: uuid4
         - name: uuid
           in: query
           description: uuid of new Version to store
@@ -551,6 +557,258 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Diff'
+
+  '/pages/{page_id}/maintainers':
+    get:
+      tags:
+        - pages and versions
+      summary: Get all the maintainers of a specific Page
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to return maintainers for
+          required: true
+          type: string
+          format: uuid4
+        - name: chunk
+          in: query
+          description: pagination parameter
+          required: false
+          type: integer
+          default: 1
+        - name: chunk_size
+          in: query
+          description: number of items per chunk
+          required: false
+          type: integer
+          default: 100
+        - name: parent
+          in: query
+          description: >-
+            Only return maintainers whose parent has this UUID.
+          required: false
+          type: string
+          format: uuid4
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/PageOfMaintainerships'
+    post:
+      tags:
+        - pages and versions
+      summary: Add a maintainer to a page
+      description: >
+        Add a maintainer to a page. The maintainer can be a pre-existing one attached to another page or it can be a completely new maintainer.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to return maintainers for
+          required: true
+          type: string
+          format: uuid4
+        - name: '[body]'
+          in: body
+          description: >
+            The request body should be a JSON object. If the
+            `uuid` parameter is specified, all others will be
+            ignored.
+          required: true
+          schema:
+            $ref: '#/definitions/MaintainerPost'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleMaintainership'
+
+  '/pages/{page_id}/maintainers/{maintainer_id}':
+    get:
+      tags:
+        - pages and versions
+      summary: Get a maintainer as attached to a page
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to return maintainers for
+          required: true
+          type: string
+          format: uuid4
+        - name: maintainer_id
+          in: path
+          description: ID of the maintainer to get
+          required: true
+          type: string
+          format: uuid4
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleMaintainership'
+    delete:
+      tags:
+        - pages and versions
+      summary: Remove a maintainer from a page
+      description: >-
+        Removes a maintainer from a page. This does not actually
+        delete the maintainer itself.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to remove the maintainer from
+          required: true
+          type: string
+          format: uuid4
+        - name: maintainer_id
+          in: path
+          description: ID of the maintainer to remove
+          required: true
+          type: string
+          format: uuid4
+      responses:
+        '302':
+          description: On success, you will be redirected to the list of all maintainers on the page.
+
+  '/pages/{page_id}/tags':
+    get:
+      tags:
+        - pages and versions
+      summary: Get all the tags on a specific Page
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to return tags for
+          required: true
+          type: string
+          format: uuid4
+        - name: chunk
+          in: query
+          description: pagination parameter
+          required: false
+          type: integer
+          default: 1
+        - name: chunk_size
+          in: query
+          description: number of items per chunk
+          required: false
+          type: integer
+          default: 100
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/PageOfTaggings'
+    post:
+      tags:
+        - pages and versions
+      summary: Add a tag to a page
+      description: >
+        Add a tag to a page. The tag can be a pre-existing one attached to another page or it can be a completely new tag.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to add the tag to
+          required: true
+          type: string
+          format: uuid4
+        - name: '[body]'
+          in: body
+          description: >
+            The request body should be a JSON object. If the
+            `uuid` parameter is specified, all others will be
+            ignored.
+          required: true
+          schema:
+            $ref: '#/definitions/TagPost'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleTagging'
+
+  '/pages/{page_id}/tags/{tag_id}':
+    get:
+      tags:
+        - pages and versions
+      summary: Get a tag as attached to a particular page.
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to return tags for
+          required: true
+          type: string
+          format: uuid4
+        - name: tag_id
+          in: path
+          description: ID of the tag to get
+          required: true
+          type: string
+          format: uuid4
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleTagging'
+    delete:
+      tags:
+        - pages and versions
+      summary: Remove a tag from a page
+      description: >-
+        Removes a tag from a page. This does not actually
+        delete the tag itself.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to remove the tag from
+          required: true
+          type: string
+          format: uuid4
+        - name: tag_id
+          in: path
+          description: ID of the tag to remove
+          required: true
+          type: string
+          format: uuid4
+      responses:
+        '302':
+          description: On success, you will be redirected to the list of all tags on the page.
+
   /versions:
     get:
       tags:
@@ -593,11 +851,11 @@ paths:
           type: string
         - name: source_metadata[:key]
           in: query
-          description: >-
+          description: >
             Filter results by a given `key` in the `source_metadata` field. You
             can include this parameter multiple times to filter by more than
             one `key`. *Note that this field is not indexed, so these queries
-            can be slow.* Examples:
+            can be slow.* Examples…
 
             - `/api/v0/versions?source_metadata[version_id]=12345678`
 
@@ -681,6 +939,242 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/ImportStatus'
+
+  '/maintainers':
+    get:
+      tags:
+        - maintainers
+      summary: Get all maintainers
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: chunk
+          in: query
+          description: pagination parameter
+          required: false
+          type: integer
+          default: 1
+        - name: chunk_size
+          in: query
+          description: number of items per chunk
+          required: false
+          type: integer
+          default: 100
+        - name: parent
+          in: query
+          description: >-
+            Only return maintainers whose parent has this UUID.
+          required: false
+          type: string
+          format: uuid4
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/PageOfMaintainers'
+    post:
+      tags:
+        - maintainers
+      summary: Add a maintainer
+      description: >-
+        Add a maintainer. This does not associate the maintainer
+        with a particular page. Usually you will want to POST
+        to `/pages/{page_id}/maintainers` instead, which will
+        create the maintainer if it does not already exist.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to return maintainers for
+          required: true
+          type: string
+          format: uuid4
+        - name: '[body]'
+          in: body
+          description: >-
+            The request body should be a JSON object. For this
+            endpoint, the `uuid` parameter is not supported.
+          required: true
+          schema:
+            $ref: '#/definitions/MaintainerPost'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleMaintainer'
+
+  '/maintainers/{maintainer_id}':
+    get:
+      tags:
+        - maintainers
+      summary: Get a maintainer
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: maintainer_id
+          in: path
+          description: ID of the maintainer to get
+          required: true
+          type: string
+          format: uuid4
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleMaintainer'
+
+    patch:
+      tags:
+        - maintainers
+      summary: Update a maintainer
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: maintainer_id
+          in: path
+          description: ID of the maintainer to update
+          required: true
+          type: string
+          format: uuid4
+        - name: '[body]'
+          in: body
+          description: >-
+            The request body should be a JSON object.
+          required: true
+          schema:
+            $ref: '#/definitions/MaintainerPost'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleMaintainer'
+
+  '/tags':
+    get:
+      tags:
+        - tags
+      summary: Get all tags
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: chunk
+          in: query
+          description: pagination parameter
+          required: false
+          type: integer
+          default: 1
+        - name: chunk_size
+          in: query
+          description: number of items per chunk
+          required: false
+          type: integer
+          default: 100
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/PageOfTags'
+    post:
+      tags:
+        - tags
+      summary: Add a tag
+      description: >
+        Add a tag. This does not associate the tag
+        with a particular page. Usually you will want to POST
+        to `/pages/{page_id}/tags` instead, which will
+        create the tag if it does not already exist.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: page_id
+          in: path
+          description: ID of Page to return tags for
+          required: true
+          type: string
+          format: uuid4
+        - name: '[body]'
+          in: body
+          description: >
+            The request body should be a JSON object. For this
+            endpoint, the `uuid` parameter is not supported.
+          required: true
+          schema:
+            $ref: '#/definitions/TagPost'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleMaintainer'
+
+  '/tags/{tag_id}':
+    get:
+      tags:
+        - tags
+      summary: Get a tag
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: tag_id
+          in: path
+          description: ID of the tag to get
+          required: true
+          type: string
+          format: uuid4
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleTag'
+
+    patch:
+      tags:
+        - tags
+      summary: Update a tag
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: tag_id
+          in: path
+          description: ID of the tag to update
+          required: true
+          type: string
+          format: uuid4
+        - name: '[body]'
+          in: body
+          description: >
+            The request body should be a JSON object.
+          required: true
+          schema:
+            $ref: '#/definitions/TagPost'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SingleTag'
+
 definitions:
   Version:
     type: object
@@ -953,6 +1447,231 @@ definitions:
                 type: object
               version:
                 type: string
+
+  Maintainership:
+    type: object
+    properties:
+      uuid:
+        type: string
+        format: uuid4
+      name:
+        type: string
+      parent_uuid:
+        type: string
+        format: uuid4
+      assigned_at:
+        type: string
+        format: datetime
+
+  Maintainer:
+    type: object
+    properties:
+      uuid:
+        type: string
+        format: uuid4
+      name:
+        type: string
+      parent_uuid:
+        type: string
+        format: uuid4
+      created_at:
+        type: string
+        format: datetime
+      updated_at:
+        type: string
+        format: datetime
+
+  MaintainerPost:
+    description: >-
+      This data can be posted to create or update a maintainer.
+      The `uuid` field is only valid when being used to attach
+      a maintainer to a page, and if it is used, all other fields
+      are ignored.
+    type: object
+    properties:
+      uuid:
+        type: string
+        format: uuid4
+      name:
+        type: string
+      parent_uuid:
+        type: string
+        format: uuid4
+
+  SingleMaintainership:
+    type: object
+    properties:
+      links:
+        type: object
+        properties:
+          parent:
+            type: string
+            format: url
+          children:
+            type: string
+            format: url
+      data:
+        $ref: '#/definitions/Maintainership'
+
+  PageOfMaintainerships:
+    type: object
+    properties:
+      links:
+        type: object
+        properties:
+          first:
+            type: string
+            format: uri
+          last:
+            type: string
+            format: uri
+          prev:
+            type: string
+            format: uri
+          next:
+            type: string
+            format: uri
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Maintainership'
+
+  SingleMaintainer:
+    type: object
+    properties:
+      links:
+        type: object
+        properties:
+          parent:
+            type: string
+            format: url
+          children:
+            type: string
+            format: url
+      data:
+        $ref: '#/definitions/Maintainer'
+
+  PageOfMaintainers:
+    type: object
+    properties:
+      links:
+        type: object
+        properties:
+          first:
+            type: string
+            format: uri
+          last:
+            type: string
+            format: uri
+          prev:
+            type: string
+            format: uri
+          next:
+            type: string
+            format: uri
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Maintainer'
+
+  Tagging:
+    type: object
+    properties:
+      uuid:
+        type: string
+        format: uuid4
+      name:
+        type: string
+      assigned_at:
+        type: string
+        format: datetime
+
+  Tag:
+    type: object
+    properties:
+      uuid:
+        type: string
+        format: uuid4
+      name:
+        type: string
+      created_at:
+        type: string
+        format: datetime
+      updated_at:
+        type: string
+        format: datetime
+
+  TagPost:
+    description: >-
+      This data can be posted to create or update a tag.
+      The `uuid` field is only valid when being used to attach
+      a tag to a page, and if it is used, all other fields
+      are ignored.
+    type: object
+    properties:
+      uuid:
+        type: string
+        format: uuid4
+      name:
+        type: string
+
+  SingleTagging:
+    type: object
+    properties:
+      data:
+        $ref: '#/definitions/Tagging'
+
+  PageOfTaggings:
+    type: object
+    properties:
+      links:
+        type: object
+        properties:
+          first:
+            type: string
+            format: uri
+          last:
+            type: string
+            format: uri
+          prev:
+            type: string
+            format: uri
+          next:
+            type: string
+            format: uri
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Tagging'
+
+  SingleTag:
+    type: object
+    properties:
+      data:
+        $ref: '#/definitions/Tag'
+
+  PageOfTags:
+    type: object
+    properties:
+      links:
+        type: object
+        properties:
+          first:
+            type: string
+            format: uri
+          last:
+            type: string
+            format: uri
+          prev:
+            type: string
+            format: uri
+          next:
+            type: string
+            format: uri
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/Tag'
 
 externalDocs:
   description: Find out more about the web-monitoring project.

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -21,6 +21,72 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
       {
         page_url: 'http://testsite.com/',
         title: 'Example Page',
+        page_maintainers: ['The Federal Example Agency'],
+        page_tags: ['Example Site'],
+        capture_time: '2017-05-01T12:33:01Z',
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+        version_hash: 'f366e89639758cd7f75d21e5026c04fb1022853844ff471865004b3274059686',
+        source_type: 'some_source',
+        source_metadata: { test_meta: 'data' }
+      },
+      {
+        page_url: 'http://testsite.com/',
+        title: 'Example Page',
+        page_maintainers: ['The Federal Example Agency'],
+        page_tags: ['Test', 'Home Page'],
+        capture_time: '2017-05-02T12:33:01Z',
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v2',
+        version_hash: 'f366e89639758cd7f75d21e5026c04fb1022853844ff471865004b3274059687',
+        source_type: 'some_source',
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path,
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+    assert_response :success
+    body_json = JSON.parse(@response.body)
+    job_id = body_json['data']['id']
+    assert_equal 'pending', body_json['data']['status']
+
+    get api_v0_import_path(id: job_id)
+    body_json = JSON.parse(@response.body)
+    assert_equal 'complete', body_json['data']['status']
+    assert_equal 0, body_json['data']['processing_errors'].length
+
+    pages = Page.where(url: 'http://testsite.com/')
+    assert_equal 1, pages.length
+    assert_equal import_data[0][:title], pages[0].title
+
+    maintainer_names = pages[0].maintainers.pluck(:name).to_a
+    imported_maintainers = import_data.flat_map {|d| d[:page_maintainers]}
+    imported_maintainers.each do |name|
+      assert_includes(maintainer_names, name)
+    end
+
+    tag_names = pages[0].tags.pluck(:name).collect(&:downcase)
+    imported_tags = import_data.flat_map {|d| d[:page_tags]}
+    imported_tags.each do |name|
+      assert_includes(tag_names, name.downcase)
+    end
+
+    versions = pages[0].versions
+    assert_equal 2, versions.length
+  end
+
+  test 'can import data with deprecated `site_agency`, `site_name` fields' do
+    import_data = [
+      {
+        page_url: 'http://testsite.com/',
+        title: 'Example Page',
         site_agency: 'The Federal Example Agency',
         site_name: 'Example Site',
         capture_time: '2017-05-01T12:33:01Z',
@@ -65,8 +131,11 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
     pages = Page.where(url: 'http://testsite.com/')
     assert_equal 1, pages.length
     assert_equal import_data[0][:title], pages[0].title
-    assert_equal import_data[0][:site_agency], pages[0].agency
-    assert_equal import_data[0][:site_name], pages[0].site
+
+    maintainer_names = pages[0].maintainers.pluck(:name)
+    tag_names = pages[0].tags.pluck(:name).collect(&:downcase)
+    assert_includes(maintainer_names, 'The Federal Example Agency')
+    assert_includes(tag_names, 'site:example site')
 
     versions = pages[0].versions
     assert_equal 2, versions.length

--- a/test/controllers/api/v0/maintainers_controller_test.rb
+++ b/test/controllers/api/v0/maintainers_controller_test.rb
@@ -113,7 +113,8 @@ class Api::V0::MaintainersControllerTest < ActionDispatch::IntegrationTest
     maintainer_names = body['data'].pluck('name')
     assert_includes(
       maintainer_names,
-      'EPA','The maintainer was not added to the page maintainers list'
+      'EPA',
+      'The maintainer was not added to the page maintainers list'
     )
   end
 

--- a/test/controllers/api/v0/maintainers_controller_test.rb
+++ b/test/controllers/api/v0/maintainers_controller_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class Api::V0::MaintainersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'cannot list maintainers without auth' do
+    get api_v0_maintainers_path
+    assert_response :unauthorized
+  end
+
+  test 'can list maintainers' do
+    sign_in users(:alice)
+    get api_v0_maintainers_path
+    assert_response :success
+    assert_equal 'application/json', @response.content_type
+    body = JSON.parse @response.body
+
+    assert body.key?('links'), 'Response should have a "links" property'
+    assert body.key?('data'), 'Response should have a "data" property'
+    assert body.key?('meta'), 'Response should have a "meta" property'
+    assert_kind_of(Array, body['data'])
+
+    body['data'].each do |maintainer|
+      assert_includes(maintainer, 'uuid')
+      assert_includes(maintainer, 'name')
+      assert_includes(maintainer, 'parent_uuid')
+    end
+  end
+
+  test 'can get a single maintainer' do
+    sign_in users(:alice)
+    get api_v0_maintainer_path(maintainers(:someone))
+    assert_response :success
+    assert_equal 'application/json', @response.content_type
+    body = JSON.parse @response.body
+
+    assert body.key?('links'), 'Response should have a "links" property'
+    assert_includes(body['links'], 'parent', 'Maintainer should have a link to its parent')
+    assert_includes(body['links'], 'children', 'Maintainer should have a link to its children')
+    assert body.key?('data'), 'Response should have a "data" property'
+    assert_kind_of(Hash, body['data'])
+    assert_includes(body['data'], 'uuid')
+    assert_includes(body['data'], 'name')
+    assert_includes(body['data'], 'parent_uuid')
+  end
+
+  test "can list a page's maintainers" do
+    pages(:home_page).add_maintainer(maintainers(:someone))
+
+    sign_in users(:alice)
+    get api_v0_page_maintainers_path(pages(:home_page))
+    assert_response :success
+    body = JSON.parse @response.body
+
+    ids = body['data'].pluck('uuid')
+    assert_includes(ids, maintainers(:someone).uuid)
+
+    body['data'].each do |maintainer|
+      assert_includes(maintainer, 'uuid')
+      assert_includes(maintainer, 'name')
+      assert_includes(maintainer, 'parent_uuid')
+      assert_includes(maintainer, 'assigned_at')
+    end
+  end
+
+  test "can list maintainers by their parent" do
+    maintainers(:someone).update(parent: maintainers(:epa))
+
+    sign_in(users(:alice))
+    get(api_v0_maintainers_path(params: { parent: maintainers(:epa).uuid }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+
+    assert_equal(1, body['data'].length)
+    assert_equal(maintainers(:someone).uuid, body['data'][0]['uuid'])
+  end
+
+  test "can list a page's maintainers by their parent" do
+    maintainers(:someone).update(parent: maintainers(:epa))
+    pages(:home_page).add_maintainer(maintainers(:someone))
+    pages(:home_page).add_maintainer(maintainers(:doi))
+
+    sign_in(users(:alice))
+    get(api_v0_page_maintainers_path(
+      pages(:home_page),
+      params: { parent: maintainers(:epa).uuid })
+    )
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+
+    assert_equal(1, body['data'].length)
+    assert_equal(maintainers(:someone).uuid, body['data'][0]['uuid'])
+  end
+end

--- a/test/controllers/api/v0/maintainers_controller_test.rb
+++ b/test/controllers/api/v0/maintainers_controller_test.rb
@@ -63,7 +63,7 @@ class Api::V0::MaintainersControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "can list maintainers by their parent" do
+  test 'can list maintainers by their parent' do
     maintainers(:someone).update(parent: maintainers(:epa))
 
     sign_in(users(:alice))
@@ -81,9 +81,11 @@ class Api::V0::MaintainersControllerTest < ActionDispatch::IntegrationTest
     pages(:home_page).add_maintainer(maintainers(:doi))
 
     sign_in(users(:alice))
-    get(api_v0_page_maintainers_path(
-      pages(:home_page),
-      params: { parent: maintainers(:epa).uuid })
+    get(
+      api_v0_page_maintainers_path(
+        pages(:home_page),
+        params: { parent: maintainers(:epa).uuid }
+      )
     )
     assert_response(:success)
     body = JSON.parse(@response.body)

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -418,4 +418,26 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal(page.maintainers.first.uuid, maintainers.first['uuid'])
     assert_equal(page.maintainers.first.name, maintainers.first['name'])
   end
+
+  test 'includes tags in list response' do
+    sign_in users(:alice)
+    get api_v0_pages_path
+    assert_response :success
+    result = JSON.parse(@response.body)['data']
+    result.each do |page|
+      assert_kind_of(Array, page['tags'])
+      actual_page = Page.find(page['uuid'])
+      assert_equal(actual_page.tags.count, page['tags'].length)
+    end
+  end
+
+  test 'includes tags in single page response' do
+    page = pages(:dot_home_page)
+
+    sign_in users(:alice)
+    get api_v0_page_path(page)
+    assert_response :success
+    body = JSON.parse @response.body
+    assert_kind_of(Array, body['data']['tags'])
+  end
 end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -418,6 +418,10 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal(page.maintainers.count, maintainers.length)
     assert_equal(page.maintainers.first.uuid, maintainers.first['uuid'])
     assert_equal(page.maintainers.first.name, maintainers.first['name'])
+    assert_equal(
+      page.maintainerships.first.created_at.iso8601,
+      maintainers.first['assigned_at'].sub(/\.\d+/, '')
+    )
   end
 
   test 'includes tags in list response' do
@@ -434,12 +438,22 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
 
   test 'includes tags in single page response' do
     page = pages(:dot_home_page)
+    page.add_tag(tags(:listing_page))
 
     sign_in users(:alice)
     get api_v0_page_path(page)
     assert_response :success
     body = JSON.parse @response.body
     assert_kind_of(Array, body['data']['tags'])
+
+    tags = body['data']['tags']
+    assert_equal(page.tags.count, tags.length)
+    assert_equal(page.tags.first.uuid, tags.first['uuid'])
+    assert_equal(page.tags.first.name, tags.first['name'])
+    assert_equal(
+      page.taggings.first.created_at.iso8601,
+      tags.first['assigned_at'].sub(/\.\d+/, '')
+    )
   end
 
   test 'can filter by tags' do

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -402,6 +402,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     dot_home = result.find {|page| page['uuid'] == pages(:dot_home_page).uuid}
     assert_includes(dot_home['maintainers'].first, 'uuid')
     assert_includes(dot_home['maintainers'].first, 'name')
+    assert_includes(dot_home['maintainers'].first, 'assigned_at')
   end
 
   test 'includes maintainers in single page response' do
@@ -425,6 +426,8 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes tags in list response' do
+    pages(:dot_home_page).add_tag(tags(:site_whatever))
+
     sign_in users(:alice)
     get api_v0_pages_path
     assert_response :success

--- a/test/controllers/api/v0/tags_controller_test.rb
+++ b/test/controllers/api/v0/tags_controller_test.rb
@@ -56,4 +56,99 @@ class Api::V0::TagsControllerTest < ActionDispatch::IntegrationTest
       assert_includes(tag, 'assigned_at')
     end
   end
+
+  test 'can add a tag to a page' do
+    sign_in users(:alice)
+    post(
+      api_v0_page_tags_path(pages(:home_page)),
+      as: :json,
+      params: { name: 'Page of wonderment' }
+    )
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_equal('Page of wonderment', body['data']['name'])
+
+    get(api_v0_page_tags_path(pages(:home_page)))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    tag_names = body['data'].pluck('name')
+    assert_includes(tag_names, 'Page of wonderment', 'The tag was not added to the page tags list')
+  end
+
+  test 'can add a tag to a page by UUID' do
+    sign_in users(:alice)
+    post(
+      api_v0_page_tags_path(pages(:home_page)),
+      as: :json,
+      params: { uuid: tags(:site_whatever).uuid }
+    )
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_equal('site:whatever', body['data']['name'])
+
+    get(api_v0_page_tags_path(pages(:home_page)))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    tag_ids = body['data'].pluck('uuid')
+    assert_includes(
+      tag_ids,
+      tags(:site_whatever).uuid,
+      'The tag was not added to the page tags list'
+    )
+  end
+
+  test 'can create a tag' do
+    sign_in users(:alice)
+    post(
+      api_v0_tags_path,
+      as: :json,
+      params: { name: 'Page of wonderment' }
+    )
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_equal('Page of wonderment', body['data']['name'])
+
+    get(api_v0_tags_path)
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    tag_names = body['data'].pluck('name')
+    assert_includes(tag_names, 'Page of wonderment', 'The tag was not added to the tags list')
+  end
+
+  test 'cannot add a tag with no name or UUID to a page' do
+    sign_in users(:alice)
+    post(
+      api_v0_page_tags_path(pages(:home_page)),
+      as: :json,
+      params: { xyz: 'Page of wonderment' }
+    )
+    assert_response(:bad_request)
+  end
+
+  test 'can edit a tag' do
+    sign_in users(:alice)
+    patch(
+      api_v0_tag_path(tags(:site_whatever)),
+      as: :json,
+      params: { name: 'site:wherever' }
+    )
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_equal('site:wherever', body['data']['name'])
+  end
+
+  test 'can delete a tag from a page' do
+    pages(:home_page).add_tag(tags(:site_whatever))
+
+    sign_in users(:alice)
+    delete(api_v0_page_tag_path(pages(:home_page), tags(:site_whatever)))
+    assert_response(:redirect)
+    follow_redirect!
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+
+    assert_kind_of(Array, body['data'], 'A list of tags was not returned')
+    tag_names = body['data'].pluck('name')
+    assert_not_includes(tag_names, 'site:whatever', 'The tag was not removed from the page')
+  end
 end

--- a/test/controllers/api/v0/tags_controller_test.rb
+++ b/test/controllers/api/v0/tags_controller_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class Api::V0::TagsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'cannot list tags without auth' do
+    get api_v0_tags_path
+    assert_response :unauthorized
+  end
+
+  test 'can list tags' do
+    sign_in users(:alice)
+    get api_v0_tags_path
+    assert_response :success
+    assert_equal 'application/json', @response.content_type
+    body = JSON.parse @response.body
+
+    assert body.key?('links'), 'Response should have a "links" property'
+    assert body.key?('data'), 'Response should have a "data" property'
+    assert body.key?('meta'), 'Response should have a "meta" property'
+    assert_kind_of(Array, body['data'])
+
+    body['data'].each do |tag|
+      assert_includes(tag, 'uuid')
+      assert_includes(tag, 'name')
+    end
+  end
+
+  test 'can get a single tag' do
+    sign_in users(:alice)
+    get api_v0_tag_path(tags(:frequently_updated))
+    assert_response :success
+    assert_equal 'application/json', @response.content_type
+    body = JSON.parse @response.body
+
+    assert body.key?('data'), 'Response should have a "data" property'
+    assert_kind_of(Hash, body['data'])
+    assert_includes(body['data'], 'uuid')
+    assert_includes(body['data'], 'name')
+  end
+
+  test "can list a page's tags" do
+    pages(:home_page).add_tag(tags(:frequently_updated))
+
+    sign_in users(:alice)
+    get api_v0_page_tags_path(pages(:home_page))
+    assert_response :success
+    body = JSON.parse @response.body
+
+    ids = body['data'].pluck('uuid')
+    assert_includes(ids, tags(:frequently_updated).uuid)
+
+    body['data'].each do |tag|
+      assert_includes(tag, 'uuid')
+      assert_includes(tag, 'name')
+      assert_includes(tag, 'assigned_at')
+    end
+  end
+end

--- a/test/fixtures/maintainers.yml
+++ b/test/fixtures/maintainers.yml
@@ -3,3 +3,6 @@ epa:
 
 doi:
   name: DOI
+
+someone:
+  name: Someone

--- a/test/fixtures/maintainers.yml
+++ b/test/fixtures/maintainers.yml
@@ -1,0 +1,5 @@
+epa:
+  name: EPA
+
+doi:
+  name: DOI

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,11 @@
+site_whatever:
+  name: 'site:whatever'
+
+listing_page:
+  name: 'Listing Page'
+
+frequently_updated:
+  name: 'Frequently Updated'
+
+home_page:
+  name: 'Home Page'

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -111,6 +111,7 @@ class PageTest < ActiveSupport::TestCase
     pages(:home_page_site2).add_tag('frequently updated')
     assert_equal(
       ['Listing Page', 'Frequently Updated'],
-      pages(:home_page_site2).tag_names)
+      pages(:home_page_site2).tag_names
+    )
   end
 end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -67,4 +67,50 @@ class PageTest < ActiveSupport::TestCase
 
     assert_equal(1, pages(:home_page).maintainers.count)
   end
+
+  test 'can add many tags to a page' do
+    pages(:home_page).add_tag(tags(:listing_page))
+    pages(:home_page).add_tag(tags(:frequently_updated))
+    assert pages(:home_page).tags.find(tags(:listing_page).uuid)
+    assert pages(:home_page).tags.find(tags(:frequently_updated).uuid)
+  end
+
+  test 'can add a tag to a page by name' do
+    pages(:home_page).add_tag('Listing Page')
+    assert pages(:home_page).tags.find(tags(:listing_page).uuid)
+  end
+
+  test 'can add a tag case-insensitively' do
+    pages(:home_page).add_tag('lIStinG page')
+    assert pages(:home_page).tags.find(tags(:listing_page).uuid)
+  end
+
+  test 'adding an unknown tag to a page creates that tag' do
+    pages(:home_page).add_tag('Unicorns and rainbows')
+    unicorns = Tag.find_by!(name: 'Unicorns and rainbows')
+    assert pages(:home_page).tags.include?(unicorns)
+  end
+
+  test 'adding a tag repeatedly to a page does not cause errors or duplicates' do
+    pages(:home_page_site2).add_tag('listing page')
+    pages(:home_page_site2).add_tag(tags(:listing_page))
+
+    assert_equal(1, pages(:home_page_site2).tags.count)
+  end
+
+  test 'a page can be untagged' do
+    pages(:home_page_site2).add_tag('listing page')
+    assert_equal(1, pages(:home_page_site2).tags.count)
+
+    pages(:home_page_site2).untag('Listing Page')
+    assert_equal(0, pages(:home_page_site2).tags.count)
+  end
+
+  test 'can list the names of tags' do
+    pages(:home_page_site2).add_tag('listing page')
+    pages(:home_page_site2).add_tag('frequently updated')
+    assert_equal(
+      ['Listing Page', 'Frequently Updated'],
+      pages(:home_page_site2).tag_names)
+  end
 end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -37,4 +37,34 @@ class PageTest < ActiveSupport::TestCase
     refute(page.changed?, 'The page was left with unsaved changes')
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has an empty title')
   end
+
+  test 'can add many maintainer models to a page' do
+    pages(:home_page).add_maintainer(maintainers(:epa))
+    pages(:home_page).add_maintainer(maintainers(:doi))
+    assert pages(:home_page).maintainers.find(maintainers(:epa).uuid)
+    assert pages(:home_page).maintainers.find(maintainers(:doi).uuid)
+  end
+
+  test 'can add a maintainer to a page by name' do
+    pages(:home_page).add_maintainer('EPA')
+    assert pages(:home_page).maintainers.find(maintainers(:epa).uuid)
+  end
+
+  test 'can add a maintainer case-insensitively' do
+    pages(:home_page).add_maintainer('ePa')
+    assert pages(:home_page).maintainers.find(maintainers(:epa).uuid)
+  end
+
+  test 'adding an unknown maintainer to a page creates that maintainer' do
+    pages(:home_page).add_maintainer('Department of Unicorns')
+    unicorns = Maintainer.find_by!(name: 'Department of Unicorns')
+    assert pages(:home_page).maintainers.include?(unicorns)
+  end
+
+  test 'adding a maintainer repeatedly to a page does not cause errors or duplicates' do
+    pages(:home_page).add_maintainer('EPA')
+    pages(:home_page).add_maintainer(maintainers(:epa))
+
+    assert_equal(1, pages(:home_page).maintainers.count)
+  end
 end


### PR DESCRIPTION
~**Work in progress; do not merge!**~

Fixes #24.

Replace the `agency` field on `Page` models with an N:M relationship to a new `Maintainer` model; replace the `site` field on `Page` models with an N:M relationship to a new `Tag` model.

- [x] Add `Maintainer`
- [x] Add `Tag`
- [x] Show page maintainers and tags in API
- [x] Make maintainers and tags queryable in pages API
- [x] Populate maintainers and tags during import
- [x] Copy existing site/agency data to new maintainer/tag models
- [x] Merge existing pages that are currently duplicated as a result of multiple sites or agencies
- [x] Add routes to list maintainers and tags:
    - [x] `GET /maintainers`
    - [x] `GET /maintainers/{uuid|name}`
    - [x] `PATCH|POST /maintainers/{uuid|name}`
    - [x] `GET /pages/{uuid}/maintainers`
    - [x] `POST /pages/{uuid}/maintainers`
    - [x] `GET /tags`
    - [x] `GET /tags/{uuid|name}`
    - [x] `PATCH|POST /tags/{uuid|name}`
    - [x] `GET /pages/{uuid}/tags`
    - [x] `POST /pages/{uuid}/tags`
- [x] Document new schemas, query params, and routes

Note: this PR intentionally leaves the old `site` and `agency` fields in place so as not to break existing clients. We’ll remove them later when we’re confident most clients are working in terms of maintainers/tags.

OK! This is most of the way done now, so I think it’s ready for feedback on whether this looks right. Some questions/things I’d really like feedback on here:

1. Do we need all the extra routes for listing/renaming/adding maintainers and tags as above?

2. Tag names are *not* case-sensitive (for querying, that is; the response shows the case they were originally set in), but maintainer names are. This made sense to me when I wrote it, but in hindsight, I’m not so sure.

3. Unlike versions, the page listing *always* includes associated maintainers and tags. I *think* that’s OK because we probably don’t expect there to be a lot of them, but who knows, that could be a terrible assumption.

4. Maintainers and tags are each exposed on page records as the full serialization of their object, e.g:

    ```js
    {
      /* page fields here */
      "maintainers": [
        {
          "uuid": "191da223-428f-44c7-9411-ef102c87b465",
          "name": "NASA",
          "parent_uuid": null,
          "created_at": "2018-02-07T06:22:43Z",
          "updated_at": "2018-02-07T06:22:43Z"
        }
      ],
      "tags": [
        {
          "uuid": "2ab826bb-99de-496d-bf5c-4f9e669c1522",
          "name": "site:NASA - science.nasa.gov - Earth Science",
          "created_at": "2018-02-07T06:22:43Z",
          "updated_at": "2018-02-07T06:22:43Z"
        }
      ]
    }
    ```

    Is that right? Should we just expose UUIDs or names? (e.g. `{maintainers: ["191da223-428f-44c7-9411-ef102c87b465"]}` or `{maintainers: ["NASA"]}`) (Is the right answer here different for maintainers and tags?)

    We could also expose a simplified list of names or UUIDs when attached to a page, but expose the full object when requesting `GET /pages/{uuid}/maintainers` / `GET /pages/{uuid}/tags`.

5. Related to (4), the association between pages and tags has one extra piece of metadata: the time it was created. Should tag records on pages be a wholly separate thing like:

    ```js
    {
      /* page fields here */
      "tags": [
        {
          "uuid": "2ab826bb-99de-496d-bf5c-4f9e669c1522",
          "name": "site:NASA - science.nasa.gov - Earth Science",
          "tagged_at": "2018-02-07T07:22:43Z"
        }
      ]
    }
    ```

    Note the `tagged_at` instead of `created_at`, implying this is the time the tag was added *to this page,* not the time the tag was first created.

6. Filtering: these are the first 1:N relation we have that’s queryable by some unique identifier (versions we only support filtering in ways that are non-unique). I’ve leaned on the standard way Rails does arrays in the querystring, so if you’re filtering by tags, it looks like:

    ```
    ?tags[]=tag1&tags[]=tag2

    # Basically the same for filtering by a single tag
    ?tags[]=tag1

    # Same pattern for maintainers
    ?maintainers[]=NASA&maintainers[]=DOE
    ```

    These lists are also OR (union) lists. So the above query gets all pages tagged with `tag1` and all pages tagged with `tag2`. It does *not* get you only the pages that are tagged with *both.*

    Is that right? Should we flip it to be AND (more complicated to implement, but I think doable)? Should we have some crazy complicated thing where you can do both, e.g:

    ```
    # Pages with: (tag1 AND tag2) OR (tag3 AND tag4)
    ?tags[]=tag1,tag2&tags[]=tag3,tag4
    ```

    My gut tells me this is getting overcomplicated for now.

7. Maintainers and tags both use UUIDs. At this point, I feel like the few places I used numeric IDs make things confusing, so I decided not to do that here, even though they don’t remotely have the constraints around quantity of values or ability to create an ID without already knowing what’s in the DB that pages and versions do.

/cc @danielballan 