### PR TITLE
Ensure Version/Page titles are normalized to be a single line, remove surrounding spaces, etc.

### DIFF
--- a/app/models/concerns/simple_title.rb
+++ b/app/models/concerns/simple_title.rb
@@ -1,0 +1,21 @@
+module SimpleTitle
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :normalize_title
+  end
+
+  class_methods do
+    # A class using this concern can provide its own implementation of
+    # normalize_title_string(string) to customize the normalization.
+    def normalize_title_string(title)
+      title.strip.gsub(/\s+/, ' ')
+    end
+  end
+
+  protected
+
+  def normalize_title
+    self.title = self.class.normalize_title_string(title) if title.present?
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,6 +1,7 @@
 class Page < ApplicationRecord
   include UuidPrimaryKey
   include Taggable
+  include SimpleTitle
 
   has_many :versions,
     -> { order(capture_time: :desc) },

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,5 +1,6 @@
 class Version < ApplicationRecord
   include UuidPrimaryKey
+  include SimpleTitle
 
   belongs_to :page, foreign_key: :page_uuid, required: true, inverse_of: :versions, touch: true
   has_many :tracked_changes, class_name: 'Change', foreign_key: 'uuid_to'

--- a/lib/tasks/data/20181124_normalize_titles.rake
+++ b/lib/tasks/data/20181124_normalize_titles.rake
@@ -1,0 +1,62 @@
+namespace :data do
+  desc 'Clean up and normalize badly formatted Page and Version titles.'
+  task :'20181124_normalize_titles', [] => [:environment] do |_t|
+    ActiveRecord::Migration.say_with_time('Updating `uri` on versions to new S3 buckets') do
+      count = 0
+      with_activerecord_log_level(:error) do
+        count += clean_titles(Version)
+        count += clean_titles(Page)
+      end
+
+      count
+    end
+  end
+
+  def clean_titles(model_type)
+    query = model_type
+      .where("title LIKE ' %' OR title LIKE '% ' OR title LIKE '%\n%'")
+      .order(created_at: :asc)
+
+    # We're updating what we're querying on, so just repeat until no results.
+    updated = 0
+    loop do
+      values = query.limit(500).collect do |model|
+        "('#{model.uuid}', '#{model_type.normalize_title_string(model.title)}')"
+      end
+
+      updated += values.length
+      print "   Updating #{updated} #{model_type.to_s.pluralize} with malformed titles...\r"
+      STDOUT.flush
+
+      if values.empty?
+        # We have to print here to clear the \r at end of the last line
+        puts ''
+        break
+      end
+
+      Version.connection.execute(
+        <<-QUERY
+          UPDATE
+            #{model_type.table_name}
+          SET
+            title = valueset.title,
+            updated_at = #{Version.connection.quote(Time.now)}
+          FROM
+            (values #{values.join(',')}) as valueset(uuid, title)
+          WHERE
+            #{model_type.table_name}.uuid = valueset.uuid::uuid
+        QUERY
+      )
+    end
+
+    updated
+  end
+
+  def with_activerecord_log_level(level = :error)
+    original_level = ActiveRecord::Base.logger.level
+    ActiveRecord::Base.logger.level = level
+    yield
+  ensure
+    ActiveRecord::Base.logger.level = original_level
+  end
+end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -14,6 +14,11 @@ class PageTest < ActiveSupport::TestCase
     assert_not(page.valid?, 'The page should be invalid because it has no domain')
   end
 
+  test 'page titles should be single lines with no outside spaces' do
+    page = Page.create(url: 'example1.com/', title: "  This\nis the title\n  ")
+    assert_equal('This is the title', page.title, 'The title was not normalized')
+  end
+
   test 'page title should sync with title from version with most recent capture time' do
     page = pages(:home_page)
     assert_equal('Page One', page.title)

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -46,4 +46,14 @@ class VersionTest < ActiveSupport::TestCase
     assert(Version.find(a2.uuid).different?, 'Updating a version inserted before an existing version updates the existing version, too')
     assert(Version.find(b2.uuid).different?, 'Updating a version inserted before an existing version updates the existing version for a given source_type, too')
   end
+
+  test 'version titles should be single lines with no outside spaces' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      version_hash: 'icanputanythingheremwahahahaha',
+      title: "   This is \n\n the title  \n "
+    )
+    assert_equal('This is the title', version.title, 'The title was not normalized')
+  end
 end


### PR DESCRIPTION
Fixes #430 by adding a concern (a mixing for models) that normalizes the `title` attribute before saving. Both the `Page` and `Version` models use it. I’m thinking it might make sense to extend to tags and maintainers in the future, but that’s out of scope here.

Also adds a data migration to fix existing records with bad titles.