### PR TITLE
Add hash validation to Archiver + validate imports

### DIFF
--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -35,7 +35,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
         raise Api::NotImplementedError, 'Raw content uploading not implemented yet.'
       end
     elsif !Archiver.already_archived?(@version.uri) || !@version.version_hash
-      result = Archiver.archive(@version.uri)
+      result = Archiver.archive(@version.uri, expected_hash: @version.version_hash)
       @version.version_hash = result[:hash]
       @version.uri = result[:url]
     end

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -34,4 +34,14 @@ module Api
       409
     end
   end
+
+  class MismatchedHashError < ApiError
+    def status_code
+      502
+    end
+
+    def initialize(url, hash)
+      super("Response body for '#{url}' did not match expected hash (#{hash})")
+    end
+  end
 end

--- a/lib/archiver/archiver.rb
+++ b/lib/archiver/archiver.rb
@@ -30,9 +30,15 @@ module Archiver
 
   # Primary API ----------
 
-  def self.archive(url)
+  def self.archive(url, expected_hash: nil)
     response = HTTParty.get(url, limit: REDIRECT_LIMIT)
     hash = hash_content(response.body)
+    if expected_hash && expected_hash != hash
+      raise Api::DynamicError.new(
+        "Response body for '#{url}' did not match expected hash (#{expected_hash})",
+        :bad_gateway
+      )
+    end
 
     url =
       if already_archived?(url)

--- a/lib/archiver/archiver.rb
+++ b/lib/archiver/archiver.rb
@@ -34,10 +34,7 @@ module Archiver
     response = HTTParty.get(url, limit: REDIRECT_LIMIT)
     hash = hash_content(response.body)
     if expected_hash && expected_hash != hash
-      raise Api::DynamicError.new(
-        "Response body for '#{url}' did not match expected hash (#{expected_hash})",
-        :bad_gateway
-      )
+      raise Api::MismatchedHashError.new(url, expected_hash)
     end
 
     url =

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -284,6 +284,49 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test 'validates the version_hash' do
+    stub_request(:any, 'http://example.storage/example-v1')
+      .to_return(body: 'Hello!', status: 200)
+
+    import_data = [
+      {
+        page_url: 'http://testsite.com/',
+        title: 'Example Page',
+        site_agency: 'The Federal Example Agency',
+        site_name: 'Example Site',
+        capture_time: '2017-05-01T12:33:01Z',
+        uri: 'http://example.storage/example-v1',
+        version_hash: 'f366e89639758cd7f75d21e5026c04fb1022853844ff471865004b3274059686',
+        source_type: 'some_source',
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path,
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+    assert_response :success
+    body_json = JSON.parse(@response.body)
+    job_id = body_json['data']['id']
+    assert_equal('pending', body_json['data']['status'])
+
+    get api_v0_import_path(id: job_id)
+    body_json = JSON.parse(@response.body)
+    assert_equal('complete', body_json['data']['status'])
+    assert_equal(1, body_json['data']['processing_errors'].length)
+    assert_match(
+      /\shash\s/i,
+      body_json['data']['processing_errors'].first,
+      'The error message did not mention an issue with the hash'
+    )
+  end
+
   test 'can import `null` page_maintainers' do
     import_data = [
       {

--- a/test/lib/archiver/archiver_test.rb
+++ b/test/lib/archiver/archiver_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class Archiver::ArchiverTest < ActiveSupport::TestCase
+  def setup
+    @original_storage = Archiver.store
+    Archiver.store = FileStorage::LocalFile.new(path: Rails.root.join('tmp/test/storage'))
+  end
+
+  def teardown
+    Archiver.store = @original_storage
+  end
+
+  test 'it saves the URL by its hash' do
+    hash = '334d016f755cd6dc58c53a86e183882f8ec14f52fb05345887c8a5edd42c87b7'
+    stub_request(:any, 'http://example.com')
+      .to_return(body: 'Hello!', status: 200)
+
+    result = Archiver.archive('http://example.com')
+    expected_url = "file://#{Rails.root.join('tmp/test/storage', hash)}"
+    assert_equal(expected_url, result[:url])
+    assert_equal(hash, result[:hash])
+    assert_equal('Hello!', Archiver.store.get_file(hash))
+  end
+
+  test 'it accepts an expected hash' do
+    hash = '334d016f755cd6dc58c53a86e183882f8ec14f52fb05345887c8a5edd42c87b7'
+    stub_request(:any, 'http://example.com')
+      .to_return(body: 'Hello!', status: 200)
+
+    Archiver.archive('http://example.com', expected_hash: hash)
+    assert_equal('Hello!', Archiver.store.get_file(hash))
+  end
+
+  test 'raises if response does not match expected hash' do
+    stub_request(:any, 'http://example.com')
+      .to_return(body: 'Hello!', status: 200)
+
+    assert_raises(Api::ApiError) do
+      Archiver.archive('http://example.com', expected_hash: 'abc')
+    end
+  end
+end


### PR DESCRIPTION
If imports include a hash, use it to validate raw content when downloading and archiving it. Fixes #262.