### PR TITLE
Change fixtures to sort the same across systems

### DIFF
--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -69,7 +69,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
 
   test 'can filter pages by site' do
     sign_in users(:alice)
-    site = 'http://example.com/'
+    site = 'http://example1.com/'
     get "/api/v0/pages/?site=#{URI.encode_www_form_component site}"
     body_json = JSON.parse @response.body
     ids = body_json['data'].pluck 'uuid'
@@ -108,7 +108,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
 
   test 'can filter pages by URL' do
     sign_in users(:alice)
-    url = 'http://example.com/'
+    url = 'http://example1.com/'
     get "/api/v0/pages/?url=#{URI.encode_www_form_component url}"
     body_json = JSON.parse @response.body
     ids = body_json['data'].pluck 'uuid'
@@ -123,7 +123,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
 
   test 'can filter pages by URL with "*" wildcard' do
     sign_in users(:alice)
-    url = 'http://example.com/*'
+    url = 'http://example1.com/*'
     get "/api/v0/pages/?url=#{URI.encode_www_form_component url}"
     body_json = JSON.parse @response.body
     ids = body_json['data'].pluck 'uuid'
@@ -310,7 +310,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
       100.times {|i| first_page.versions.create(capture_time: now - i.days)}
 
       (105 - Page.count).times do
-        page = Page.create(url: "http://example.com/temp/#{SecureRandom.hex}")
+        page = Page.create(url: "http://example1.com/temp/#{SecureRandom.hex}")
         page.versions.create(capture_time: now - 1.day)
       end
     end

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -1,14 +1,14 @@
 home_page:
-  url: 'http://example.com/'
+  url: 'http://example1.com/'
   title: 'Page One'
   agency: 'Department of Examples'
-  site: 'http://example.com/'
+  site: 'http://example1.com/'
 
 sub_page:
-  url: 'http://example.com/page2.html'
+  url: 'http://example1.com/page2.html'
   title: 'Page Two'
   agency: 'Department of Examples'
-  site: 'http://example.com/'
+  site: 'http://example1.com/'
 
 home_page_site2:
   url: 'http://example2.com/index.html'

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -6,7 +6,7 @@
 #
 page1_v1:
   page: home_page
-  uri: 'http://example.com/page1_v1'
+  uri: 'http://example1.com/page1_v1'
   capture_time: '2017-03-01T00:00:00Z'
   version_hash: 'abc'
   source_type: 'versionista'
@@ -24,7 +24,7 @@ page1_v1:
 
 page2_v1:
   page: sub_page
-  uri: 'http://example.com/page2_v1'
+  uri: 'http://example1.com/page2_v1'
   capture_time: '2017-03-01T00:00:01Z'
   version_hash: 'def'
   source_type: 'versionista'
@@ -42,7 +42,7 @@ page2_v1:
 
 page1_v2:
   page: home_page
-  uri: 'http://example.com/page1_v2'
+  uri: 'http://example1.com/page1_v2'
   capture_time: '2017-03-02T00:00:00Z'
   version_hash: 'ghi'
   source_type: 'versionista'
@@ -60,7 +60,7 @@ page1_v2:
 
 page2_v2:
   page: sub_page
-  uri: 'http://example.com/page2_v2'
+  uri: 'http://example1.com/page2_v2'
   capture_time: '2017-03-02T00:00:01Z'
   version_hash: 'jkl'
   source_type: 'versionista'

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class PageTest < ActiveSupport::TestCase
   test 'page urls should always have a protocol' do
-    page = Page.create(url: 'www.example.com/whatever')
-    assert_equal('http://www.example.com/whatever', page.url, 'The URL was not given a protocol')
+    page = Page.create(url: 'www.example1.com/whatever')
+    assert_equal('http://www.example1.com/whatever', page.url, 'The URL was not given a protocol')
 
-    page = Page.create(url: 'https://www.example.com/whatever')
-    assert_equal('https://www.example.com/whatever', page.url, 'The URL was modified unnecessarily')
+    page = Page.create(url: 'https://www.example1.com/whatever')
+    assert_equal('https://www.example1.com/whatever', page.url, 'The URL was modified unnecessarily')
   end
 
   test 'page urls without a domain should be invalid' do


### PR DESCRIPTION
AKA fix test failures on some Linuxes.

It turns out Ubuntu desktop vs. Ubuntu server vs. Mac vs. Windows have different system-level libraries for text collation (sorting). What I did not expect was that *Ruby* does not use them, while *Postgres* does. And, most painfully, `.` vs. `5` sorts differently across some of these systems.

What this all adds up to is odd-seeming test failures around sorting on Ubuntu Desktop because we sort pages with the URL `example.com` and `example2.com` and then validate the sort result in Ruby (which doesn't work because Ruby sorts differently from Postgres there). I'm not sure what the “right” answer is here, so I've just modified the fixtures in such a way that we simply don't hit this scenario.

@gblike does this fix it for you? If so I’ll merge.