### PR TITLE
Remove conflicting SSL config from Rails upgrade initializer

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -16,6 +16,3 @@ ActiveSupport.to_time_preserves_timezone = true
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = true
-
-# Configure SSL options to enable HSTS with subdomains. Previous versions had false.
-Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
In #418, @jsnshrmn noted that @danielballan’s change to enable non-SSL responses for the healthcheck endpoint didn’t work. That was because the `ssl_config` option was be overridden and re-set by this initializer (initializers run after the environment-specific config files). This is the fix.

The option this was setting is the default — so it wasn't doing anything meaningful other than blowing away the config option that we were setting in the `production` environment config file.

This initializer just sets properties to their new defaults in Rails 5 (it's still hanging around from a very old upgrade) so you can test options that are about to change (or that just changed, depending on which side of the upgrade you're using it on). I'm pretty sure we could just delete this whole initializer file, but I think it'll be safer to save that for a separate commit.