### PR TITLE
Canonical, SURTified Page URLs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ AllCops:
 Metrics/ClassLength:
   Enabled: false
 
+Metrics/ModuleLength:
+  Enabled: false
+
 Metrics/ParameterLists:
   Exclude:
     - 'lib/versionista_service/*'
@@ -25,6 +28,7 @@ Metrics/CyclomaticComplexity:
   Max: 12
   Exclude:
     - 'app/controllers/api/v0/pages_controller.rb'
+    - 'app/lib/surt/canonicalize.rb'
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
@@ -36,6 +40,10 @@ Style/ClassAndModuleChildren:
   Enabled: false
 
 Layout/EmptyLines:
+  Enabled: false
+
+# This was mostly all false positives.
+Style/FormatStringToken:
   Enabled: false
 
 Style/GuardClause:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,6 +47,7 @@ Metrics/PerceivedComplexity:
   Max: 12
   Exclude:
     - 'app/controllers/api/v0/pages_controller.rb'
+    - 'app/lib/surt/canonicalize.rb'
 
 # Offense count: 7
 # Cop supports --auto-correct.

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'sentry-raven'
 gem 'readthis'
 gem 'hiredis'
 gem 'google-api-client'
+gem 'addressable', '~> 2.5'
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (~> 2.5)
   aws-sdk-s3 (~> 1.8)
   byebug
   devise

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
+release: bundle exec rake db:migrate
 web: bundle exec rails server -p $PORT
 worker: QUEUE=* VERBOSE=1 bundle exec rake environment resque:work

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -81,6 +81,7 @@ class ImportVersionsJob < ApplicationJob
     # TODO: Remove line 74 below once full transition from 'page_title' to 'title'
     # is complete
     record['title'] = record['page_title'] if record.key?('page_title')
+    record['capture_url'] = record['page_url'] if record.key?('page_url')
     disallowed = ['id', 'uuid', 'created_at', 'updated_at']
     allowed = Version.attribute_names - disallowed
 

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -112,8 +112,8 @@ class ImportVersionsJob < ApplicationJob
     validate_kind!([Array, NilClass], record, 'page_maintainers')
     validate_kind!([Array, NilClass], record, 'page_tags')
 
-    record_url = Page.normalize_url(record['page_url'])
-    page = Page.find_or_create_by(url: record_url)
+    url = record['page_url']
+    page = Page.find_by_url(url) || Page.create(url: url)
 
     (record['page_maintainers'] || []).each {|name| page.add_maintainer(name)}
     page.add_maintainer(record['site_agency']) if record.key?('site_agency')

--- a/app/lib/surt.rb
+++ b/app/lib/surt.rb
@@ -1,19 +1,37 @@
 require 'addressable/uri'
 
+# Tools for canonicalizing and formatting URLs according to the Internet
+# Archive's "Sort-friendly URI Reordering Transform" (SURT) format:
+# http://crawler.archive.org/articles/user_manual/glossary.html#surt
+#
+# For example:
+#
+#     URL:  https://energy.gov/eere/sunshot/downloads/
+#     SURT: gov,energy)/eere/sunshot/downloads
+#
+# The implementations primarily live in submodules (Canonicalize and Format),
+# while the methods here serve as public entry points. See each implementation
+# module for a list of options and default values (at the top of each module).
+#
+# Code in the submodules is generally based on the Internet Archive's Python
+# SURT module: https://github.com/internetarchive/surt
+# With some added inspiration from Purell: https://github.com/PuerkitoBio/purell
+# and normalize_url: https://github.com/rwz/normalize_url
 module Surt
+  # Canonicalize and format a URL according to SURT.
   def self.surt(url, options = {})
     Surt::Format.url(Surt::Canonicalize.url(parse_url(url), options), options)
   end
 
+  # Canonicalize a URL. The result of this is a URL, not a SURT string.
   def self.canonicalize(url, options = {})
     Surt::Canonicalize.url(parse_url(url), options).to_s
   end
 
+  # Format a URL as SURT without doing any canonicalization or cleanup.
   def self.format(url, options = {})
     Surt::Format.url(parse_url(url), options)
   end
-
-  private
 
   def self.parse_url(url)
     url = url.strip.gsub(/[\r\n\t]/, '').gsub(/\s/, '%20')

--- a/app/lib/surt.rb
+++ b/app/lib/surt.rb
@@ -2,7 +2,7 @@ require 'addressable/uri'
 
 module Surt
   def self.surt(url, options = {})
-    Surt::Format.format(canonicalize(url, options), options)
+    Surt::Format.url(Surt::Canonicalize.url(parse_url(url), options), options)
   end
 
   def self.canonicalize(url, options = {})
@@ -10,7 +10,7 @@ module Surt
   end
 
   def self.format(url, options = {})
-    Surt::Format.format(parse_url(url), options)
+    Surt::Format.url(parse_url(url), options)
   end
 
   private

--- a/app/lib/surt.rb
+++ b/app/lib/surt.rb
@@ -1,0 +1,23 @@
+require 'addressable/uri'
+
+module Surt
+  def self.surt(url, options = {})
+    Surt::Format.format(canonicalize(url, options), options)
+  end
+
+  def self.canonicalize(url, options = {})
+    Surt::Canonicalize.url(parse_url(url), options).to_s
+  end
+
+  def self.format(url, options = {})
+    Surt::Format.format(parse_url(url), options)
+  end
+
+  private
+
+  def self.parse_url(url)
+    url = url.strip.gsub(/[\r\n\t]/, '').gsub(/\s/, '%20')
+    url = "http://#{url}" unless url.match?(/^[^:\/.]*:/)
+    Addressable::URI.parse(url)
+  end
+end

