### PR TITLE
Add retry/backoff logic to SimpleDiff

### DIFF
--- a/lib/archiver/archiver.rb
+++ b/lib/archiver/archiver.rb
@@ -87,7 +87,7 @@ module Archiver
       begin
         response = yield
         return response if attempt >= tries || (response.code != 503 && response.code != 504)
-      rescue HTTParty::ResponseError => error
+      rescue HTTParty::ResponseError, Timeout::Error => error
         raise error if attempt >= tries
       end
 


### PR DESCRIPTION
Hopefully this is pretty straightforward. We should generally be expecting that any upstream HTTP service could have intermittent failures (general network problems, machine being restarted, etc). We weren’t doing that with `SimpleDiff`, but this adds it.

Fixes #414.