### PR TITLE
 Add retry/backoff to Archiver when downloading raw content

### DIFF
--- a/lib/archiver/archiver.rb
+++ b/lib/archiver/archiver.rb
@@ -85,7 +85,7 @@ module Archiver
         raise error if attempt >= tries
       end
 
-      sleep(attempt ** 2)
+      sleep(attempt**2)
     end
   end
 end

--- a/lib/archiver/archiver.rb
+++ b/lib/archiver/archiver.rb
@@ -3,6 +3,7 @@ require 'httparty'
 
 module Archiver
   REDIRECT_LIMIT = 10
+  MAXIMUM_TRIES = 3
 
   # Configuration ----------
 
@@ -31,7 +32,10 @@ module Archiver
   # Primary API ----------
 
   def self.archive(url, expected_hash: nil)
-    response = HTTParty.get(url, limit: REDIRECT_LIMIT)
+    response = retry_request do
+      HTTParty.get(url, limit: REDIRECT_LIMIT)
+    end
+
     hash = hash_content(response.body)
     if expected_hash && expected_hash != hash
       raise Api::MismatchedHashError.new(url, expected_hash)
@@ -57,7 +61,9 @@ module Archiver
   end
 
   def self.hash_content_at_url(url)
-    response = HTTParty.get(url, limit: REDIRECT_LIMIT)
+    response = retry_request do
+      HTTParty.get(url, limit: REDIRECT_LIMIT)
+    end
     hash_content(response.body)
   end
 
@@ -67,5 +73,19 @@ module Archiver
 
   def self.external_archive_url?(url)
     allowed_hosts.any? {|base| url.starts_with?(base)}
+  end
+
+  # Auto-retry requests that error out or have gateway errors
+  def self.retry_request(tries: MAXIMUM_TRIES)
+    (1..tries).each do |attempt|
+      begin
+        response = yield
+        return response if attempt >= tries || (response.code != 503 && response.code != 504)
+      rescue HTTParty::ResponseError => error
+        raise error if attempt >= tries
+      end
+
+      sleep(attempt ** 2)
+    end
   end
 end

--- a/test/lib/archiver/archiver_test.rb
+++ b/test/lib/archiver/archiver_test.rb
@@ -8,6 +8,7 @@ class Archiver::ArchiverTest < ActiveSupport::TestCase
 
   def teardown
     Archiver.store = @original_storage
+    WebMock.reset!
   end
 
   test 'it saves the URL by its hash' do
@@ -38,5 +39,33 @@ class Archiver::ArchiverTest < ActiveSupport::TestCase
     assert_raises(Api::ApiError) do
       Archiver.archive('http://example.com', expected_hash: 'abc')
     end
+  end
+
+  test 'it should retry on HTTP errors and gateway errors' do
+    request = stub_request(:get, 'http://example.com')
+      .to_return(body: 'Gateway Error', status: 503).then
+      .to_return(body: 'Hello!', status: 200)
+
+    result = Archiver.archive('http://example.com')
+    assert_requested(request, times: 2)
+    assert_equal('Hello!', Archiver.store.get_file(result[:hash]))
+  end
+
+  test 'it should save error content after the maximum number of retries' do
+    request = stub_request(:get, 'http://example.com')
+      .to_return(body: 'Gateway Error', status: 503).times(3)
+
+    result = Archiver.archive('http://example.com')
+    assert_requested(request, times: 3)
+    assert_equal('Gateway Error', Archiver.store.get_file(result[:hash]))
+  end
+
+  test 'it hashes the content at a URL' do
+    hash = '334d016f755cd6dc58c53a86e183882f8ec14f52fb05345887c8a5edd42c87b7'
+    stub_request(:any, 'http://example.com')
+      .to_return(body: 'Hello!', status: 200)
+
+    result = Archiver.hash_content_at_url('http://example.com')
+    assert_equal(hash, result)
   end
 end


### PR DESCRIPTION
When downloading raw content, the archiver should retry (up to two additional times) for gateway errors and timeouts. If the final result was still a gateway error, we process it as a success anyhow -- its possible that the actual snapshotted response was a gateway error and we don't want to fail to save that.

Fixes #261.

*Note: this depends on #271*