### PR TITLE
Stop archiving if the hash is known and archived

### DIFF
--- a/lib/file_storage/s3.rb
+++ b/lib/file_storage/s3.rb
@@ -15,7 +15,11 @@ module FileStorage
 
     def contains_url?(url_string)
       details = parse_s3_url(url_string)
-      details && details[:bucket] == @bucket
+      return false if details.nil? || details[:bucket] != @bucket
+
+      @client.head_object(bucket: @bucket, key: details[:path]).present?
+    rescue Aws::S3::Errors::NotFound
+      false
     end
 
     def get_file(path)

--- a/test/lib/archiver/archiver_test.rb
+++ b/test/lib/archiver/archiver_test.rb
@@ -3,7 +3,9 @@ require 'test_helper'
 class Archiver::ArchiverTest < ActiveSupport::TestCase
   def setup
     @original_storage = Archiver.store
-    Archiver.store = FileStorage::LocalFile.new(path: Rails.root.join('tmp/test/storage'))
+    path = Rails.root.join('tmp/test/storage')
+    FileUtils.remove_dir(path, force: true)
+    Archiver.store = FileStorage::LocalFile.new(path: path)
   end
 
   def teardown

--- a/test/lib/file_storage/s3_test.rb
+++ b/test/lib/file_storage/s3_test.rb
@@ -40,14 +40,28 @@ class FileStorage::S3Test < ActiveSupport::TestCase
   end
 
   test 's3 storage can determine whether an S3 URI matches it' do
+    stub_request(:head, "https://test-bucket.s3.us-west-2.amazonaws.com/something.txt")
+      .to_return(status: 200, body: "", headers: {})
+    stub_request(:head, "https://test-bucket.s3.us-west-2.amazonaws.com/does-not-exist.txt")
+      .to_return(status: 404, body: "", headers: {})
+
     storage = test_storage
     assert storage.contains_url?('s3://test-bucket/something.txt')
+    assert_not storage.contains_url?('s3://test-bucket/does-not-exist.txt')
+    # No stub because no request should be made (it's in the wrong bucket)
     assert_not storage.contains_url?('s3://other-bucket/something.txt')
   end
 
   test 's3 storage can determine whether an S3 URL matches it' do
+    stub_request(:head, "https://test-bucket.s3.us-west-2.amazonaws.com/something.txt")
+      .to_return(status: 200, body: "", headers: {})
+    stub_request(:head, "https://test-bucket.s3.us-west-2.amazonaws.com/does-not-exist.txt")
+      .to_return(status: 404, body: "", headers: {})
+
     storage = test_storage
     assert storage.contains_url?('https://test-bucket.s3.amazonaws.com/something.txt')
+    assert_not storage.contains_url?('s3://test-bucket/does-not-exist.txt')
+    # No stub because no request should be made (it's in the wrong bucket)
     assert_not storage.contains_url?('https://other-bucket.s3.amazonaws.com/something.txt')
   end
 


### PR DESCRIPTION
Since we store files by their hash, we know that a hash that is already in the store should be good, so we can stop early; there's [generally] no reason to download the content at all. If you *really* want to verify that the content at the URL to archive matches the already known hash, you can set the `force: true` argument.

This also updates the S3 storage layer to actually check whether the object is in the bucket (as opposed to just whether the bucket is correct). I think I had intended to do this before, but never got around to it! :(

Finally, the order of checks in `Archiver.already_archived?()` is reversed so that the cheapest check is first (there's no network hit for determining whether the URL is at an allowable, external archive host).

Fixes #377.