### PR TITLE
Allow `null` value when importing maintainers/tags

### DIFF
--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -242,8 +242,6 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can import `null` page_maintainers' do
-    page_versions_count = pages(:home_page).versions.count
-    original_data = versions(:page1_v1).as_json
     import_data = [
       {
         page_url: 'http://testsite.com/',
@@ -278,8 +276,6 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'cannot import non-array page_maintainers' do
-    page_versions_count = pages(:home_page).versions.count
-    original_data = versions(:page1_v1).as_json
     import_data = [
       {
         page_url: 'http://testsite.com/',
@@ -314,8 +310,6 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can import `null` page_tags' do
-    page_versions_count = pages(:home_page).versions.count
-    original_data = versions(:page1_v1).as_json
     import_data = [
       {
         page_url: 'http://testsite.com/',
@@ -350,8 +344,6 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'cannot import non-array page_tags' do
-    page_versions_count = pages(:home_page).versions.count
-    original_data = versions(:page1_v1).as_json
     import_data = [
       {
         page_url: 'http://testsite.com/',

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -240,4 +240,148 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
     expected_meta = original_data['source_metadata'].merge('test_meta' => 'data')
     assert_equal(expected_meta, version.source_metadata, 'source_metadata was not merged')
   end
+
+  test 'can import `null` page_maintainers' do
+    page_versions_count = pages(:home_page).versions.count
+    original_data = versions(:page1_v1).as_json
+    import_data = [
+      {
+        page_url: 'http://testsite.com/',
+        page_title: 'Test Page',
+        page_maintainers: nil,
+        capture_time: versions(:page1_v1).capture_time,
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+        version_hash: 'INVALID_HASH',
+        source_type: versions(:page1_v1).source_type,
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path,
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+    assert_response :success
+    body_json = JSON.parse(@response.body)
+    job_id = body_json['data']['id']
+    assert_equal 'pending', body_json['data']['status']
+
+    get api_v0_import_path(id: job_id)
+    body_json = JSON.parse(@response.body)
+    assert_equal 'complete', body_json['data']['status']
+    assert_equal 0, body_json['data']['processing_errors'].length
+  end
+
+  test 'cannot import non-array page_maintainers' do
+    page_versions_count = pages(:home_page).versions.count
+    original_data = versions(:page1_v1).as_json
+    import_data = [
+      {
+        page_url: 'http://testsite.com/',
+        page_title: 'Test Page',
+        page_maintainers: 5,
+        capture_time: versions(:page1_v1).capture_time,
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+        version_hash: 'INVALID_HASH',
+        source_type: versions(:page1_v1).source_type,
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path,
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+    assert_response :success
+    body_json = JSON.parse(@response.body)
+    job_id = body_json['data']['id']
+    assert_equal 'pending', body_json['data']['status']
+
+    get api_v0_import_path(id: job_id)
+    body_json = JSON.parse(@response.body)
+    assert_equal 'complete', body_json['data']['status']
+    assert_equal 1, body_json['data']['processing_errors'].length
+  end
+
+  test 'can import `null` page_tags' do
+    page_versions_count = pages(:home_page).versions.count
+    original_data = versions(:page1_v1).as_json
+    import_data = [
+      {
+        page_url: 'http://testsite.com/',
+        page_title: 'Test Page',
+        page_tags: nil,
+        capture_time: versions(:page1_v1).capture_time,
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+        version_hash: 'INVALID_HASH',
+        source_type: versions(:page1_v1).source_type,
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path,
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+    assert_response :success
+    body_json = JSON.parse(@response.body)
+    job_id = body_json['data']['id']
+    assert_equal 'pending', body_json['data']['status']
+
+    get api_v0_import_path(id: job_id)
+    body_json = JSON.parse(@response.body)
+    assert_equal 'complete', body_json['data']['status']
+    assert_equal 0, body_json['data']['processing_errors'].length
+  end
+
+  test 'cannot import non-array page_tags' do
+    page_versions_count = pages(:home_page).versions.count
+    original_data = versions(:page1_v1).as_json
+    import_data = [
+      {
+        page_url: 'http://testsite.com/',
+        page_title: 'Test Page',
+        page_tags: 5,
+        capture_time: versions(:page1_v1).capture_time,
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+        version_hash: 'INVALID_HASH',
+        source_type: versions(:page1_v1).source_type,
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path,
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+    assert_response :success
+    body_json = JSON.parse(@response.body)
+    job_id = body_json['data']['id']
+    assert_equal 'pending', body_json['data']['status']
+
+    get api_v0_import_path(id: job_id)
+    body_json = JSON.parse(@response.body)
+    assert_equal 'complete', body_json['data']['status']
+    assert_equal 1, body_json['data']['processing_errors'].length
+  end
 end

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -129,6 +129,6 @@ class ImportVersionsJobTest < ActiveJob::TestCase
       ].map(&:to_json).join("\n")
     )
     ImportVersionsJob.perform_now(import)
-    assert_equal(['Row 0: page_url is missing from record'], import.processing_errors, 'expected error due to missing page_url')
+    assert_equal(['Row 0: `page_url` is missing'], import.processing_errors, 'expected error due to missing page_url')
   end
 end


### PR DESCRIPTION
This makes things much easier for client libraries (i.e. it’s needed for edgi-govdata-archiving/web-monitoring-processing#167). While we're add it, just do better type checking and error messaging around the page fields in general.