### PR TITLE
Automatically publish docker images from release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,9 @@ workflows:
       - build:
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - release
 
   build-and-publish:
     jobs:
@@ -74,11 +76,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
-      - hold:
-          type: approval
-          requires:
-            - build
+                - release
       - publish_docker:
           requires:
-            - hold
+            - build


### PR DESCRIPTION
We previously used CircleCI’s “approval” feature for managing the publishing of docker images from the `master` branch. Unfortunately, experience has shown us that what sounds like a promising feature is actually poorly executed enough that it causes confusion and wasted build time on CircleCI. Because nobody gets notified that a job is awaiting approval and jobs can't expire (see *many* CircleCI support tickets requesting this from plenty of users), workflow approvals often get forgotten and are then stuck hanging until someone comes along to clean them out.

Instead, we're adding a `release` branch. Any pushes to this branch will get automatically published to Docker Hub, no approval needed. Management is now handled by someone manually adding a commit from `master` onto `release`.

I’m going to try publishing #406 using this mechanism instead of the approval system to test it out.