### PR TITLE
Add `?create_pages=false` import query argument

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -57,9 +57,10 @@ class Api::V0::ApiController < ApplicationController
       error.to_s
   end
 
-  def boolean_param(param, presence_implies_true = true)
+  def boolean_param(param, presence_implies_true: true, default: false)
+    return default unless params.key?(param)
     value = params[param]
-    return true if params.key?(param) && value.nil? && presence_implies_true
+    return true if value.nil? && presence_implies_true
     /^(true|t|1)$/i.match? value
   end
 

--- a/app/controllers/api/v0/imports_controller.rb
+++ b/app/controllers/api/v0/imports_controller.rb
@@ -15,7 +15,8 @@ class Api::V0::ImportsController < Api::V0::ApiController
 
     @import = Import.create_with_data({
       user: current_user,
-      update_behavior: update_behavior
+      update_behavior: update_behavior,
+      create_pages: boolean_param(:create_pages, default: true)
     }, request.body)
     ImportVersionsJob.perform_later(@import)
     show

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -49,7 +49,7 @@ class ImportVersionsJob < ApplicationJob
   def import_record(record)
     page = page_for_record(record, create: @import.create_pages)
     unless page
-      Rails.logger.warn {"Import #{@import.id} skipping unknown URL: #{record['page_url']}@#{record['capture_time']}"}
+      warn "Skipped unknown URL: #{record['page_url']}@#{record['capture_time']}"
       return
     end
 
@@ -131,6 +131,11 @@ class ImportVersionsJob < ApplicationJob
   end
 
   private
+
+  def warn(message)
+    @import.processing_warnings << message
+    Rails.logger.warn "Import #{@import.id} #{message}"
+  end
 
   # iterate through a JSON array or series of newline-delimited JSON objects
   def each_json_line(raw_json)

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -48,7 +48,10 @@ class ImportVersionsJob < ApplicationJob
 
   def import_record(record)
     page = page_for_record(record, create: @import.create_pages)
-    return unless page
+    unless page
+      Rails.logger.warn {"Import #{@import.id} skipping unknown URL: #{record['page_url']}@#{record['capture_time']}"}
+      return
+    end
 
     existing = page.versions.find_by(
       capture_time: record['capture_time'],

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -3,7 +3,7 @@ class Import < ApplicationRecord
   enum status: [:pending, :processing, :complete]
   enum update_behavior: [:skip, :replace, :merge], _suffix: :existing_records
   validates :file, presence: true
-  after_initialize :ensure_processing_errors
+  after_initialize :ensure_processing_errors_and_warnings
 
   def self.create_with_data(attributes, data)
     create(attributes.merge(file: create_data_file(data)))
@@ -21,7 +21,8 @@ class Import < ApplicationRecord
 
   protected
 
-  def ensure_processing_errors
+  def ensure_processing_errors_and_warnings
     self.processing_errors ||= []
+    self.processing_warnings ||= []
   end
 end

--- a/db/migrate/20180413051144_add_create_pages_to_imports.rb
+++ b/db/migrate/20180413051144_add_create_pages_to_imports.rb
@@ -1,0 +1,5 @@
+class AddCreatePagesToImports < ActiveRecord::Migration[5.1]
+  def change
+    add_column :imports, :create_pages, :boolean, null: false, default: true
+  end
+end

--- a/db/migrate/20180415063842_add_processing_warnings_to_imports.rb
+++ b/db/migrate/20180415063842_add_processing_warnings_to_imports.rb
@@ -1,0 +1,5 @@
+class AddProcessingWarningsToImports < ActiveRecord::Migration[5.1]
+  def change
+    add_column :imports, :processing_warnings, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180227034314) do
+ActiveRecord::Schema.define(version: 20180413051144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20180227034314) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "update_behavior", default: 0, null: false
+    t.boolean "create_pages", default: true, null: false
     t.index ["user_id"], name: "index_imports_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180413051144) do
+ActiveRecord::Schema.define(version: 20180415063842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20180413051144) do
     t.datetime "updated_at", null: false
     t.integer "update_behavior", default: 0, null: false
     t.boolean "create_pages", default: true, null: false
+    t.jsonb "processing_warnings"
     t.index ["user_id"], name: "index_imports_on_user_id"
   end
 

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -539,12 +539,13 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     body_json = JSON.parse(@response.body)
     job_id = body_json['data']['id']
-    assert_equal 'pending', body_json['data']['status']
+    assert_equal('pending', body_json['data']['status'])
 
     get api_v0_import_path(id: job_id)
     body_json = JSON.parse(@response.body)
-    assert_equal 'complete', body_json['data']['status']
-    assert_equal 0, body_json['data']['processing_errors'].length
+    assert_equal('complete', body_json['data']['status'])
+    assert_equal(0, body_json['data']['processing_errors'].length)
+    assert_equal(1, body_json['data']['processing_warnings'].length)
 
     pages = Page.where(url: 'http://whoa-there-betcha-this.com/is/not/in/the/database')
     assert_equal(0, pages.count)

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -501,4 +501,53 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'complete', body_json['data']['status']
     assert_equal 1, body_json['data']['processing_errors'].length
   end
+
+  test 'can not create new pages if ?create_pages=false' do
+    existing_page_versions = pages(:home_page).versions.count
+
+    import_data = [
+      {
+        page_url: 'http://whoa-there-betcha-this.com/is/not/in/the/database',
+        title: 'Heyooooo!',
+        capture_time: '2017-05-01T12:33:01Z',
+        uri: 'https://test-bucket.s3.amazonaws.com/unknown-v1',
+        version_hash: 'abc',
+        source_type: 'some_source',
+        source_metadata: { test_meta: 'data' }
+      },
+      {
+        page_url: pages(:home_page).url,
+        title: 'Example Page',
+        capture_time: '2017-05-02T12:33:01Z',
+        uri: 'https://test-bucket.s3.amazonaws.com/example-v2',
+        version_hash: 'def',
+        source_type: 'some_source',
+        source_metadata: { test_meta: 'data' }
+      }
+    ]
+
+    sign_in users(:alice)
+
+    perform_enqueued_jobs do
+      post(
+        api_v0_imports_path(params: { create_pages: false }),
+        headers: { 'Content-Type': 'application/x-json-stream' },
+        params: import_data.map(&:to_json).join("\n")
+      )
+    end
+
+    assert_response :success
+    body_json = JSON.parse(@response.body)
+    job_id = body_json['data']['id']
+    assert_equal 'pending', body_json['data']['status']
+
+    get api_v0_import_path(id: job_id)
+    body_json = JSON.parse(@response.body)
+    assert_equal 'complete', body_json['data']['status']
+    assert_equal 0, body_json['data']['processing_errors'].length
+
+    pages = Page.where(url: 'http://whoa-there-betcha-this.com/is/not/in/the/database')
+    assert_equal(0, pages.count)
+    assert_equal(existing_page_versions + 1, pages(:home_page).versions.count)
+  end
 end


### PR DESCRIPTION
To prevent imports from creating completely new pages (when there's a previously unknown URL in the import data), set the `create_pages` query argument to false in `POST /api/v0/imports?create_pages=false`.

Fixes #265.