### PR TITLE
Read database credentials from dotenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           PGHOST: 127.0.0.1
           PGUSER: root
           HOST_URL: 'web-monitoring-db.test'
-          DATABASE_URL_TEST: 'postgres://root@localhost:5432/circle-test_test'
+          DATABASE_TEST_URL: 'postgres://root@localhost:5432/circle-test_test'
           ALLOWED_ARCHIVE_HOSTS: 'https://edgi-versionista-archive.s3.amazonaws.com/ https://test-bucket.s3.amazonaws.com/'
       - image: circleci/postgres:9.5-alpine
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           PGHOST: 127.0.0.1
           PGUSER: root
           HOST_URL: 'web-monitoring-db.test'
+          DATABASE_URL_TEST: 'postgres://root@localhost:5432/circle-test_test'
           ALLOWED_ARCHIVE_HOSTS: 'https://edgi-versionista-archive.s3.amazonaws.com/ https://test-bucket.s3.amazonaws.com/'
       - image: circleci/postgres:9.5-alpine
         environment:

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ HOST_URL='web-monitoring-db.dev'
 
 # OPTIONAL: only set this if your database is at a different location than
 # specified in config/database.yml
-# DATABASE_URL=postgres://user:password@localhost:5432/db-name
+DATABASE_URL_DEV=postgres://localhost:5432/web-monitoring-db_development
+DATABASE_URL_TEST=postgres://localhost:5432/web-monitoring-db_test
 
 # OPTIONAL: only set this if your Redis is at a non-standard location
 # REDIS_URL=redis://user:password@localhost:6379

--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@ HOST_URL='web-monitoring-db.dev'
 
 # OPTIONAL: only set this if your database is at a different location than
 # specified in config/database.yml
-DATABASE_URL_DEV=postgres://localhost:5432/web-monitoring-db_development
-DATABASE_URL_TEST=postgres://localhost:5432/web-monitoring-db_test
+DATABASE_DEV_URL=postgres://localhost:5432/web-monitoring-db_development
+DATABASE_TEST_URL=postgres://localhost:5432/web-monitoring-db_test
 
 # OPTIONAL: only set this if your Redis is at a non-standard location
 # REDIS_URL=redis://user:password@localhost:6379

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,7 +24,7 @@ default: &default
 
 development:
   <<: *default
-  url: <%= ENV['DATABASE_URL_DEV'] %>
+  url: <%= ENV['DATABASE_DEV_URL'] %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -58,7 +58,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  url: <%= ENV['DATABASE_URL_TEST'] %>
+  url: <%= ENV['DATABASE_TEST_URL'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,7 +24,7 @@ default: &default
 
 development:
   <<: *default
-  database: web-monitoring-db_development
+  url: <%= ENV['DATABASE_URL_DEV'] %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -58,7 +58,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: web-monitoring-db_test
+  url: <%= ENV['DATABASE_URL_TEST'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
I'm one of those people on an old platform with postgres defaulting to be on non-standard ports :)

I have to adjust `config/database.yml` and so my workspace is always dirty.

Can we move database config into the .env  as DATABASE_URL file so that people can do whatever they please locally, and it will stay out of git-space? This has the nice perk of being more aligned with how we do it on prod.

Thanks!