### PR TITLE
Remove auto-migrations as part of Heroku release process

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
-release: bundle exec rake db:migrate
 web: bundle exec rails server -p $PORT
 worker: QUEUE=* VERBOSE=1 bundle exec rake environment resque:work


### PR DESCRIPTION
Lesson learned: this is great for schema migrations, but for large data migrations, it can be a big problem. This was not the brilliant idea I thought it was.