--- a/app/lib/surt/canonicalize.rb
+++ b/app/lib/surt/canonicalize.rb
@@ -21,26 +21,26 @@ module Surt::Canonicalize
     remove_trailing_slash_unless_empty: true,
     remove_userinfo: true,
     remove_www: true,
-    sort_query: true,
-  }
+    sort_query: true
+  }.freeze
 
   DEFAULT_PORTS = {
     'http' => 80,
     'https' => 443
-  }
+  }.freeze
 
   PATH_SESSION_IDS = [
     /^(.*\/)(\((?:[a-z]\([0-9a-z]{24}\))+\)\/)([^\?]+\.aspx.*)$/i,
     /^(.*\/)(\([0-9a-z]{24}\)\/)([^\?]+\.aspx.*)$/i
-  ]
+  ].freeze
 
   QUERY_SESSION_IDS = [
     /^(.*)(?:jsessionid=[0-9a-zA-Z]{32})(?:&(.*))?$/i,
     /^(.*)(?:phpsessid=[0-9a-zA-Z]{32})(?:&(.*))?$/i,
     /^(.*)(?:sid=[0-9a-zA-Z]{32})(?:&(.*))?$/i,
     /^(.*)(?:ASPSESSIONID[a-zA-Z]{8}=[a-zA-Z]{24})(?:&(.*))?$/i,
-    /^(.*)(?:cfid=[^&]+&cftoken=[^&]+)(?:&(.*))?$/i,
-  ]
+    /^(.*)(?:cfid=[^&]+&cftoken=[^&]+)(?:&(.*))?$/i
+  ].freeze
 
   OCTAL_IP = /^(0[0-7]*)(\.[0-7]+)?(\.[0-7]+)?(\.[0-7]+)?$/
   WWW_SUBDOMAIN = /(^|\.)www\d*\./
@@ -48,12 +48,10 @@ module Surt::Canonicalize
 
   # TODO: Internet Archive's SURT uses this crazy charcater set, but only one
   # test fails if we just use Addressable's standard set. Maybe drop this?
-  SAFE_CHARACTERS = '0-9a-zA-Z' + (
-    '!"$&\'()*+,-./:;<=>?@[\]^_`{|}~'
-      .split('')
-      .collect {|character| "\\#{character}"}
-      .join('')
-  )
+  SAFE_CHARACTERS = '0-9a-zA-Z' + '!"$&\'()*+,-./:;<=>?@[\]^_`{|}~'
+    .split('')
+    .collect {|character| "\\#{character}"}
+    .join('')
 
   # Canonicalize a URL. This is the normal entrypoint to this module.
   #
@@ -121,13 +119,12 @@ module Surt::Canonicalize
     items = path.split('/', -1)[1..-1] || []
 
     if options[:remove_dot_segments]
-      items = items.reduce([]) do |accumulator, item|
+      items = items.each_with_object([]) do |item, accumulator|
         if item == '..'
           accumulator.pop
         elsif item != '.'
           accumulator.push(item)
         end
-        accumulator
       end
     end
 
@@ -170,8 +167,6 @@ module Surt::Canonicalize
       url.fragment = nil if url.fragment && url.fragment[0] != '!'
     end
   end
-
-  private
 
   def self.dword_to_decimal_ip(raw_dword)
     dword = raw_dword.to_i

