### PR TITLE
Add sorting via `?sort=` query parameter

### DIFF
--- a/app/controllers/api/v0/annotations_controller.rb
+++ b/app/controllers/api/v0/annotations_controller.rb
@@ -1,9 +1,11 @@
 class Api::V0::AnnotationsController < Api::V0::ApiController
+  include SortingConcern
   before_action :set_annotation, only: [:show]
 
   def index
-    paging = pagination(parent_change.annotations)
-    annotations = parent_change.annotations.limit(paging[:chunk_size]).offset(paging[:offset])
+    annotations = sort_using_params(parent_change.annotations)
+    paging = pagination(annotations)
+    annotations = annotations.limit(paging[:chunk_size]).offset(paging[:offset])
 
     render json: {
       links: paging[:links],

--- a/app/controllers/api/v0/changes_controller.rb
+++ b/app/controllers/api/v0/changes_controller.rb
@@ -1,4 +1,6 @@
 class Api::V0::ChangesController < Api::V0::ApiController
+  include SortingConcern
+
   def index
     query = changes_collection
     paging = pagination(query)
@@ -42,9 +44,9 @@ class Api::V0::ChangesController < Api::V0::ApiController
   end
 
   def changes_collection
-    collection = Change
+    collection = Change.order(created_at: :asc)
     collection = where_in_interval_param(collection, :priority)
     collection = where_in_interval_param(collection, :significance)
-    collection
+    sort_using_params(collection)
   end
 end

--- a/app/controllers/api/v0/maintainers_controller.rb
+++ b/app/controllers/api/v0/maintainers_controller.rb
@@ -1,4 +1,6 @@
 class Api::V0::MaintainersController < Api::V0::ApiController
+  include SortingConcern
+
   def index
     query = maintainer_collection
     paging = pagination(query)
@@ -101,6 +103,7 @@ class Api::V0::MaintainersController < Api::V0::ApiController
         end
     end
 
-    collection.order(created_at: :asc)
+    collection = collection.order(created_at: :asc)
+    sort_using_params(collection)
   end
 end

--- a/app/controllers/api/v0/tags_controller.rb
+++ b/app/controllers/api/v0/tags_controller.rb
@@ -1,4 +1,6 @@
 class Api::V0::TagsController < Api::V0::ApiController
+  include SortingConcern
+
   def index
     query = tag_collection
     paging = pagination(query)
@@ -68,6 +70,7 @@ class Api::V0::TagsController < Api::V0::ApiController
 
   def tag_collection
     collection = page ? page.taggings.joins(:tag) : Tag
-    collection.order(created_at: :asc)
+    collection = collection.order(created_at: :asc)
+    sort_using_params(collection)
   end
 end

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -1,4 +1,6 @@
 class Api::V0::VersionsController < Api::V0::ApiController
+  include SortingConcern
+
   def index
     query = version_collection
     paging = pagination(query)
@@ -87,7 +89,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
   end
 
   def version_collection
-    collection = page && page.versions || Version
+    collection = page && page.versions || Version.order(created_at: :asc)
 
     collection = collection.where({
       version_hash: params[:hash],
@@ -100,6 +102,8 @@ class Api::V0::VersionsController < Api::V0::ApiController
       end
     end
 
-    where_in_range_param(collection, :capture_time, &method(:parse_date!))
+    collection = where_in_range_param(collection, :capture_time, &method(:parse_date!))
+
+    sort_using_params(collection)
   end
 end

--- a/app/controllers/concerns/sorting_concern.rb
+++ b/app/controllers/concerns/sorting_concern.rb
@@ -1,0 +1,42 @@
+module SortingConcern
+  extend ActiveSupport::Concern
+
+  protected
+
+  def sorting_params
+    raw = params[:sort] || ''
+    raw.split(',').collect(&method(:sql_order_for_param))
+  end
+
+  def sql_order_for_param(param)
+    field, direction = param.split(':')
+    { sanitize_field_name!(field) => sanitize_direction!(direction) }
+    # "#{sanitize_field_name!(field)} #{sanitize_direction!(direction)}"
+  end
+
+  def sanitize_field_name!(field)
+    sanitized = field.strip
+    unless sanitized.match?(/^\w+$/)
+      raise Api::InputError, "'#{field}' is not a valid attribute name for sorting"
+    end
+    sanitized.to_sym
+  end
+
+  def sanitize_direction!(direction)
+    direction = 'asc' if direction.blank?
+    sanitized = direction.strip.downcase
+    unless ['asc', 'desc'].include?(sanitized)
+      raise Api::InputError, "'#{direction}' is not a valid sort direction. It must be either 'asc' or 'desc'"
+    end
+    sanitized.to_sym
+  end
+
+  def sort_using_params(collection)
+    sort = sorting_params
+    if sort.present?
+      collection.reorder(sort)
+    else
+      collection
+    end
+  end
+end

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -20,6 +20,19 @@ tags:
     description: Bulk-importing Versions
 schemes:
   - https
+
+parameters:
+  sort:
+    name: sort
+    in: query
+    required: false
+    type: string
+    description: >
+      Sort the results. This should be a comma-separated list of sort
+      values, where each value is in the form `field:order`, e.g.
+      `title:asc,url:desc`. You can sort by any field on the result
+      objects.
+
 paths:
   /pages:
     get:
@@ -44,6 +57,7 @@ paths:
           required: false
           type: integer
           default: 100
+        - $ref: '#/parameters/sort'
         - name: site
           in: query
           description: Filter results by site.
@@ -198,6 +212,7 @@ paths:
           required: false
           type: integer
           default: 100
+        - $ref: '#/parameters/sort'
         - name: capture_time
           in: query
           description: >-
@@ -332,6 +347,7 @@ paths:
           required: false
           type: integer
           default: 1
+        - $ref: '#/parameters/sort'
         - name: chunk_size
           in: query
           description: number of items per chunk
@@ -418,6 +434,7 @@ paths:
           required: true
           type: string
           format: uuid4
+        - $ref: '#/parameters/sort'
       responses:
         '200':
           description: successful operation
@@ -622,6 +639,7 @@ paths:
           required: false
           type: integer
           default: 100
+        - $ref: '#/parameters/sort'
         - name: parent
           in: query
           description: >-
@@ -751,6 +769,7 @@ paths:
           required: false
           type: integer
           default: 100
+        - $ref: '#/parameters/sort'
       responses:
         '200':
           description: successful operation
@@ -867,6 +886,7 @@ paths:
           required: false
           type: integer
           default: 100
+        - $ref: '#/parameters/sort'
         - name: capture_time
           in: query
           description: >-
@@ -1000,6 +1020,7 @@ paths:
           required: false
           type: integer
           default: 100
+        - $ref: '#/parameters/sort'
         - name: parent
           in: query
           description: >-
@@ -1121,6 +1142,7 @@ paths:
           required: false
           type: integer
           default: 100
+        - $ref: '#/parameters/sort'
       responses:
         '200':
           description: successful operation

--- a/test/controllers/api/v0/annotations_controller_test.rb
+++ b/test/controllers/api/v0/annotations_controller_test.rb
@@ -214,4 +214,39 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
       'Should contain the count of total results across all pages'
     )
   end
+
+  test 'can order annotations with `?sort=field:direction`' do
+    sign_in users(:alice)
+    page = pages(:home_page)
+    annotations(:annotation1).touch
+    get(
+      api_v0_page_change_annotations_url(
+        page,
+        changes(:page1_change_1_2),
+        params: { sort: 'updated_at:asc' }
+      )
+    )
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_ordered_by(
+      body['data'],
+      [['updated_at']],
+      name: 'Annotations'
+    )
+
+    get(
+      api_v0_page_change_annotations_url(
+        page,
+        changes(:page1_change_1_2),
+        params: { sort: 'updated_at:desc' }
+      )
+    )
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_ordered_by(
+      body['data'],
+      [['updated_at', 'desc']],
+      name: 'Annotations'
+    )
+  end
 end

--- a/test/controllers/api/v0/changes_controller_test.rb
+++ b/test/controllers/api/v0/changes_controller_test.rb
@@ -128,4 +128,36 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
       'Should contain count of total results across all pages'
     )
   end
+
+  test 'can order changes with `?sort=field:direction`' do
+    sign_in users(:alice)
+    page = pages(:home_page)
+    get(
+      api_v0_page_changes_url(
+        page,
+        params: { sort: 'priority:asc,significance:asc' }
+      )
+    )
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_ordered_by(
+      body['data'],
+      [['priority'], ['significance']],
+      name: 'Changes'
+    )
+
+    get(
+      api_v0_page_changes_url(
+        page,
+        params: { sort: 'priority:desc,significance:desc' }
+      )
+    )
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_ordered_by(
+      body['data'],
+      [['priority', 'desc'], ['significance', 'desc']],
+      name: 'Changes'
+    )
+  end
 end

--- a/test/controllers/api/v0/maintainers_controller_test.rb
+++ b/test/controllers/api/v0/maintainers_controller_test.rb
@@ -234,4 +234,25 @@ class Api::V0::MaintainersControllerTest < ActionDispatch::IntegrationTest
     maintainer_names = body['data'].pluck('name')
     assert_not_includes(maintainer_names, 'EPA', 'The maintainer was not removed from the page')
   end
+
+  test 'can order maintainers with `?sort=field:direction`' do
+    sign_in users(:alice)
+    get(api_v0_maintainers_url(params: { sort: 'name:asc' }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_ordered_by(
+      body['data'],
+      [['name']],
+      name: 'Maintainers'
+    )
+
+    get(api_v0_maintainers_url(params: { sort: 'name:desc' }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_ordered_by(
+      body['data'],
+      [['name', 'desc']],
+      name: 'Maintainers'
+    )
+  end
 end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -541,4 +541,59 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     })
     assert_response :success
   end
+
+  test 'can order pages with `?sort=field:direction,field:direction`' do
+    sign_in users(:alice)
+    get(api_v0_pages_url(params: { sort: 'title:asc, url:asc' }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+
+    assert_ordered_by(
+      body['data'],
+      [['title'], ['url']],
+      name: 'Pages'
+    )
+
+    get(api_v0_pages_url(params: { sort: 'title:desc, url:desc' }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+
+    assert_ordered_by(
+      body['data'],
+      [['title', 'desc'], ['url', 'desc']],
+      name: 'Pages'
+    )
+  end
+
+  test 'can order pages with latest with `?sort=field:direction`' do
+    sign_in users(:alice)
+    get(api_v0_pages_url(params: {
+      include_latest: true,
+      sort: 'title:asc, url:asc'
+    }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+
+    assert_ordered_by(
+      body['data'],
+      [['title'], ['url']],
+      name: 'Pages'
+    )
+  end
+
+  test 'can order pages with versions with `?sort=field:direction`' do
+    sign_in users(:alice)
+    get(api_v0_pages_url(params: {
+      include_versions: true,
+      sort: 'title:asc, url:asc'
+    }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+
+    assert_ordered_by(
+      body['data'],
+      [['title'], ['url']],
+      name: 'Pages'
+    )
+  end
 end

--- a/test/controllers/api/v0/tags_controller_test.rb
+++ b/test/controllers/api/v0/tags_controller_test.rb
@@ -151,4 +151,25 @@ class Api::V0::TagsControllerTest < ActionDispatch::IntegrationTest
     tag_names = body['data'].pluck('name')
     assert_not_includes(tag_names, 'site:whatever', 'The tag was not removed from the page')
   end
+
+  test 'can order tags with `?sort=field:direction`' do
+    sign_in users(:alice)
+    get(api_v0_tags_url(params: { sort: 'name:asc' }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_ordered_by(
+      body['data'],
+      [['name']],
+      name: 'Tags'
+    )
+
+    get(api_v0_tags_url(params: { sort: 'name:desc' }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_ordered_by(
+      body['data'],
+      [['name', 'desc']],
+      name: 'Tags'
+    )
+  end
 end

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -204,4 +204,20 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
       'Should contain the total number of versions mathcing the query for the page'
     )
   end
+
+  test 'can order versions with `?sort=field:direction,field:direction`' do
+    sign_in users(:alice)
+    get(
+      api_v0_versions_url(
+        params: { sort: 'source_type:asc, capture_time:asc' }
+      )
+    )
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert_ordered_by(
+      body['data'],
+      [['source_type'], ['capture_time']],
+      name: 'Versions'
+    )
+  end
 end

--- a/test/fixtures/changes.yml
+++ b/test/fixtures/changes.yml
@@ -9,3 +9,9 @@ page1_change_2_3:
   version: page1_v3
   priority: 0.5
   significance: 0.5
+
+page1_change_4_5:
+  from_version: page1_v4
+  version: page1_v5
+  priority: 0.75
+  significance: 0.5

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -21,3 +21,9 @@ dot_home_page:
   title: 'Welcome to the Department of Testing'
   agency: 'Department of Testing'
   site: 'DOT - Home Site'
+
+other_page_one:
+  url: 'http://example3.com/'
+  title: 'Page One'
+  agency: 'Department of Whatever'
+  site: 'http://example3.com/'

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -25,7 +25,7 @@ page1_v1:
 page2_v1:
   page: sub_page
   uri: 'http://example.com/page2_v1'
-  capture_time: '2017-03-01T00:00:00Z'
+  capture_time: '2017-03-01T00:00:01Z'
   version_hash: 'def'
   source_type: 'versionista'
   source_metadata: {
@@ -61,7 +61,7 @@ page1_v2:
 page2_v2:
   page: sub_page
   uri: 'http://example.com/page2_v2'
-  capture_time: '2017-03-02T00:00:00Z'
+  capture_time: '2017-03-02T00:00:01Z'
   version_hash: 'jkl'
   source_type: 'versionista'
   source_metadata: {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,4 +13,20 @@ class ActiveSupport::TestCase
     sorted = sorted.reverse if reverse
     assert_equal(sorted, list, "#{name} were not in order: #{list}")
   end
+
+  def assert_ordered_by(list, orderings, name: 'Items')
+    sorted = list.sort do |a, b|
+      result = 0
+      orderings.each do |ordering|
+        result = a[ordering[0]] <=> b[ordering[0]]
+        unless result.zero?
+          result *= -1 if ordering[1] && ordering[1].casecmp?('desc')
+          break
+        end
+      end
+      result
+    end
+
+    assert_equal(sorted, list, "#{name} were not in ordered by: #{orderings}")
+  end
 end


### PR DESCRIPTION
Fixes #165.

The overall approach here is inspired by @tylerferraro’s original PR from a few months ago. This adds sorting to all list requests with a `?sort=field:order,field:order,...` query parameter. For example:

```
GET /api/v0/pages?sort=title:asc,updated_at:desc
```

Sorting happens in order, so results are sorted by the first field, then, only if that field is equal, by the second field, and so on.

Open questions:

1. Is `sort` the right name here? (vs. `order`? or something else?)
2. Is comma-separated the right thing, or should this be `?sort[]=title:asc&sort[]=updated_at:desc`?
3. Is `field:order` the right way to go here? Seems like that sounded best to everyone earlier on.