### PR TITLE
Ensure AWS region is set for internal/private storage

### DIFF
--- a/config/initializers/file_storage.rb
+++ b/config/initializers/file_storage.rb
@@ -4,6 +4,7 @@ require_dependency 'file_storage/s3'
 if ENV['AWS_WORKING_BUCKET']
   FileStorage.default = FileStorage::S3.new(
     bucket: ENV['AWS_WORKING_BUCKET'],
+    region: ENV['AWS_WORKING_REGION'] || ENV['AWS_REGION'],
     acl: 'private'
   )
 else


### PR DESCRIPTION
We correctly set the region for public archival storage, but not for internal, private storage of working files. The old storage bucket was in `us-east-1` (the default), so this was easy to miss until edgi-govdata-archiving/web-monitoring#101 was solved.