--- a/app/lib/surt/canonicalize.rb
+++ b/app/lib/surt/canonicalize.rb
@@ -1,0 +1,195 @@
+require 'addressable/uri'
+
+module Surt::Canonicalize
+  DEFAULT_OPTIONS = {
+    decode_dword_host: true,
+    decode_hex_host: true,
+    decode_octal_host: true,
+    lowercase_host: true,
+    lowercase_path: true,
+    lowercase_query: true,
+    lowercase_scheme: true,
+    remove_default_port: true,
+    remove_dot_segments: true,
+    remove_empty_query: true,
+    remove_fragment: false,
+    remove_non_hashbang_fragment: true,
+    remove_sessions_in_path: true,
+    remove_sessions_in_query: true,
+    remove_repeated_slashes: true,
+    remove_trailing_slash: false,
+    remove_trailing_slash_unless_empty: true,
+    remove_userinfo: true,
+    remove_www: true,
+    sort_query: true,
+  }
+
+  DEFAULT_PORTS = {
+    'http' => 80,
+    'https' => 443
+  }
+
+  PATH_SESSION_IDS = [
+    /^(.*\/)(\((?:[a-z]\([0-9a-z]{24}\))+\)\/)([^\?]+\.aspx.*)$/i,
+    /^(.*\/)(\([0-9a-z]{24}\)\/)([^\?]+\.aspx.*)$/i
+  ]
+
+  QUERY_SESSION_IDS = [
+    /^(.*)(?:jsessionid=[0-9a-zA-Z]{32})(?:&(.*))?$/i,
+    /^(.*)(?:phpsessid=[0-9a-zA-Z]{32})(?:&(.*))?$/i,
+    /^(.*)(?:sid=[0-9a-zA-Z]{32})(?:&(.*))?$/i,
+    /^(.*)(?:ASPSESSIONID[a-zA-Z]{8}=[a-zA-Z]{24})(?:&(.*))?$/i,
+    /^(.*)(?:cfid=[^&]+&cftoken=[^&]+)(?:&(.*))?$/i,
+  ]
+
+  OCTAL_IP = /^(0[0-7]*)(\.[0-7]+)?(\.[0-7]+)?(\.[0-7]+)?$/
+  WWW_SUBDOMAIN = /(^|\.)www\d*\./
+
+
+  # TODO: Internet Archive's SURT uses this crazy charcater set, but only one
+  # test fails if we just use Addressable's standard set. Maybe drop this?
+  SAFE_CHARACTERS = '0-9a-zA-Z' + (
+    '!"$&\'()*+,-./:;<=>?@[\]^_`{|}~'
+      .split('')
+      .collect {|character| "\\#{character}"}
+      .join('')
+  )
+
+  # Canonicalize a URL. This is the normal entrypoint to this module.
+  #
+  # == Parameters:
+  # url::
+  #   The URL to canonicalize as a URI object.
+  # options::
+  #   Most canonicalization options are optional and can be explicitly enabled
+  #   or disabled using a hash of options.
+  #
+  # == Returns:
+  # The canonicalized URL as a new URI object.
+  #
+  def self.url(raw_url, options = {})
+    return raw_url unless ['http', 'https'].include?(raw_url.scheme)
+
+    url = raw_url.clone
+    options = DEFAULT_OPTIONS.clone.merge(options)
+    scheme(url, options)
+    userinfo(url, options)
+    host(url, options)
+    path(url, options)
+    query(url, options)
+    fragment(url, options)
+    url
+  end
+
+  def self.scheme(url, options)
+    url.scheme = url.scheme.downcase if options[:lowercase_scheme]
+  end
+
+  def self.userinfo(url, options)
+    url.user = nil if options[:remove_userinfo]
+    url.user = escape_minimally(url.user) if url.user
+    url.password = escape_minimally(url.password) if url.password
+  end
+
+  def self.host(url, options)
+    hostname = unescape_repeatedly(url.host)
+    hostname = Addressable::IDNA.to_ascii(hostname)
+    hostname = hostname.downcase if options[:lowercase_host]
+    hostname = hostname.sub(WWW_SUBDOMAIN, '\1') if options[:remove_www]
+    hostname = hostname.gsub(/\.\./, '.').gsub(/(^\.+)|(\.+$)/, '')
+
+    if options[:decode_dword_host] && hostname.match?(/^\d+$/)
+      hostname = dword_to_decimal_ip(hostname)
+    elsif options[:decode_hex_host] && hostname.start_with?('0x')
+      hostname = dword_to_decimal_ip(hostname.hex)
+    elsif options[:decode_octal_host] && hostname.match?(OCTAL_IP)
+      hostname = hostname.split('.').collect(&:oct).join('.')
+    end
+
+    url.host = escape(hostname)
+    url.port = nil if url.port == DEFAULT_PORTS[url.scheme] && options[:remove_default_port]
+  end
+
+  def self.path(url, options)
+    path = unescape_repeatedly(url.path)
+    path = path.downcase if options[:lowercase_path]
+
+    if options[:remove_sessions_in_path]
+      PATH_SESSION_IDS.each {|expression| path = path.gsub(expression, '\1\3')}
+    end
+
+    items = path.split('/', -1)[1..-1] || []
+
+    if options[:remove_dot_segments]
+      items = items.reduce([]) do |accumulator, item|
+        if item == '..'
+          accumulator.pop
+        elsif item != '.'
+          accumulator.push(item)
+        end
+        accumulator
+      end
+    end
+
+    if options[:remove_repeated_slashes] && items.length > 1
+      items = [
+        *items[0...-1].reject {|item| item == ''},
+        items[-1]
+      ]
+    end
+
+    path = "#{path[0] || ''}#{items.join('/')}"
+
+    if options[:remove_trailing_slash] ||
+       (options[:remove_trailing_slash_unless_empty] && path.length > 1)
+      path = path.chomp('/')
+    end
+
+    url.path = escape(path)
+  end
+
+  def self.query(url, options)
+    if url.query.present?
+      if options[:remove_sessions_in_query]
+        # TODO: could this be better handled without regexes?
+        url.query = QUERY_SESSION_IDS.reduce(url.query) do |query, expression|
+          query.gsub(expression, '\1\2')
+        end.sub(/&$/, '')
+      end
+      url.query = url.query.downcase if options[:lowercase_query]
+      url.query = (url.normalized_query(:sorted) || '') if options[:sort_query]
+    end
+
+    url.query = nil if url.query.blank? && options[:remove_empty_query]
+  end
+
+  def self.fragment(url, options)
+    if options[:remove_fragment]
+      url.fragment = nil
+    elsif options[:remove_non_hashbang_fragment]
+      url.fragment = nil if url.fragment && url.fragment[0] != '!'
+    end
+  end
+
+  private
+
+  def self.dword_to_decimal_ip(raw_dword)
+    dword = raw_dword.to_i
+    [24, 16, 8, 0].collect {|shift| dword >> shift & 0xff}.join('.')
+  end
+
+  def self.unescape_repeatedly(raw_string)
+    unescaped = Addressable::URI.unencode_component(raw_string)
+    unescaped == raw_string ? unescaped : unescape_repeatedly(unescaped)
+  end
+
+  # Take a string that has been re-escaped any number of times and make sure it
+  # is only escaped once.
+  def self.escape_minimally(raw_string)
+    Addressable::URI.encode_component(unescape_repeatedly(raw_string))
+  end
+
+  def self.escape(raw_string)
+    Addressable::URI.encode_component(raw_string, SAFE_CHARACTERS)
+  end
+end

--- a/app/lib/surt/format.rb
+++ b/app/lib/surt/format.rb
@@ -1,0 +1,15 @@
+module Surt::Format
+  # Format a URL as a SURT string.
+  #
+  # == Parameters:
+  # url::
+  #   The URL to format as SURT.
+  # options::
+  #   Configuration for how to format the URL.
+  #
+  # == Returns:
+  # The SURT-formatted URL as a string
+  def self.format(raw_url, options = {})
+    raise NotImplementedError
+  end
+end

