### PR TITLE
 Add `?include_change_from_*` to version endpoints

### DIFF
--- a/app/jobs/analyze_change_job.rb
+++ b/app/jobs/analyze_change_job.rb
@@ -7,7 +7,7 @@ class AnalyzeChangeJob < ApplicationJob
     change = if from_version
       Change.between(from: from_version, to: to_version)
     else
-      to_version.change_from_previous
+      to_version.ensure_change_from_previous
     end
 
     return unless is_analyzable(change)
@@ -15,9 +15,8 @@ class AnalyzeChangeJob < ApplicationJob
     analyze_change(change)
 
     if compare_earliest
-      earliest = to_version.page.versions.reorder(capture_time: :asc).first
-      change_from_earliest = Change.between(from: earliest, to: to_version)
-      analyze_change(change_from_earliest) if is_analyzable(change_from_earliest)
+      earliest_change = to_version.ensure_change_from_earliest
+      analyze_change(earliest_change) if is_analyzable(earliest_change)
     end
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -10,6 +10,10 @@ class Version < ApplicationRecord
 
   after_create :sync_page_title
 
+  def earliest
+    self.page.versions.reorder(capture_time: :asc).first
+  end
+
   def previous
     self.page.versions.where('capture_time < ?', self.capture_time).first
   end
@@ -19,11 +23,27 @@ class Version < ApplicationRecord
   end
 
   def change_from_previous
-    Change.between(from: previous, to: self)
+    Change.between(from: previous, to: self, create: nil)
   end
 
   def change_from_next
-    Change.between(from: self, to: self.next)
+    Change.between(from: self, to: self.next, create: nil)
+  end
+
+  def change_from_earliest
+    Change.between(from: earliest, to: self, create: nil)
+  end
+
+  def ensure_change_from_previous
+    Change.between(from: previous, to: self, create: :new)
+  end
+
+  def ensure_change_from_next
+    Change.between(from: self, to: self.next, create: :new)
+  end
+
+  def ensure_change_from_earliest
+    Change.between(from: earliest, to: self, create: :new)
   end
 
   def update_different_attribute(save: true)

--- a/lib/tasks/import_from_sheets.rake
+++ b/lib/tasks/import_from_sheets.rake
@@ -84,7 +84,7 @@ def change_for_version_url(url)
       "source_type = 'versionista' AND source_metadata->>'version_id' = ?",
       match[2]
     )
-    return Change.between(from: from_version, to: to_version, create: true)
+    return Change.between(from: from_version, to: to_version, create: :create)
   end
 
   # Handle our URLs
@@ -92,7 +92,7 @@ def change_for_version_url(url)
   if match
     from_version = Version.find(match[1])
     to_version = Version.find(match[2])
-    return Change.between(from: from_version, to: to_version, create: true)
+    return Change.between(from: from_version, to: to_version, create: :create)
   end
 
   raise StandardError, "Unknown change URL format: '#{url}'"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -231,6 +231,24 @@ paths:
           required: false
           type: string
           default: true
+        - name: include_change_from_previous
+          in: query
+          type: boolean
+          required: false
+          default: false
+          description: >
+            If present, include a `change_from_previous` field in the result
+            that represents a change object between this version and the
+            previous version of this page.
+        - name: include_change_from_earliest
+          in: query
+          type: boolean
+          required: false
+          default: false
+          description: >
+            If present, include a `change_from_earliest` field in the result
+            that represents a change object between this version and the
+            earliest version of this page.
       responses:
         '200':
           description: successful operation
@@ -318,6 +336,24 @@ paths:
           required: true
           type: string
           format: uuid4
+        - name: include_change_from_previous
+          in: query
+          type: boolean
+          required: false
+          default: false
+          description: >
+            If present, include a `change_from_previous` field in the result
+            that represents a change object between this version and the
+            previous version of this page.
+        - name: include_change_from_earliest
+          in: query
+          type: boolean
+          required: false
+          default: false
+          description: >
+            If present, include a `change_from_earliest` field in the result
+            that represents a change object between this version and the
+            earliest version of this page.
       responses:
         '200':
           description: successful operation
@@ -914,6 +950,24 @@ paths:
             - `/api/v0/versions?source_metadata[version_id]=12345678`
 
             - `/api/v0/versions?source_metadata[account]=versionista1&source_metadata[has_content]=true`
+        - name: include_change_from_previous
+          in: query
+          type: boolean
+          required: false
+          default: false
+          description: >
+            If present, include a `change_from_previous` field in the result
+            that represents a change object between this version and the
+            previous version of this page.
+        - name: include_change_from_earliest
+          in: query
+          type: boolean
+          required: false
+          default: false
+          description: >
+            If present, include a `change_from_earliest` field in the result
+            that represents a change object between this version and the
+            earliest version of this page.
       responses:
         '200':
           description: successful operation
@@ -936,6 +990,24 @@ paths:
           required: true
           type: string
           format: uuid4
+        - name: include_change_from_previous
+          in: query
+          type: boolean
+          required: false
+          default: false
+          description: >
+            If present, include a `change_from_previous` field in the result
+            that represents a change object between this version and the
+            previous version of this page.
+        - name: include_change_from_earliest
+          in: query
+          type: boolean
+          required: false
+          default: false
+          description: >
+            If present, include a `change_from_earliest` field in the result
+            that represents a change object between this version and the
+            earliest version of this page.
       responses:
         '200':
           description: successful operation

