### PR TITLE
Add `?skip_unchanged_versions=true` to imports (#266 Primary)

### DIFF
--- a/app/controllers/api/v0/imports_controller.rb
+++ b/app/controllers/api/v0/imports_controller.rb
@@ -16,7 +16,8 @@ class Api::V0::ImportsController < Api::V0::ApiController
     @import = Import.create_with_data({
       user: current_user,
       update_behavior: update_behavior,
-      create_pages: boolean_param(:create_pages, default: true)
+      create_pages: boolean_param(:create_pages, default: true),
+      skip_unchanged_versions: boolean_param(:skip_unchanged_versions)
     }, request.body)
     ImportVersionsJob.perform_later(@import)
     show

--- a/db/migrate/20180418061850_add_skip_unchanged_versions_to_imports.rb
+++ b/db/migrate/20180418061850_add_skip_unchanged_versions_to_imports.rb
@@ -1,0 +1,5 @@
+class AddSkipUnchangedVersionsToImports < ActiveRecord::Migration[5.1]
+  def change
+    add_column :imports, :skip_unchanged_versions, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180415063842) do
+ActiveRecord::Schema.define(version: 20180418061850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20180415063842) do
     t.integer "update_behavior", default: 0, null: false
     t.boolean "create_pages", default: true, null: false
     t.jsonb "processing_warnings"
+    t.boolean "skip_unchanged_versions", default: false, null: false
     t.index ["user_id"], name: "index_imports_on_user_id"
   end
 


### PR DESCRIPTION
Fixes #266 via the primary proposal

NOTE: this approach means we will *occasionally* miss versions or capture versions we should not have when they are received or processed out of order.

Mainly for comparison with #279.