--- a/app/lib/surt/format.rb
+++ b/app/lib/surt/format.rb
@@ -1,15 +1,49 @@
 module Surt::Format
+  DEFAULT_OPTIONS = {
+    include_scheme: false,
+    include_trailing_comma: false,
+  }
+
   # Format a URL as a SURT string.
   #
   # == Parameters:
   # url::
-  #   The URL to format as SURT.
+  #   The URL to format as SURT as a URI object.
   # options::
   #   Configuration for how to format the URL.
   #
   # == Returns:
   # The SURT-formatted URL as a string
-  def self.format(raw_url, options = {})
-    raise NotImplementedError
+  def self.url(url, options = {})
+    options = DEFAULT_OPTIONS.clone.merge(options)
+    result = ''
+
+    if options[:include_scheme]
+      delimiter = scheme != 'dns' ? '//' : ''
+      result = "#{url.scheme}:#{delimiter}("
+    elsif url.host.blank?
+      result = "#{url.scheme}:"
+    end
+
+    result += host(url, options) if url.host.present?
+
+    if url.path.present?
+      result += url.path
+    elsif url.query.present? || url.fragment.present?
+      result += '/'
+    end
+
+    result += "?#{url.query}" if url.query.present?
+    result += "\##{url.fragment}" if url.fragment.present?
+
+    result
+  end
+
+  def self.host(url, options)
+    host = url.host.split('.').reverse.join(',')
+    host = "#{url.userinfo}@#{host}" if url.userinfo
+    host = "#{host}:#{url.port}" if url.port
+    host += ',' if options[:include_trailing_comma]
+    host += ')'
   end
 end

--- a/app/lib/surt/format.rb
+++ b/app/lib/surt/format.rb
@@ -1,8 +1,8 @@
 module Surt::Format
   DEFAULT_OPTIONS = {
     include_scheme: false,
-    include_trailing_comma: false,
-  }
+    include_trailing_comma: false
+  }.freeze
 
   # Format a URL as a SURT string.
   #
@@ -44,6 +44,6 @@ module Surt::Format
     host = "#{url.userinfo}@#{host}" if url.userinfo
     host = "#{host}:#{url.port}" if url.port
     host += ',' if options[:include_trailing_comma]
-    host += ')'
+    host + ')'
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -22,6 +22,7 @@ class Page < ApplicationRecord
   has_many :maintainerships, foreign_key: :page_uuid
   has_many :maintainers, through: :maintainerships
 
+  before_create :ensure_url_key
   before_save :normalize_url
   validate :url_must_have_domain
 
@@ -85,7 +86,19 @@ class Page < ApplicationRecord
     result
   end
 
+  def update_url_key
+    update(url_key: generate_url_key)
+  end
+
   protected
+
+  def ensure_url_key
+    self.url_key ||= generate_url_key
+  end
+
+  def generate_url_key
+    Surt.surt(self.url)
+  end
 
   def normalize_url
     self.url = self.class.normalize_url(self.url)

--- a/db/migrate/20180227021126_add_capture_url_to_version.rb
+++ b/db/migrate/20180227021126_add_capture_url_to_version.rb
@@ -1,0 +1,32 @@
+class AddCaptureUrlToVersion < ActiveRecord::Migration[5.1]
+  def change
+    add_column :versions, :capture_url, :string
+
+    reversible do |direction|
+      direction.up do
+        say_with_time('Copying URLs from pages to versions') do
+          page_count = 0
+          version_count = 0
+          iterate_batches(Page.order(created_at: :asc)) do |page|
+            page_count += 1
+            version_count += page.versions.update_all(capture_url: page.url)
+          end
+          say("#{page_count} pages assessed", :subitem)
+          say("#{version_count} versions updated", :subitem)
+        end
+      end
+    end
+  end
+
+  # Kind of like find_each, but allows for ordered queries. We need this since
+  # a) UUIDs are not really ordered and b) we are still live inserting data.
+  def iterate_batches(collection, batch_size: 1000)
+    offset = 0
+    loop do
+      items = collection.limit(batch_size).offset(offset)
+      items.each {|item| yield item}
+      break if items.count.zero?
+      offset += batch_size
+    end
+  end
+end

--- a/db/migrate/20180227024610_add_url_key_to_page.rb
+++ b/db/migrate/20180227024610_add_url_key_to_page.rb
@@ -1,0 +1,31 @@
+class AddUrlKeyToPage < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pages, :url_key, :string
+    add_index :pages, :url_key
+
+    reversible do |direction|
+      direction.up do
+        say_with_time('Generating url_keys for pages') do
+          page_count = 0
+          iterate_batches(Page.order(created_at: :asc)) do |page|
+            page_count += 1
+            page.update_url_key
+          end
+          say("#{page_count} pages assessed", :subitem)
+        end
+      end
+    end
+  end
+
+  # Kind of like find_each, but allows for ordered queries. We need this since
+  # a) UUIDs are not really ordered and b) we are still live inserting data.
+  def iterate_batches(collection, batch_size: 1000)
+    offset = 0
+    loop do
+      items = collection.limit(batch_size).offset(offset)
+      items.each {|item| yield item}
+      break if items.count.zero?
+      offset += batch_size
+    end
+  end
+end

