### PR TITLE
Disable returning versions from /pages and /pages/{page_id}

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,10 @@ TOKEN_PRIVATE_KEY='MIIEogIBAAKCAQEAufNrDQRl6Gj1yuga0DVHeJ4fi+lNWtn4S8XRU8/nBwm9v
 # Set these if you are running rake tasks to import data from Google Sheets
 # GOOGLE_CLIENT_ID=XYZ
 # GOOGLE_CLIENT_SECRET=XYZ
+
+# Toggle returning an object with all versions for pages. 
+# We are turning it off temporarily because of the large number of accumulated versions. 
+# See: https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
+# NOTE: This can be removed once this issue is resolved.
+# https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+ALLOW_VERSIONS_IN_PAGE_RESPONSES='false'

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -18,7 +18,7 @@ class Api::V0::PagesController < Api::V0::ApiController
 
     result_data =
       if !should_allow_versions && should_include_versions
-        raise Api::NotImplementedError, 'The ?include_versions query argument has been disabled temporarily.'
+        raise Api::NotImplementedError, 'The ?include_versions query argument has been disabled.'
       elsif should_allow_versions && should_include_versions
         results = query
           .where(uuid: page_ids)
@@ -83,7 +83,7 @@ class Api::V0::PagesController < Api::V0::ApiController
     if should_allow_versions
       !should_include_versions && boolean_param(:include_latest)
     else
-      boolean_param :include_latest
+      boolean_param(:include_latest)
     end
   end
 

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -17,7 +17,16 @@ class Api::V0::PagesController < Api::V0::ApiController
     page_ids = id_query.pluck(:uuid, *order_attributes).collect {|data| data[0]}
 
     result_data =
-      if should_include_latest
+      if !should_allow_versions && should_include_versions
+        raise Api::NotImplementedError, 'The ?include_versions query argument has been disabled temporarily.'
+      elsif should_allow_versions && should_include_versions
+        results = query
+          .where(uuid: page_ids)
+          .includes(:versions)
+          .where(versions: { different: true })
+          .order('versions.capture_time DESC')
+        lightweight_query(results, &method(:format_page_json))
+      elsif should_include_latest
         # Filters from the original query should *not* affect what's "latest",
         # (though they do affect which *pages* get included) so we build a
         # whole new query from scratch here.
@@ -46,16 +55,11 @@ class Api::V0::PagesController < Api::V0::ApiController
   end
 
   def show
-    # NOTE: This check can be removed once this issue is resolved.
-    # https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
-    if should_include_versions
-      raise Api::NotImplementedError, 'The ?include_versions query argument has been disabled temporarily.'
-    end
     page = Page.find(params[:id])
     data = page.as_json(include: [:maintainers, :tags])
-    # NOTE: We'll re-attach versions to /pages/{page_id} when this issue is resolved.
-    # https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
-    # data['versions'] = page.versions.where(different: true).as_json
+    if should_allow_versions
+      data['versions'] = page.versions.where(different: true).as_json
+    end
     render json: { data: data }
   end
 
@@ -65,12 +69,22 @@ class Api::V0::PagesController < Api::V0::ApiController
     api_v0_pages_url(*args)
   end
 
+  # NOTE: This check can be removed once this issue is resolved.
+  # https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+  def should_allow_versions
+    ActiveModel::Type::Boolean.new.cast(ENV['ALLOW_VERSIONS_IN_PAGE_RESPONSES'])
+  end
+
   def should_include_versions
     boolean_param :include_versions
   end
 
   def should_include_latest
-    boolean_param :include_latest
+    if should_allow_versions
+      !should_include_versions && boolean_param(:include_latest)
+    else
+      boolean_param :include_latest
+    end
   end
 
   def page_collection

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -46,12 +46,16 @@ class Api::V0::PagesController < Api::V0::ApiController
   end
 
   def show
+    # NOTE: This check can be removed once this issue is resolved.
+    # https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     if should_include_versions
       raise Api::NotImplementedError, 'The ?include_versions query argument has been disabled temporarily.'
     end
     page = Page.find(params[:id])
     data = page.as_json(include: [:maintainers, :tags])
-    data['versions'] = page.versions.where(different: true).as_json
+    # NOTE: We'll re-attach versions to /pages/{page_id} when this issue is resolved.
+    # https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    # data['versions'] = page.versions.where(different: true).as_json
     render json: { data: data }
   end
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -80,14 +80,6 @@ paths:
             performance.
           required: false
           type: string
