### PR TITLE
Increase redirect limit to 10 when archiving a URL

### DIFF
--- a/lib/archiver/archiver.rb
+++ b/lib/archiver/archiver.rb
@@ -2,6 +2,8 @@ require 'digest'
 require 'httparty'
 
 module Archiver
+  REDIRECT_LIMIT = 10
+
   # Configuration ----------
 
   def self.store=(store)
@@ -29,7 +31,7 @@ module Archiver
   # Primary API ----------
 
   def self.archive(url)
-    response = HTTParty.get(url)
+    response = HTTParty.get(url, limit: REDIRECT_LIMIT)
     hash = hash_content(response.body)
 
     url =
@@ -52,7 +54,7 @@ module Archiver
   end
 
   def self.hash_content_at_url(url)
-    response = HTTParty.get(url)
+    response = HTTParty.get(url, limit: REDIRECT_LIMIT)
     hash_content(response.body)
   end
 


### PR DESCRIPTION
Internet Archive stores all the redirects in the original request, which means they get replayed to us or anyone else who tries to retrieve an IA page. It turns out that sometimes that's a lot of redirects! Increase our limit to 10 for now (the default in HTTParty is 5).

This fixes some issues I hit while working on https://github.com/edgi-govdata-archiving/web-monitoring-processing/pull/174.