--- a/db/migrate/20180227034314_dedupe_pages_with_matching_url_keys.rb
+++ b/db/migrate/20180227034314_dedupe_pages_with_matching_url_keys.rb
@@ -1,0 +1,72 @@
+class DedupePagesWithMatchingUrlKeys < ActiveRecord::Migration[5.1]
+  # Find all pages sharing the same `url_key` and de-duplicate them by copying
+  # the maintainers, tags, and versions of all subsequent pages onto the one
+  # that was created first.
+  def up
+    total_deletions = 0
+
+    Page.group(:url_key).having('count(*) > 1').count.each_key do |url_key|
+      say("Deduplicating pages for '#{url_key}'")
+
+      canonical_page = nil
+      deletable = []
+      pages = Page.where(url_key: url_key)
+        .eager_load(:maintainers, :tags)
+        .order(created_at: :asc)
+
+      pages.each do |page|
+        if canonical_page.nil?
+          canonical_page = page
+        else
+          page.maintainers.each {|item| canonical_page.add_maintainer(item)}
+          page.maintainers.clear
+
+          page.tags.each {|item| canonical_page.add_tag(item)}
+          page.tags.clear
+
+          page.versions.update_all(page_uuid: canonical_page.uuid)
+          deletable << page.uuid
+        end
+      end
+
+      Page.where(uuid: deletable).delete_all
+      say("Deleted #{deletable.length} pages.", true)
+
+      total_deletions += deletable.length
+    end
+
+    say("Deleted #{total_deletions} pages in total.")
+  end
+
+  def down
+    total_creations = 0
+
+    # Crazy Arel join time! Maybe would have been easier to just write SQL...
+    pages = Page.arel_table
+    versions = Version.arel_table
+    condition = versions.create_on(versions[:capture_url].eq(pages[:url]))
+    join_on_url = versions.create_join(pages, condition, Arel::Nodes::OuterJoin)
+    urls_with_no_page = Version
+      .joins(join_on_url)
+      .where(pages[:url].eq(nil))
+      .distinct
+      .pluck(:capture_url)
+
+    urls_with_no_page.each do |url|
+      say("Recreating page for '#{url}'")
+
+      # This will fall back to url_key and find our existing page
+      page = Page.find_by_url(url)
+      values = page.attributes.reject {|key, _| key == 'uuid'}.merge(url: url)
+
+      new_page = Page.create(values)
+      page.maintainers.each {|item| new_page.add_maintainer(item)}
+      page.tags.each {|item| new_page.add_tag(item)}
+      Version.where(capture_url: url).update_all(page_uuid: new_page.uuid)
+
+      total_creations += 1
+    end
+
+    say("Created #{total_creations} pages in total.")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180227021126) do
+ActiveRecord::Schema.define(version: 20180227024610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,8 +88,10 @@ ActiveRecord::Schema.define(version: 20180227021126) do
     t.string "site"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "url_key"
     t.index ["site"], name: "index_pages_on_site"
     t.index ["url"], name: "index_pages_on_url"
+    t.index ["url_key"], name: "index_pages_on_url_key"
   end
 
   create_table "taggings", id: false, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180227024610) do
+ActiveRecord::Schema.define(version: 20180227034314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180212043742) do
+ActiveRecord::Schema.define(version: 20180227021126) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 20180212043742) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title"
+    t.string "capture_url"
     t.index ["capture_time"], name: "index_versions_on_capture_time"
     t.index ["page_uuid"], name: "index_versions_on_page_uuid"
     t.index ["version_hash"], name: "index_versions_on_version_hash"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1247,11 +1247,21 @@ definitions:
       capture_time:
         type: string
         format: datetime
+        description: The time that the version was captured at.
+      capture_url:
+        type: string
+        format: uri
+        description: >
+          The exact URL the version was originally captured at. A page may
+          capture versions from several URLs that are *effectively* the same,
+          but the `capture_url` on Version gives the exact URL.
       uri:
         type: string
         format: uri
+        description: A URL from which to retrieve the raw content of the version.
       version_hash:
         type: string
+        description: A SHA-256 hash of the version’s raw content.
       source_type:
         type: string
       source_metadata:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1279,6 +1279,15 @@ definitions:
         format: uuid4
       url:
         type: string
+      url_key:
+        type: string
+        format: surt
+        description: >
+          A canonical version of the Page's URL. It is mostly used for
+          determining whether versions from different capture_urls represent
+          the same page, e.g. `http://epa.gov` vs. `https://epa.gov`. For more
+          about the SURT format, see:
+          http://crawler.archive.org/articles/user_manual/glossary.html#surt
       title:
         type: string
       site:

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -79,7 +79,9 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
     end
 
     versions = pages[0].versions
-    assert_equal 2, versions.length
+    assert_equal(2, versions.length)
+    assert_equal(import_data[0][:page_url], versions[1].capture_url)
+    assert_equal(import_data[1][:page_url], versions[0].capture_url)
   end
 
   test 'can import data with deprecated `site_agency`, `site_name` fields' do

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -63,8 +63,9 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, body_json['data']['processing_errors'].length
 
     pages = Page.where(url: 'http://testsite.com/')
-    assert_equal 1, pages.length
-    assert_equal import_data[0][:title], pages[0].title
+    assert_equal(1, pages.length)
+    assert_equal('com,testsite)/', pages[0].url_key, 'URL key was not generated')
+    assert_equal(import_data[0][:title], pages[0].title)
 
     maintainer_names = pages[0].maintainers.pluck(:name).to_a
     imported_maintainers = import_data.flat_map {|d| d[:page_maintainers]}

--- a/test/lib/surt/surt_test.rb
+++ b/test/lib/surt/surt_test.rb
@@ -17,12 +17,12 @@ class SurtTest < ActiveSupport::TestCase
     assert_canonicalized(
       'http://alexa.com/',
       'http://www.alexa.com/',
-      'It did not remove a "www." subdomain'
+      'It failed to remove a "www." subdomain'
     )
     assert_canonicalized(
       'http://archive.org/',
       'http://www34.archive.org/',
-      'It removed a "www[digit]." subdomain'
+      'It failed to remove a "www[digit]." subdomain'
     )
   end
 