--- a/test/models/change_test.rb
+++ b/test/models/change_test.rb
@@ -48,7 +48,7 @@ class ChangeTest < ActiveSupport::TestCase
   test 'between should create and persist a change if requested' do
     from_version = versions(:page1_v3)
     to_version = versions(:page1_v4)
-    found = Change.between(from: from_version, to: to_version, create: true)
+    found = Change.between(from: from_version, to: to_version, create: :create)
 
     assert(found.is_a?(Change), 'It did not return a Change')
     assert(found.persisted?, 'The returned change was not persisted')
@@ -76,21 +76,21 @@ class ChangeTest < ActiveSupport::TestCase
   end
 
   test 'annotate should create an annotation' do
-    change = versions(:page2_v2).change_from_previous
+    change = versions(:page2_v2).ensure_change_from_previous
     change.annotate({ test_field: 'test_value' }, users(:alice))
 
     assert_equal 1, change.annotations.length, 'The wrong number of annotations were added!'
   end
 
   test 'adding an annotation should update current_annotation' do
-    change = versions(:page2_v2).change_from_previous
+    change = versions(:page2_v2).ensure_change_from_previous
     change.annotate({ test_field: 'test_value' }, users(:alice))
 
     assert_equal({ 'test_field' => 'test_value' }, change.current_annotation)
   end
 
   test 'annotations should merge by including omitted properties and removing null properties' do
-    change = versions(:page2_v2).change_from_previous
+    change = versions(:page2_v2).ensure_change_from_previous
 
     change.annotate({ one: 'a', two: 'b', three: 'c' }, users(:admin_user))
     change.annotate({ one: 'new!', three: nil }, users(:alice))
@@ -99,7 +99,7 @@ class ChangeTest < ActiveSupport::TestCase
   end
 
   test 'annotating a new change should persist it' do
-    change = versions(:page2_v2).change_from_previous
+    change = versions(:page2_v2).ensure_change_from_previous
     assert_not change.persisted?, 'The change we are testing was not newly created'
 
     change.annotate({ test_field: 'test_value' }, users(:alice))
@@ -107,7 +107,7 @@ class ChangeTest < ActiveSupport::TestCase
   end
 
   test 'subsequent annotations by the same user should replace the existing annotation' do
-    change = versions(:page2_v2).change_from_previous
+    change = versions(:page2_v2).ensure_change_from_previous
 
     change.annotate({ one: 'a', two: 'b', three: 'c' }, users(:alice))
     change.annotate({ one: 'new!', three: nil }, users(:alice))
@@ -118,7 +118,7 @@ class ChangeTest < ActiveSupport::TestCase
   end
 
   test 'subsequent annotations with different users should create new annotations' do
-    change = versions(:page2_v2).change_from_previous
+    change = versions(:page2_v2).ensure_change_from_previous
 
     change.annotate({ one: 'a', two: 'b', three: 'c' }, users(:alice))
     change.annotate({ one: 'new!', three: nil }, users(:admin_user))
@@ -127,13 +127,13 @@ class ChangeTest < ActiveSupport::TestCase
   end
 
   test 'annotating with `priority` should update #priority' do
-    change = versions(:page2_v2).change_from_previous
+    change = versions(:page2_v2).ensure_change_from_previous
     change.annotate({ priority: 1 }, users(:alice))
     assert_equal(1, change.priority, '#priority was not updated')
   end
 
   test 'annotating with `significance` should update #significance' do
-    change = versions(:page2_v2).change_from_previous
+    change = versions(:page2_v2).ensure_change_from_previous
     change.annotate({ significance: 1 }, users(:alice))
     assert_equal(1, change.significance, '#significance was not updated')
   end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -6,8 +6,8 @@ class VersionTest < ActiveSupport::TestCase
     assert_equal versions(:page2_v1), previous, 'Previous returned the wrong version'
   end
 
-  test 'change from previous should always return a change object (even if unpersisted)' do
-    change = versions(:page2_v2).change_from_previous
+  test 'ensure change from previous should always return a change object (even if unpersisted)' do
+    change = versions(:page2_v2).ensure_change_from_previous
     assert_not_nil change
   end
 
@@ -16,8 +16,8 @@ class VersionTest < ActiveSupport::TestCase
     assert_equal versions(:page1_v2), next_version, 'Next returned the wrong version'
   end
 
-  test 'change from next should always return a change object (even if unpersisted)' do
-    change = versions(:page2_v1).change_from_next
+  test 'ensure change from next should always return a change object (even if unpersisted)' do
+    change = versions(:page2_v1).ensure_change_from_next
     assert_not_nil change
   end
 


### PR DESCRIPTION
This adds to additional query params to endpoints that return a version or a list of versions:

- `?include_change_from_previous`
- `?include_change_from_earliest`

That include a field with the given name whose value the the change object (if any) representing the the change relative to the requested version. This is implemented *really* inefficiently (so it's very good that you have to ask for it), but I couldn't think of any way to do this better without adding a lot of denormalization. Regardless, I think it's still faster to have the API include this feature than to have the scraper make more API calls when building analyst task sheets.

(One alternative I’m imagining is querying for all Change objects related to captures in a given timeframe via a non-existent `/changes` endpoint and then manually correlating those with a list of Versions. But that’s a *lot* more work for an API consumer.)

This also depends on #406. I was hoping to avoid that, but big API changes here mean it intersects with that PR. Fixes #404.

Note: check just this commit to see the changes here that aren’t part of #406: https://github.com/edgi-govdata-archiving/web-monitoring-db/pull/408/commits/c27146ff82727df1474c01c57a6ab6ba8c19ff98