-        - name: include_versions
-          in: query
-          description: >-
-            If true, add a versions key to the each item with the output of
-            /pages/{page_id}/versions inlined.
-          required: false
-          type: string
-          default: false
         - name: include_latest
           in: query
           description: >-

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -185,7 +185,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes versions if include_versions = true' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     sign_in users(:alice)
@@ -205,7 +205,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes only versions if include_versions = true and include_latest = true' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     sign_in users(:alice)
@@ -220,7 +220,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'Only includes versions that match query when include_versions = true' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     sign_in users(:alice)
@@ -236,7 +236,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'Included versions should be in descending capture_time order' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     sign_in users(:alice)
@@ -255,7 +255,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions can be "1"' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     sign_in users(:alice)
@@ -266,7 +266,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions can be "t"' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     sign_in users(:alice)
@@ -277,7 +277,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions can be value-less (e.g. "pages?include_versions")' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     sign_in users(:alice)
@@ -288,7 +288,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions cannot be an empty string (e.g. "pages?include_versions")' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     sign_in users(:alice)
@@ -323,7 +323,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes all pages when include_versions is true' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     sign_in users(:alice)
@@ -609,7 +609,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can order pages with versions with `?sort=field:direction`' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     sign_in users(:alice)
@@ -628,6 +628,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'only lists versions that are different from the previous version on page data' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     now = Time.now
     page_versions = [
       { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
@@ -650,7 +653,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'only lists versions that are different from the previous version on ?include_versions' do
-    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
     # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
     skip
     now = Time.now

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -185,6 +185,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes versions if include_versions = true' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     sign_in users(:alice)
     get api_v0_pages_path(include_versions: true)
     body = JSON.parse @response.body
@@ -202,6 +205,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes only versions if include_versions = true and include_latest = true' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     sign_in users(:alice)
     get api_v0_pages_path(include_versions: true, include_latest: true)
     body = JSON.parse @response.body
@@ -214,6 +220,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'Only includes versions that match query when include_versions = true' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     sign_in users(:alice)
     get api_v0_pages_path(
       capture_time: '2017-03-01T00:00:00Z..2017-03-01T12:00:00Z',
@@ -227,6 +236,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'Included versions should be in descending capture_time order' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     sign_in users(:alice)
     # Add a version whose natural order and capture_time order are different
     latest_time = pages(:home_page).versions.first.capture_time
@@ -243,6 +255,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions can be "1"' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     sign_in users(:alice)
     get api_v0_pages_path(include_versions: 1)
     body = JSON.parse @response.body
@@ -251,6 +266,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions can be "t"' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     sign_in users(:alice)
     get api_v0_pages_path(include_versions: 't')
     body = JSON.parse @response.body
@@ -259,6 +277,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions can be value-less (e.g. "pages?include_versions")' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     sign_in users(:alice)
     get "#{api_v0_pages_path}?include_versions"
     body = JSON.parse @response.body
@@ -267,6 +288,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'include_versions cannot be an empty string (e.g. "pages?include_versions")' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     sign_in users(:alice)
     get "#{api_v0_pages_path}?include_versions="
     body = JSON.parse @response.body
@@ -299,6 +323,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'includes all pages when include_versions is true' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     sign_in users(:alice)
     # This is a regression test for an issue where limit/offset queries for
     # paging wind up taking into account page-version combinations, not just
@@ -582,6 +609,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can order pages with versions with `?sort=field:direction`' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     sign_in users(:alice)
     get(api_v0_pages_url(params: {
       include_versions: true,
@@ -620,6 +650,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'only lists versions that are different from the previous version on ?include_versions' do
+    # Temporarily skip because of https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264 
+    # until https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
+    skip
     now = Time.now
     page_versions = [
       { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },


### PR DESCRIPTION
Fixes #264 

This is my first attempt at writing code for -db, so I'm probably not doing this idiomatically. I went the very conservative route of mostly commenting out code and skipping tests because we'll re-implement this functionality as described in #274. We'll need edgi-govdata-archiving/web-monitoring-ui#218 merged and deployed before deploying this.

Good news, I learned about implicit behavior in Rails and got to dig around in this repo! 