@@ -30,17 +30,17 @@ class SurtTest < ActiveSupport::TestCase
     assert_canonicalized(
       'http://archive.org/index.html',
       'http://archive.org/index.html?',
-      'It removed an empty query'
+      'It failed to remove an empty query'
     )
     assert_canonicalized(
       'http://archive.org/index.html?a=b&b=b',
       'http://archive.org/index.html?b=b&a=b',
-      'It alphabetized the query'
+      'It failed to alphabetized the query'
     )
     assert_canonicalized(
       'http://archive.org/index.html?a=b&b=a&b=b',
       'http://archive.org/index.html?b=a&b=b&a=b',
-      'It alphabetized a query with repeat keys'
+      'It failed to alphabetized a query with repeat keys'
     )
   end
 
@@ -82,17 +82,17 @@ class SurtTest < ActiveSupport::TestCase
     assert_canonicalized(
       'http://168.188.99.26',
       'http://168.188.99.26',
-      'It did leave a simple IPv4 alone'
+      'It failed to leave a simple IPv4 alone'
     )
     assert_canonicalized(
       'http://15.0.0.1',
       'http://017.0.0.1',
-      'It did not decode an octal IP'
+      'It failed to decode an octal IP'
     )
     assert_canonicalized(
       'http://195.127.0.11/blah',
       'http://3279880203/blah',
-      'It did not decode a DWORD host'
+      'It failed to decode a DWORD host'
     )
     # Python SURT does some crazy fixing of IPv4 addresses, but I'm not sure
     # it's actually worth supporting here.
@@ -169,7 +169,7 @@ class SurtTest < ActiveSupport::TestCase
     assert_canonicalized(
       'http://xn--n3h.com',
       '☃.com',
-      '?'
+      'It failed to IDNA-encode the host name'
     )
   end
 
@@ -202,7 +202,7 @@ class SurtTest < ActiveSupport::TestCase
     assert_canonicalized(
       'http://gotaport.com:1234/',
       'http://gotaport.com:1234/',
-      'It did not keep non-standard port numbers'
+      'It failed to keep non-standard port numbers'
     )
   end
 

--- a/test/lib/surt/surt_test.rb
+++ b/test/lib/surt/surt_test.rb
@@ -282,16 +282,16 @@ class SurtTest < ActiveSupport::TestCase
   end
 
   test 'it formats URLs as SURT' do
-    assert_equal('org,archive)/', Surt::format('http://archive.org/'))
-    assert_equal('org,archive,xyz)/', Surt::format('http://xyz.archive.org/'))
-    assert_equal('org,archive)/goo', Surt::format('http://archive.org/goo'))
-    assert_equal('org,archive)/goo/gah', Surt::format('http://archive.org/goo/gah'))
+    assert_equal('org,archive)/', Surt.format('http://archive.org/'))
+    assert_equal('org,archive,xyz)/', Surt.format('http://xyz.archive.org/'))
+    assert_equal('org,archive)/goo', Surt.format('http://archive.org/goo'))
+    assert_equal('org,archive)/goo/gah', Surt.format('http://archive.org/goo/gah'))
   end
 
   test 'it canonicalizes and formats URLs' do
-    assert_equal('org,archive)/goo', Surt::surt('http://archive.org/goo/'))
-    assert_equal('org,archive)/goo', Surt::surt('http://archive.org/goo/?'))
-    assert_equal('org,archive)/goo?a&b', Surt::surt('http://archive.org/goo/?b&a'))
-    assert_equal('org,archive)/goo?a=1&a=2&b', Surt::surt('http://archive.org/goo/?a=2&b&a=1'))
+    assert_equal('org,archive)/goo', Surt.surt('http://archive.org/goo/'))
+    assert_equal('org,archive)/goo', Surt.surt('http://archive.org/goo/?'))
+    assert_equal('org,archive)/goo?a&b', Surt.surt('http://archive.org/goo/?b&a'))
+    assert_equal('org,archive)/goo?a=1&a=2&b', Surt.surt('http://archive.org/goo/?a=2&b&a=1'))
   end
 end

