### PR TITLE
Clean up and loosen auto-analysis hotfixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,7 @@ ALLOW_VERSIONS_IN_PAGE_RESPONSES='false'
 # Set this in production to look up the user associated with automatic
 # annotations. Note a user with this e-mail must exist.
 # AUTO_ANNOTATION_USER='someone@example.com'
+
+# Set to 'true' to require versions to have valid mime/content/media type fields
+# in order to be automatically analyzed after importing.
+# ANALYSIS_REQUIRE_MEDIA_TYPE='false'

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM base as import-worker
 MAINTAINER enviroDGI@gmail.com
 WORKDIR /app
 
-ENV QUEUE=*
+ENV QUEUES=import,analysis
 ENV VERBOSE=1
 
 CMD ["bundle", "exec", "rake", "environment", "resque:work"]

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec rails server -p $PORT
-worker: QUEUE=* VERBOSE=1 RESQUE_PRE_SHUTDOWN_TIMEOUT=10 RESQUE_TERM_TIMEOUT=10 bundle exec rake environment resque:work
+worker: QUEUES=import,analysis VERBOSE=1 RESQUE_PRE_SHUTDOWN_TIMEOUT=10 RESQUE_TERM_TIMEOUT=10 bundle exec rake environment resque:work

--- a/app/jobs/analyze_change_job.rb
+++ b/app/jobs/analyze_change_job.rb
@@ -182,7 +182,7 @@ class AnalyzeChangeJob < ApplicationJob
   end
 
   def allowed_extension?(url)
-    extension = Addressable::URI.parse(url).extname
+    extension = Addressable::URI.parse(url).try(:extname)
     !extension || !DISALLOWED_EXTENSIONS.include?(extension)
   end
 
@@ -192,13 +192,13 @@ class AnalyzeChangeJob < ApplicationJob
 
   def annotator
     email = ENV['AUTO_ANNOTATION_USER']
-    user = if email
+    user = if email.present?
       User.find_by(email: email)
     elsif !Rails.env.production?
       User.first
     end
 
-    raise StandardError, 'Could not user to annotate changes' unless user
+    raise StandardError, 'Could not find user to annotate changes' unless user
 
     user
   end

--- a/app/jobs/analyze_change_job.rb
+++ b/app/jobs/analyze_change_job.rb
@@ -175,7 +175,7 @@ class AnalyzeChangeJob < ApplicationJob
         media.start_with?('text/') && !DISALLOWED_MEDIA.include?(media)
       )
     elsif !require_media_type?
-      allowed_extension(version.capture_url)
+      allowed_extension?(version.capture_url)
     else
       false
     end

--- a/app/jobs/analyze_change_job.rb
+++ b/app/jobs/analyze_change_job.rb
@@ -80,12 +80,14 @@ class AnalyzeChangeJob < ApplicationJob
     text_diff_changes = text_diff.select {|operation| operation[0] != 0}
     results[:text_diff_hash] = hash_changes(text_diff_changes)
     results[:text_diff_count] = text_diff_changes.length
+    results[:text_diff_length] = text_diff_changes.sum {|code, text| text.length}
     results[:text_diff_ratio] = diff_ratio(text_diff)
 
     source_diff = Differ.for_type!('html_source_dmp').diff(change)['diff']
     diff_changes = source_diff.select {|operation| operation[0] != 0}
     results[:source_diff_hash] = hash_changes(diff_changes)
     results[:source_diff_count] = diff_changes.length
+    results[:source_diff_length] = diff_changes.sum {|code, text| text.length}
     results[:source_diff_ratio] = diff_ratio(source_diff)
 
     # A text diff change necessarily implies a source change; don't double-count

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -1,5 +1,5 @@
 class ImportVersionsJob < ApplicationJob
-  queue_as :default
+  queue_as :import
 
   # TODO: wrap in transaction?
   def perform(import)

--- a/lib/differ/differ.rb
+++ b/lib/differ/differ.rb
@@ -19,8 +19,12 @@ module Differ
 
   # If configured, create a default/fallback differ for a given type.
   def self.default_for_type(type)
-    default_url = @type_map && @type_map[nil]
-    default_url ? SimpleDiff.new(default_url, type) : nil
+    value = @type_map && @type_map[nil]
+    if value.is_a?(String)
+      SimpleDiff.new(value, type)
+    elsif value.respond_to?(:diff)
+      value
+    end
   end
 
   # Hint for other tools to expire cached diffs older than this date.

