### PR TITLE
Upgrade loofah gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
This resolves the CVE vuln from a few days ago.

Changelog: https://github.com/flavorjones/loofah/blob/master/CHANGELOG.md#221--2018-03-19