--- a/test/lib/surt/surt_test.rb
+++ b/test/lib/surt/surt_test.rb
@@ -1,0 +1,299 @@
+require 'test_helper'
+
+class SurtTest < ActiveSupport::TestCase
+  # Give us a nice syntax so we can visually align output vs. input
+  def assert_canonicalized(expected, url, message = nil, options = {})
+    assert_equal(expected, Surt.canonicalize(url, options), message)
+  end
+
+  test 'it does not modify canonical URLs' do
+    assert_canonicalized(
+      'http://archive.org/index.html',
+      'http://archive.org/index.html'
+    )
+  end
+
+  test 'it removes "www[digit?]" subdomains' do
+    assert_canonicalized(
+      'http://alexa.com/',
+      'http://www.alexa.com/',
+      'It did not remove a "www." subdomain'
+    )
+    assert_canonicalized(
+      'http://archive.org/',
+      'http://www34.archive.org/',
+      'It removed a "www[digit]." subdomain'
+    )
+  end
+
+  test 'it cleans up querystrings' do
+    assert_canonicalized(
+      'http://archive.org/index.html',
+      'http://archive.org/index.html?',
+      'It removed an empty query'
+    )
+    assert_canonicalized(
+      'http://archive.org/index.html?a=b&b=b',
+      'http://archive.org/index.html?b=b&a=b',
+      'It alphabetized the query'
+    )
+    assert_canonicalized(
+      'http://archive.org/index.html?a=b&b=a&b=b',
+      'http://archive.org/index.html?b=a&b=b&a=b',
+      'It alphabetized a query with repeat keys'
+    )
+  end
+
+  test 'it singly escapes deeply nested escaped strings' do
+    assert_canonicalized(
+      'http://host/%25',
+      'http://host/%25%32%35'
+    )
+    assert_canonicalized(
+      'http://host/%25%25',
+      'http://host/%25%32%35%25%32%35'
+    )
+    assert_canonicalized(
+      'http://host/%25',
+      'http://host/%2525252525252525'
+    )
+    assert_canonicalized(
+      'http://host/asdf%25asd',
+      'http://host/asdf%25%32%35asd'
+    )
+    assert_canonicalized(
+      'http://host/%25%25%25asd%25%25',
+      'http://host/%%%25%32%35asd%%'
+    )
+  end
+
+  test 'it removes unnecessary escapes' do
+    assert_canonicalized(
+      'http://168.188.99.26/.secure/www.ebay.com',
+      'http://%31%36%38%2e%31%38%38%2e%39%39%2e%32%36/%2E%73%65%63%75%72%65/%77%77%77%2E%65%62%61%79%2E%63%6F%6D/'
+    )
+    assert_canonicalized(
+      'http://host%23.com/~a!b@c%23d$e%25f^00&11*22(33)44_55+',
+      'http://host%23.com/%257Ea%2521b%2540c%2523d%2524e%25f%255E00%252611%252A22%252833%252944_55%252B'
+    )
+  end
+
+  test 'it decimal encodes IP addresses' do
+    assert_canonicalized(
+      'http://168.188.99.26',
+      'http://168.188.99.26',
+      'It did leave a simple IPv4 alone'
+    )
+    assert_canonicalized(
+      'http://15.0.0.1',
+      'http://017.0.0.1',
+      'It did not decode an octal IP'
+    )
+    assert_canonicalized(
+      'http://195.127.0.11/blah',
+      'http://3279880203/blah',
+      'It did not decode a DWORD host'
+    )
+    # Python SURT does some crazy fixing of IPv4 addresses, but I'm not sure
+    # it's actually worth supporting here.
+    # assert_canonicalized(
+    #   'http://10.0.1.2',
+    #   'http://10.0.258',
+    #   'It did not correct a poorly encoded IPv4'
+    # )
+  end
+
+  test 'it normalizes and removes dots in path segments' do
+    assert_canonicalized(
+      'http://google.com/',
+      'http://google.com/blah/..',
+      'A double-dot did not remove the preceding path segment'
+    )
+  end
+
+  test 'it removes fragments' do
+    assert_canonicalized(
+      'http://evil.com/blah',
+      'http://evil.com/blah#frag'
+    )
+    assert_canonicalized(
+      'http://evil.com/foo',
+      'http://evil.com/foo#bar#baz'
+    )
+  end
+
+  test 'it does not remove hashbang fragments' do
+    assert_canonicalized(
+      'http://evil.com/blah#!frag',
+      'http://evil.com/blah#!frag'
+    )
+  end
+
+  test 'it lower-cases host names' do
+    assert_canonicalized(
+      'http://google.com/',
+      'http://GOOgle.com/'
+    )
+  end
+
+  test 'it removes unnecessary periods in host names' do
+    assert_canonicalized(
+      'http://google.com/',
+      'http://google.com.../'
+    )
+  end
+
+  test 'it removes invalid URL characters' do
+    assert_canonicalized(
+      'http://google.com/foobarbaz2',
+      "http://google.com/foo\tbar\rbaz\n2"
+    )
+  end
+
+  test 'it percent-encodes non-IDNA characters' do
+    assert_canonicalized(
+      'http://%01%C2%80.com/',
+      "http://\u0001\u0080.com/"
+    )
+    assert_canonicalized(
+      'http://t%EF%BF%BD%04.82.net/',
+      'http://t%EF%BF%BD%04.82.net/'
+    )
+  end
+
+  test 'it IDNA-encodes host names' do
+    assert_canonicalized(
+      'http://xn--bcher-kva.ch:8080',
+      "B\u00FCcher.ch:8080"
+    )
+    assert_canonicalized(
+      'http://xn--n3h.com',
+      '☃.com',
+      '?'
+    )
+  end
+
+  test 'it removes trailing slashes on paths' do
+    assert_canonicalized(
+      'http://notrailing.com/slash',
+      'http://notrailing.com/slash/'
+    )
+    assert_canonicalized(
+      'http://notrailing.com/',
+      'http://notrailing.com/'
+    )
+    assert_canonicalized(
+      'http://notrailing.com',
+      'http://notrailing.com/',
+      'Trailing slashes on an empty path were not removed when `remove_trailing_slash: true`',
+      remove_trailing_slash: true
+    )
+  end
+
+  test 'it removes unnecessary port numbers' do
+    assert_canonicalized(
+      'http://gotaport.com/',
+      'http://gotaport.com:80/'
+    )
+    assert_canonicalized(
+      'https://gotaport.com/',
+      'https://gotaport.com:443/'
+    )
+    assert_canonicalized(
+      'http://gotaport.com:1234/',
+      'http://gotaport.com:1234/',
+      'It did not keep non-standard port numbers'
+    )
+  end
+
+  test 'it removes leading and trailing spaces' do
+    assert_canonicalized(
+      'http://google.com/',
+      '  http://google.com/  '
+    )
+  end
+
+  test 'it removes repeated "/" characters in a path' do
+    assert_canonicalized(
+      'http://host.com/twoslashes?more//slashes',
+      'http://host.com//twoslashes?more//slashes'
+    )
+  end
+
+  test 'it does not modify mailto: URLs' do
+    assert_canonicalized(
+      'mailto:foo@example.com',
+      'mailto:foo@example.com'
+    )
+  end
+
+  test 'it removes session IDs from paths' do
+    assert_canonicalized(
+      'http://example.com/mileg.aspx',
+      'http://example.com/(S(4hqa0555fwsecu455xqckv45))/mileg.aspx',
+      'It did not remove an ASP_SESSIONID2 session ID'
+    )
+    assert_canonicalized(
+      'http://example.com/mileg.aspx',
+      'http://example.com/(4hqa0555fwsecu455xqckv45)/mileg.aspx',
+      'It did not remove an unprefixed ASP_SESSIONID2 session ID'
+    )
+    assert_canonicalized(
+      'http://example.com/mileg.aspx?page=sessionschedules',
+      'http://example.com/(a(4hqa0555fwsecu455xqckv45)S(4hqa0555fwsecu455xqckv45)f(4hqa0555fwsecu455xqckv45))/mileg.aspx?page=sessionschedules',
+      'It did not remove an unprefixed ASP_SESSIONID3 session ID'
+    )
+    assert_canonicalized(
+      'http://example.com/photos/36050182@n05',
+      'http://example.com/photos/36050182@N05',
+      'It did not leave @ signs alone in the path'
+    )
+  end
+
+  test 'it removes session IDs from querystrings' do
+    assert_canonicalized(
+      'http://example.com/x',
+      'http://example.com/x?jsessionid=0123456789abcdefghijklemopqrstuv'
+    )
+    assert_canonicalized(
+      'http://example.com/x?x=y',
+      'http://example.com/x?jsessionid=0123456789abcdefghijklemopqrstuv&x=y'
+    )
+    assert_canonicalized(
+      'http://example.com/x?x=y',
+      'http://example.com/x?x=y&jsessionid=0123456789abcdefghijklemopqrstuv'
+    )
+    assert_canonicalized(
+      'http://example.com/x?x=y',
+      'http://example.com/x?x=y&aspsessionidABCDEFGH=ABCDEFGHIJKLMNOPQRSTUVWX'
+    )
+    assert_canonicalized(
+      'http://example.com/x?x=y',
+      'http://example.com/x?x=y&phpsessid=0123456789abcdefghijklemopqrstuv'
+    )
+    assert_canonicalized(
+      'http://example.com/x?x=y',
+      'http://example.com/x?x=y&sid=9682993c8daa2c5497996114facdc805'
+    )
+    assert_canonicalized(
+      'http://example.com/x?x=y',
+      'http://example.com/x?x=y&CFID=1169580&CFTOKEN=48630702'
+    )
+  end
+
+  test 'it formats URLs as SURT' do
+    skip
+    assert_equal('org,archive)/', Surt::format('http://archive.org/'))
+    assert_equal('org,archive,xyz)/', Surt::format('http://xyz.archive.org/'))
+    assert_equal('org,archive)/goo', Surt::format('http://archive.org/goo'))
+    assert_equal('org,archive)/goo/gah', Surt::format('http://archive.org/goo/gah'))
+  end
+
+  test 'it canonicalizes and formats URLs' do
+    skip
+    assert_equal('org,archive)/goo', Surt::surt('http://archive.org/goo/'))
+    assert_equal('org,archive)/goo', Surt::surt('http://archive.org/goo/?'))
+    assert_equal('org,archive)/goo?a&b', Surt::surt('http://archive.org/goo/?b&a'))
+    assert_equal('org,archive)/goo?a=1&a=2&b', Surt::surt('http://archive.org/goo/?a=2&b&a=1'))
+  end
+end

