### PR TITLE
Add Code of Conduct to README and CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-We love improvements to our tools! EDGI has general [guidelines for contributing](https://github.com/edgi-govdata-archiving/overview/blob/master/CONTRIBUTING.md) to all of our organizational repos.
+We love improvements to our tools! EDGI has general [guidelines for contributing](https://github.com/edgi-govdata-archiving/overview/blob/master/CONTRIBUTING.md) and a [code of conduct](https://github.com/edgi-govdata-archiving/overview/blob/master/CONDUCT.md) for all of our organizational repos.
 
 ## Submitting Web Monitoring Issues
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ This repository falls under EDGI's [Code of Conduct](https://github.com/edgi-gov
 
 ## Contributors
 
-This project wouldn’t exist without a lot of amazing people’s help. Thanks to the following for all their contributions!
+This project wouldn’t exist without a lot of amazing people’s help. Thanks to the following for all their contributions! See our [contributing guidelines](https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/master/CONTRIBUTING.md) to find out how you can help.
 
 <!-- ALL-CONTRIBUTORS-LIST:START -->
 | Contributions | Name |

--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ docker run -p 6379:6379 envirodgi/db-import-worker -e <ENVIRONMENT VARIABLES> .
 
 Point your browser or ``curl`` at ``http://localhost:3000``.
 
+## Code of Conduct
+
+This repository falls under EDGI's [Code of Conduct](https://github.com/edgi-govdata-archiving/overview/blob/master/CONDUCT.md).
 
 ## Contributors
 


### PR DESCRIPTION
Fixes part of [umbrella issue #111](https://github.com/edgi-govdata-archiving/web-monitoring/issues/111) to add CoC to all of the wm repos.