### PR TITLE
Add flag for qualifying versions as different from previous (#266 alternative)

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -21,6 +21,7 @@ class Api::V0::PagesController < Api::V0::ApiController
         results = query
           .where(uuid: page_ids)
           .includes(:versions)
+          .where(versions: {different: true})
           .order('versions.capture_time DESC')
         lightweight_query(results, &method(:format_page_json))
       elsif should_include_latest
@@ -53,9 +54,9 @@ class Api::V0::PagesController < Api::V0::ApiController
 
   def show
     page = Page.find(params[:id])
-    render json: {
-      data: page
-    }, include: [:versions, :maintainers, :tags]
+    data = page.as_json(include: [:maintainers, :tags])
+    data['versions'] = page.versions.where(different: true).as_json
+    render json: { data: data }
   end
 
   protected

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -21,7 +21,7 @@ class Api::V0::PagesController < Api::V0::ApiController
         results = query
           .where(uuid: page_ids)
           .includes(:versions)
-          .where(versions: {different: true})
+          .where(versions: { different: true })
           .order('versions.capture_time DESC')
         lightweight_query(results, &method(:format_page_json))
       elsif should_include_latest

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -91,6 +91,10 @@ class Api::V0::VersionsController < Api::V0::ApiController
   def version_collection
     collection = page && page.versions || Version.order(created_at: :asc)
 
+    if boolean_param(:different, default: true)
+      collection = collection.where(different: true)
+    end
+
     collection = collection.where({
       version_hash: params[:hash],
       source_type: params[:source_type]

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -77,6 +77,7 @@ class ImportVersionsJob < ApplicationJob
     end
 
     version.validate!
+    version.update_different_attribute
     version.save
   end
 

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -77,7 +77,7 @@ class ImportVersionsJob < ApplicationJob
     end
 
     version.validate!
-    version.update_different_attribute
+    version.update_different_attribute(save: false)
     version.save
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -14,7 +14,7 @@ class Page < ApplicationRecord
       # `DISTINCT ON` statement has to be at the start of the WHERE clause, but
       # all public methods append to the end.
       relation.select_values = ['DISTINCT ON (versions.page_uuid) versions.*']
-      relation.order('versions.capture_time DESC')
+      relation.order('versions.capture_time DESC').where(different: true)
     end),
     foreign_key: 'page_uuid',
     class_name: 'Version'

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -26,7 +26,7 @@ class Version < ApplicationRecord
     Change.between(from: self, to: self.next)
   end
 
-  def update_different_attribute
+  def update_different_attribute(save: true)
     previous = page.versions
       .where(source_type: self.source_type)
       .where('capture_time < ?', self.capture_time)
@@ -35,6 +35,7 @@ class Version < ApplicationRecord
       .first
 
     self.different = previous.nil? || previous.version_hash != version_hash
+    self.save if save
 
     if self.different?
       following = page.versions

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -26,6 +26,34 @@ class Version < ApplicationRecord
     Change.between(from: self, to: self.next)
   end
 
+  def update_different_attribute
+    previous = page.versions
+      .where(source_type: self.source_type)
+      .where('capture_time < ?', self.capture_time)
+      .reorder(capture_time: :desc)
+      .limit(1)
+      .first
+
+    self.different = previous.nil? || previous.version_hash != version_hash
+
+    if self.different?
+      following = page.versions
+        .where(source_type: self.source_type)
+        .where('capture_time > ?', self.capture_time)
+        .reorder(capture_time: :asc)
+
+      following.each do |next_version|
+        new_different = version_hash != next_version.version_hash
+        if next_version.different? == new_different
+          break
+        else
+          next_version.different = new_different
+          next_version.save!
+        end
+      end
+    end
+  end
+
   private
 
   def sync_page_title

--- a/db/migrate/20180415065623_add_different_to_versions.rb
+++ b/db/migrate/20180415065623_add_different_to_versions.rb
@@ -1,0 +1,5 @@
+class AddDifferentToVersions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :versions, :different, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180415063842) do
+ActiveRecord::Schema.define(version: 20180415065623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -146,6 +146,7 @@ ActiveRecord::Schema.define(version: 20180415063842) do
     t.datetime "updated_at", null: false
     t.string "title"
     t.string "capture_url"
+    t.boolean "different", default: true
     t.index ["capture_time"], name: "index_versions_on_capture_time"
     t.index ["page_uuid"], name: "index_versions_on_page_uuid"
     t.index ["version_hash"], name: "index_versions_on_version_hash"

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -596,4 +596,72 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
       name: 'Pages'
     )
   end
+
+  test 'only lists versions that are different from the previous version on page data' do
+    now = Time.now
+    page_versions = [
+      { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
+      { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days },
+    ].collect {|data| pages(:home_page).versions.create(data)}
+    page_versions.each(&:update_different_attribute)
+
+    sign_in users(:alice)
+    get(api_v0_page_url(pages(:home_page)))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    uuids = body['data']['versions'].collect {|version| version['uuid']}
+
+    assert_includes(uuids, page_versions[0].uuid)
+    assert_includes(uuids, page_versions[1].uuid)
+    assert_not_includes(uuids, page_versions[2].uuid)
+    assert_not_includes(uuids, page_versions[3].uuid)
+  end
+
+  test 'only lists versions that are different from the previous version on ?include_versions' do
+    now = Time.now
+    page_versions = [
+      { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
+      { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days },
+    ].collect {|data| pages(:home_page).versions.create(data)}
+    page_versions.each(&:update_different_attribute)
+
+    sign_in users(:alice)
+    get(api_v0_pages_url(params: {include_versions: true}))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    uuids = body['data'].collect do |page|
+      page['versions'].collect {|version| version['uuid']}
+    end.flatten
+
+    assert_includes(uuids, page_versions[0].uuid)
+    assert_includes(uuids, page_versions[1].uuid)
+    assert_not_includes(uuids, page_versions[2].uuid)
+    assert_not_includes(uuids, page_versions[3].uuid)
+  end
+
+  test 'only lists versions that are different from the previous version on ?include_latest' do
+    now = Time.now
+    page_versions = [
+      { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
+      { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days },
+    ].collect {|data| pages(:home_page).versions.create(data)}
+    page_versions.each(&:update_different_attribute)
+
+    sign_in users(:alice)
+    get(api_v0_pages_url(params: {include_latest: true}))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    uuids = body['data'].collect {|page| page['latest'].try(:[], 'uuid')}
+
+    assert_not_includes(uuids, page_versions[0].uuid)
+    assert_includes(uuids, page_versions[1].uuid)
+    assert_not_includes(uuids, page_versions[2].uuid)
+    assert_not_includes(uuids, page_versions[3].uuid)
+  end
 end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -603,7 +603,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
       { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
       { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
       { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
-      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days }
     ].collect {|data| pages(:home_page).versions.create(data)}
     page_versions.each(&:update_different_attribute)
 
@@ -625,12 +625,12 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
       { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
       { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
       { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
-      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days }
     ].collect {|data| pages(:home_page).versions.create(data)}
     page_versions.each(&:update_different_attribute)
 
     sign_in users(:alice)
-    get(api_v0_pages_url(params: {include_versions: true}))
+    get(api_v0_pages_url(params: { include_versions: true }))
     assert_response(:success)
     body = JSON.parse(@response.body)
     uuids = body['data'].collect do |page|
@@ -649,12 +649,12 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
       { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
       { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
       { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
-      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days }
     ].collect {|data| pages(:home_page).versions.create(data)}
     page_versions.each(&:update_different_attribute)
 
     sign_in users(:alice)
-    get(api_v0_pages_url(params: {include_latest: true}))
+    get(api_v0_pages_url(params: { include_latest: true }))
     assert_response(:success)
     body = JSON.parse(@response.body)
     uuids = body['data'].collect {|page| page['latest'].try(:[], 'uuid')}

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -227,7 +227,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
       { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
       { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
       { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
-      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days }
     ].collect {|data| pages(:home_page).versions.create(data)}
     page_versions.each(&:update_different_attribute)
 
@@ -249,7 +249,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
       { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
       { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
       { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
-      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days }
     ].collect {|data| pages(:home_page).versions.create(data)}
     page_versions.each(&:update_different_attribute)
 

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -220,4 +220,48 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
       name: 'Versions'
     )
   end
+
+  test 'only lists versions that are different from the previous version' do
+    now = Time.now
+    page_versions = [
+      { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
+      { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days },
+    ].collect {|data| pages(:home_page).versions.create(data)}
+    page_versions.each(&:update_different_attribute)
+
+    sign_in users(:alice)
+    get(api_v0_versions_url)
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    uuids = body['data'].collect {|version| version['uuid']}
+
+    assert_includes(uuids, page_versions[0].uuid)
+    assert_includes(uuids, page_versions[1].uuid)
+    assert_not_includes(uuids, page_versions[2].uuid)
+    assert_not_includes(uuids, page_versions[3].uuid)
+  end
+
+  test 'lists versions regardless if different from the previous version if ?different=false' do
+    now = Time.now
+    page_versions = [
+      { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
+      { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days },
+    ].collect {|data| pages(:home_page).versions.create(data)}
+    page_versions.each(&:update_different_attribute)
+
+    sign_in users(:alice)
+    get(api_v0_versions_url(params: { different: false }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    uuids = body['data'].collect {|version| version['uuid']}
+
+    assert_includes(uuids, page_versions[0].uuid)
+    assert_includes(uuids, page_versions[1].uuid)
+    assert_includes(uuids, page_versions[2].uuid)
+    assert_includes(uuids, page_versions[3].uuid)
+  end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -20,4 +20,30 @@ class VersionTest < ActiveSupport::TestCase
     change = versions(:page2_v1).change_from_next
     assert_not_nil change
   end
+
+  test 'update_different_attribute' do
+    page = Page.create(url: 'http://somerandomsite.com/')
+    a1 = page.versions.create(source_type: 'a', version_hash: 'abc', capture_time: Time.now - 3.days)
+    b1 = page.versions.create(source_type: 'b', version_hash: 'abc', capture_time: Time.now - 2.9.days)
+    a1.update_different_attribute
+    b1.update_different_attribute
+    assert(a1.different?, 'The first version is different')
+    assert(b1.different?, 'The first version of a given source_type is different')
+
+    a2 = page.versions.create(source_type: 'a', version_hash: 'abc', capture_time: Time.now - 1.days)
+    b2 = page.versions.create(source_type: 'b', version_hash: 'abc', capture_time: Time.now - 0.9.days)
+    a2.update_different_attribute
+    b2.update_different_attribute
+    assert_not(a2.different?, 'A version with the same hash is not different')
+    assert_not(b2.different?, 'A version of a given source_type with the same hash is not different')
+
+    a3 = page.versions.create(source_type: 'a', version_hash: 'def', capture_time: Time.now - 2.days)
+    b3 = page.versions.create(source_type: 'b', version_hash: 'def', capture_time: Time.now - 1.9.days)
+    a3.update_different_attribute
+    b3.update_different_attribute
+    assert(a3.different?, 'A version with a different hash is different')
+    assert(b3.different?, 'A version of a given source_type with a different hash is different')
+    assert(Version.find(a2.uuid).different?, 'Updating a version inserted before an existing version updates the existing version, too')
+    assert(Version.find(b2.uuid).different?, 'Updating a version inserted before an existing version updates the existing version for a given source_type, too')
+  end
 end


### PR DESCRIPTION
This is an implementation of the alternative approach to handling imports of records that don’t differ from a previous capture of the same page (#266). It adds a `different` flag to the Version model and a routine for updating it.

Still needs:

- [x] All API normal queries should filter to only records where the flag is `true`
- [x] Add ability to specify `?different=true|false|any|*` for `/api/v0/versions` and `/api/v0/pages/{id}/versions`
- [x] Add tests

(Based on #277)