--- a/test/lib/surt/surt_test.rb
+++ b/test/lib/surt/surt_test.rb
@@ -282,7 +282,6 @@ class SurtTest < ActiveSupport::TestCase
   end
 
   test 'it formats URLs as SURT' do
-    skip
     assert_equal('org,archive)/', Surt::format('http://archive.org/'))
     assert_equal('org,archive,xyz)/', Surt::format('http://xyz.archive.org/'))
     assert_equal('org,archive)/goo', Surt::format('http://archive.org/goo'))
@@ -290,7 +289,6 @@ class SurtTest < ActiveSupport::TestCase
   end
 
   test 'it canonicalizes and formats URLs' do
-    skip
     assert_equal('org,archive)/goo', Surt::surt('http://archive.org/goo/'))
     assert_equal('org,archive)/goo', Surt::surt('http://archive.org/goo/?'))
     assert_equal('org,archive)/goo?a&b', Surt::surt('http://archive.org/goo/?b&a'))

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -114,4 +114,9 @@ class PageTest < ActiveSupport::TestCase
       pages(:home_page_site2).tag_names
     )
   end
+
+  test 'pages generate a url_key when created' do
+    page = Page.create(url: 'http://sub.EXAMPLE.com/somewhere')
+    assert_equal('com,example,sub)/somewhere', page.url_key)
+  end
 end


### PR DESCRIPTION
~**Work in progress; do not merge!**~

Add support for canonicalizing URLs with SURT (Internet Archive’s “Sort-friendly URI Reordering Transform”) so that we can support pages whose content may come from more than one exact URL (as is often the case when we try to import data from Internet Archive).

The idea here is that we add a `url_key` field to Pages and, when importing, match pages by that field *when they don’t match by an exact `url`* (this lets us easily disambiguate two pages with the same `url_key` that should actually be separate by simply making a new Page record with an exact URL match).

- [x] Add module for SURT-formatting a URL
- [x] Add `url_key` field to Page model and populate it
- [x] Add `capture_url` field to Version and populate it
- [x] Add import logic that looks for Pages with matching `url_key` when importing
- [x] Dedupe existing pages by `url_key`

Fixes #185.