--- a/lib/tasks/analyze_changes.rake
+++ b/lib/tasks/analyze_changes.rake
@@ -1,0 +1,34 @@
+desc 'Queue up automated analysis for versions added in a given timeframe.'
+task :analyze_changes, [:start_date, :end_date] => [:environment] do |_t, args|
+  # Kind of like find_each, but allows for ordered queries. We need this since
+  # a) UUIDs are not really ordered and b) we are still live inserting data.
+  def iterate_batches(collection, batch_size: 1000)
+    offset = 0
+    loop do
+      items = collection.limit(batch_size).offset(offset)
+      items.each {|item| yield item}
+      break if items.count.zero?
+      offset += batch_size
+    end
+  end
+
+  start_date = args.key?(:start_date) ? Time.parse(args[:start_date]) : nil
+  end_date = args.key?(:end_date) ? Time.parse(args[:end_date]) : nil
+  puts "Searching for versions between #{start_date || 'now'} and #{end_date || 'now'}"
+
+  versions = Version
+    .where_in_unbounded_range('capture_time', [start_date, end_date])
+    .order(created_at: :asc)
+
+  found_versions = 0
+  queued_jobs = 0
+  iterate_batches(versions) do |version|
+    found_versions += 1
+    unless version.change_from_previous
+      AnalyzeChangeJob.perform_later(version)
+      queued_jobs += 1
+    end
+  end
+
+  puts "Queued analysis on #{queued_jobs} of #{found_versions} versions in timeframe."
+end

--- a/lib/tasks/analyze_changes.rake
+++ b/lib/tasks/analyze_changes.rake
@@ -19,7 +19,7 @@ task :analyze_changes, [:start_date, :end_date] => [:environment] do |_t, args|
 
   versions = Version
     .where_in_unbounded_range('capture_time', [start_date, end_date])
-    .order(created_at: :asc)
+    .order(capture_time: :asc)
 
   found_versions = 0
   queued_jobs = 0

--- a/lib/tasks/analyze_changes.rake
+++ b/lib/tasks/analyze_changes.rake
@@ -8,6 +8,7 @@ task :analyze_changes, [:start_date, :end_date] => [:environment] do |_t, args|
       items = collection.limit(batch_size).offset(offset)
       items.each {|item| yield item}
       break if items.count.zero?
+
       offset += batch_size
     end
   end

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -4,11 +4,30 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
   include ActiveJob::TestHelper
 
+  class MockDiffer
+    def diff(change, options = nil)
+      {
+        'change_count' => 2,
+        'diff' => [
+          [0, 'abc'],
+          [-1, 'def'],
+          [1, 'ghi']
+        ],
+        'version' => '0.1.0',
+        'type' => 'html_text_dmp'
+      }
+    end
+  end
+
   # These tests get network privileges (for now)
   def setup
     WebMock.allow_net_connect!
     @original_allowed_hosts = Archiver.allowed_hosts
     Archiver.allowed_hosts = ['https://test-bucket.s3.amazonaws.com']
+    # Imports trigger analysis, which uses these diffs
+    Differ.register('html_source_dmp', MockDiffer.new)
+    Differ.register('html_text_dmp', MockDiffer.new)
+    Differ.register('links_json', MockDiffer.new)
   end
 
   def teardown


### PR DESCRIPTION
This changes several things around our auto-analysis code to firm it up a bit:

1. Cleans up the overall hotfix-related logic so it’s less janky (#411)
2. Loosens the restrictions put in place by the hotfix. Now that we’ve merged edgi-govdata-archiving/web-monitoring-processing#289, we don’t need the strict safety and we can attempt more diffs. **However, this also adds an `ANALYSIS_REQUIRE_MEDIA_TYPE` env var you can set to get the strict, hotfix-style behavior back an emergency.**
3. Splits jobs into two separate queues so they are easy to move to separate processes/images/pods/whatever later. There is now an `import` queue and an `analysis` queue. By default, the Import Worker image runs both, but you can change that with the `QUEUES` environment variable.
4. Adds a rake task for queuing up new analyses.

I’m going to go ahead and merge this in the morning if I don’t see any glaring errors after sleeping on it. That’s not our usual policy, but I want to do our best to have something that works for the analysts on Monday night, and we’ll need some time to run a week’s work of analyses.