### PR TITLE
Remove references to *.herokuapp.com domain

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
 
   # Action Mailer configuration
   config.action_mailer.default_url_options = {
-    host: ENV.fetch('HOST_URL', 'web-monitoring-db.herokuapp.com')
+    host: ENV.fetch('HOST_URL', 'api.monitoring.envirodatagov.org')
   }
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -9,7 +9,7 @@ info:
     name: GPL 3
     url: >-
       https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/master/LICENSE
-host: web-monitoring-db.herokuapp.com
+host: api.monitoring.envirodatagov.org
 basePath: /api/v0
 tags:
   - name: pages and versions


### PR DESCRIPTION
Our canonical names are all `*.monitoring.envirodatagov.org`. We need to actually be able to turn the Heroku stuff off, and to do that, all our examples and default values should point to the domain name we actually own and manage.