### PR TITLE
HOTFIX: querying by capture_time + source_type/hash

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -102,7 +102,7 @@ class Api::V0::PagesController < Api::V0::ApiController
 
     version_params = params.permit(:hash, :source_type)
     if version_params.present?
-      collection = collection.left_outer_joins(:versions).where(versions: {
+      collection = collection.joins(:versions).where(versions: {
         version_hash: params[:hash],
         source_type: params[:source_type]
       }.compact)

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -532,4 +532,13 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal(3, body['meta']['total_results'])
     assert_equal(3, body['data'].length)
   end
+
+  test 'can query pages by capture time and source type together' do
+    sign_in users(:alice)
+    get api_v0_pages_path(params: {
+      capture_time: '2017-03-01T00:00:00Z..2017-03-01T12:00:00Z',
+      source_type: 'versionista'
+    })
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Querying by capture_time in combination with other version parameters (`hash`, `source_type`) was broken in the maintainers update. In addition, I'm not sure why I flipped it to a left_outer_joins in the first place, which is clearly the wrong join for this particular query. I think this must have been a mistaken thing that got committed when I was trying to get all the various query params to work happily together.