### PR TITLE
Fix ActiveRecord error messages in import job

### DIFF
--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -35,7 +35,7 @@ class ImportVersionsJob < ApplicationJob
         messages = error.model.errors.full_messages.join(', ')
         @import.processing_errors << "Row #{row}: #{messages}"
       rescue ActiveRecord::RecordInvalid => error
-        messages = error.model.errors.full_messages.join(', ')
+        messages = error.record.errors.full_messages.join(', ')
         @import.processing_errors << "Row #{row}: #{messages}"
       rescue StandardError => error
         @import.processing_errors << if Rails.env.development?
@@ -113,7 +113,7 @@ class ImportVersionsJob < ApplicationJob
     validate_kind!([Array, NilClass], record, 'page_tags')
 
     url = record['page_url']
-    page = Page.find_by_url(url) || Page.create(url: url)
+    page = Page.find_by_url(url) || Page.create!(url: url)
 
     (record['page_maintainers'] || []).each {|name| page.add_maintainer(name)}
     page.add_maintainer(record['site_agency']) if record.key?('site_agency')

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -244,6 +244,46 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal(expected_meta, version.source_metadata, 'source_metadata was not merged')
   end
 
+  test 'surfaces page validation errors' do
+    import_data = [
+      {
+        page_url: 'testsite',
+        title: 'Example Page',
+        site_agency: 'The Federal Example Agency',
+        site_name: 'Example Site',
+        capture_time: '2017-05-01T12:33:01Z',
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v1',
+        version_hash: 'f366e89639758cd7f75d21e5026c04fb1022853844ff471865004b3274059686',
+        source_type: 'some_source',
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path,
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+    assert_response :success
+    body_json = JSON.parse(@response.body)
+    job_id = body_json['data']['id']
+    assert_equal('pending', body_json['data']['status'])
+
+    get api_v0_import_path(id: job_id)
+    body_json = JSON.parse(@response.body)
+    assert_equal('complete', body_json['data']['status'])
+    assert_equal(1, body_json['data']['processing_errors'].length)
+    assert_match(
+      /\sURL\s/i,
+      body_json['data']['processing_errors'].first,
+      'The error message did not mention that the URL was invalid'
+    )
+  end
+
   test 'can import `null` page_maintainers' do
     import_data = [
       {


### PR DESCRIPTION
While working on cleaning up the aftermath of edgi-govdata-archiving/web-monitoring-versionista-scraper#71, I realized we weren't surfacing validation errors that were built into our Page models. This adds that, but in the process, I realized we were also handling ActiveRecord::RecordInvalid errors incorrectly. So this fixes that, too.