### PR TITLE
Exempt the healthcheck endpoint from force_ssl.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,6 +41,12 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  # ...but exempt the healthcheck:
+  config.ssl_options = {
+    redirect: {
+      exclude: -> request { request.path =~ /healthcheck/ }
+    }
+  }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
This should allow Kubernetes liveness/readiness probes to make HTTP requests.

per documentation: https://edgeapi.rubyonrails.org/classes/ActionDispatch/SSL.html

via this SO post: https://stackoverflow.com/a/38572725/1221924