### PR TITLE
Yet another take on DB configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 # Configuration files
 .powenv
 .env
+.env.*
+!.env.example

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,19 +1,21 @@
-# PostgreSQL. Versions 9.1 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On OS X with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On OS X with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem 'pg'
-#
+# DB-related rake commands execute on both development *and* test environments
+# when the current environment is development, but that means the env vars in
+# .env.test get missed when running rake in development but operating on the
+# test DB. Fix by loading test DATABASE_* vars into DATABASE_*_TEST ◔̯◔
+<%
+  if Rails.env.development? || Rails.env.test?
+    # Copy current environment and overlay test-specific config onto it
+    test_env = {}.update(ENV)
+    Dotenv::ignoring_nonexistent_files do
+      test_env.update(Dotenv::Environment.new('.env.test', true))
+    end
+
+    # Copy any `DATABASE_*` variables to current env as `DATABASE_*_TEST`
+    test_env.each do |key, value|
+      ENV["#{key}_TEST"] = value if key.start_with?('DATABASE')
+    end
+  end
+%>
 default: &default
   adapter: postgresql
   encoding: unicode
@@ -59,6 +61,7 @@ development:
 test:
   <<: *default
   database: web-monitoring-db_test
+  url: <%= ENV['DATABASE_URL_TEST'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -81,7 +84,8 @@ test:
 #
 production:
   <<: *default
-  # database: web-monitoring-db_production
-  # username: web-monitoring-db
-  # password: <%= ENV['WEB-MONITORING-DB_DATABASE_PASSWORD'] %>
+  # Require explicit, complete DB configuration as a URL.
+  # NOTE: DATABASE_RDS is temporary, and allows us to transition databases from
+  # Heroku to AWS RDS before moving the whole application itself (because
+  # Heroku auto-manages DATABASE_URL, changes we make to it won't stick)
   url: <%= ENV['DATABASE_RDS'] || ENV['DATABASE_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,37 +23,12 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: localhost
+  # For more about other options available here, see the guide:
+  # https://guides.rubyonrails.org/configuring.html#configuring-a-database
 
 development:
   <<: *default
   database: web-monitoring-db_development
-
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  #username: webpage-versions-db
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -63,25 +38,6 @@ test:
   database: web-monitoring-db_test
   url: <%= ENV['DATABASE_URL_TEST'] %>
 
-# As with config/secrets.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password as a unix environment variable when you boot
-# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full rundown on how to provide these environment variables in a
-# production deployment.
-#
-# On Heroku and other platform providers, you may have a full connection URL
-# available as an environment variable. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# You can use this database configuration with:
-#
-#   production:
-#     url: <%= ENV['DATABASE_URL'] %>
-#
 production:
   <<: *default
   # Require explicit, complete DB configuration as a URL.


### PR DESCRIPTION
OK, we've had a lot of back-and-forth and confusion over getting databases configured right when they require passwords or are running on different ports, etc. (#294, #358, #359)

The idea here is similar to #294; you can specify a special config by using the `DATABASE_URL` environment variable, which requires you to set all aspects of the connection. Additionally, this provides a workaround for the fact that Rails runs database rake commands twice with different configs if you are in the development environment.

- If you are in a production or test environment, just set the `DATABASE_URL` environment variable.

- If you are in a local environment, where you are using both `development` and `test` configurations, you can either:

    - If you have the old-style setup with a Postgres DB requiring no authentication and superuser status, do nothing!
    - Set `DATABASE_URL` to your development DB info in your `.env` (or `.env.development`) file and set `DATABASE_URL` to your test DB info in your `.env.test` file
    - Set `DATABASE_URL` to your development DB info and `DATABASE_URL_TEST` to your test DB info

**Open question:** do we need to add more granular `DATABASE_*` items, like `DATABASE_USER`?

**TODO:** needs some README cleanup to make all the above more clear.

## Notes on testing

First, make sure your `pg_hba.conf` file (in your postgres data directory) requires `md5` auth instead of `trust`.

Second, make sure you have a few users who can have/not have permissions on things (

```sql
CREATE USER dbdev PASSWORD 'dbdev';
CREATE USER dbtest PASSWORD 'dbtest';
```

Then you can create and drop DBs between tests to your heart’s abandon:

```sql
-- Drop existing DBs
DROP DATABASE IF EXISTS example_rails_dev;
DROP DATABASE IF EXISTS example_rails_test;

-- Set up empty DBs
CREATE DATABASE example_rails_dev;
CREATE DATABASE example_rails_test;
GRANT ALL ON DATABASE example_rails_dev TO dbdev;
GRANT ALL ON DATABASE example_rails_test TO dbtest;

-- Configure Dev DB (needed if dbdev is not a superuser)
\c example_rails_dev
CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
CREATE EXTENSION IF NOT EXISTS "pgcrypto";
CREATE EXTENSION IF NOT EXISTS "plpgsql";
CREATE EXTENSION IF NOT EXISTS "citext";

-- Configure Test DB (needed if dbtest is not a superuser)
\c example_rails_test
CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
CREATE EXTENSION IF NOT EXISTS "pgcrypto";
CREATE EXTENSION IF NOT EXISTS "plpgsql";
CREATE EXTENSION IF NOT EXISTS "citext";
```

Then update your `.env` files or configs or whatever.

Finally, run the app or do `rake db:schema:load` or whatever you need to makes sure is working properly. For a clean new test, redo all the above SQL stuff.

/cc @jsnshrmn @patcon 