### PR TITLE
Add new S3 buckets to ALLOWED_ARCHIVE_HOSTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           PGHOST: 127.0.0.1
           PGUSER: root
           HOST_URL: 'web-monitoring-db.test'
-          ALLOWED_ARCHIVE_HOSTS: 'https://edgi-versionista-archive.s3.amazonaws.com/ https://test-bucket.s3.amazonaws.com/'
+          ALLOWED_ARCHIVE_HOSTS: 'https://edgi-wm-versionista.s3.amazonaws.com/ https://edgi-versionista-archive.s3.amazonaws.com/ https://test-bucket.s3.amazonaws.com/'
       - image: circleci/postgres:9.5-alpine-ram
         environment:
           POSTGRES_USER: root

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ MAIL_SENDER='some-email-account@example.com'
 # MAIL_SMTP_TLS='true'
 
 # Controls URLs that won't be downloaded and re-hosted when importing versions
-ALLOWED_ARCHIVE_HOSTS='https://edgi-versionista-archive.s3.amazonaws.com/ https://edgi-versionista-archive.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-versionista-archive/'
+ALLOWED_ARCHIVE_HOSTS='https://edgi-wm-versionista.s3.amazonaws.com/ https://edgi-wm-versionista.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-wm-versionista/ https://edgi-versionista-archive.s3.amazonaws.com/ https://edgi-versionista-archive.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-versionista-archive/'
 
 # OPTIONAL: Uncomment & fill in to use S3 for storage instead of your local
 # file system
@@ -58,8 +58,8 @@ TOKEN_PRIVATE_KEY='MIIEogIBAAKCAQEAufNrDQRl6Gj1yuga0DVHeJ4fi+lNWtn4S8XRU8/nBwm9v
 # GOOGLE_CLIENT_ID=XYZ
 # GOOGLE_CLIENT_SECRET=XYZ
 
-# Toggle returning an object with all versions for pages. 
-# We are turning it off temporarily because of the large number of accumulated versions. 
+# Toggle returning an object with all versions for pages.
+# We are turning it off temporarily because of the large number of accumulated versions.
 # See: https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
 # NOTE: This can be removed once this issue is resolved.
 # https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274


### PR DESCRIPTION
We're migrating S3 data between AWS accounts, which also means making new buckets. Instead of `edgi-versionista-archive`, we now have `edgi-wm-versionista`. We're still allowing the old buckets, though, because we haven't actually moved all the data yet.

This is a subtask of edgi-govdata-archiving/web-monitoring#101.