### PR TITLE
Add route for raw version bodies.

### DIFF
--- a/app/controllers/api/v0/raw_controller.rb
+++ b/app/controllers/api/v0/raw_controller.rb
@@ -2,9 +2,8 @@ class Api::V0::RawController < Api::V0::ApiController
 
   def show
     @version ||= Version.find_by(version_hash: params[:id])
-    # TODO: only return a local file if a bucket isn't set. Otherwise redirect to bucket
-    # TODO: don't hardcode path
-    path = '/app/tmp/storage/archive/' + @version.version_hash
+    storage_path = Rails.root.join 'tmp/storage/archive'
+    path = "#{storage_path}/#{@version.version_hash}"
     mime_type = @version.source_metadata['mime_type']
     send_file(path, type: mime_type, disposition: 'inline')
   end

--- a/app/controllers/api/v0/raw_controller.rb
+++ b/app/controllers/api/v0/raw_controller.rb
@@ -1,0 +1,11 @@
+class Api::V0::RawController < Api::V0::ApiController
+
+  def show
+    @version ||= Version.find_by(version_hash: params[:id])
+    # TODO: only return a local file if a bucket isn't set. Otherwise redirect to bucket
+    # TODO: don't hardcode path
+    path = '/app/tmp/storage/archive/' + @version.version_hash
+    mime_type = @version.source_metadata['mime_type']
+    send_file(path, type: mime_type, disposition: 'inline')
+  end
+end

--- a/app/controllers/api/v0/raw_controller.rb
+++ b/app/controllers/api/v0/raw_controller.rb
@@ -8,8 +8,4 @@ class Api::V0::RawController < Api::V0::ApiController
     send_file(path, type: mime_type, disposition: 'inline')
   end
 
-  # This is just a placeholder so the router can build a URL for file_storage.
-  def index
-    head 404
-  end
 end

--- a/app/controllers/api/v0/raw_controller.rb
+++ b/app/controllers/api/v0/raw_controller.rb
@@ -7,4 +7,9 @@ class Api::V0::RawController < Api::V0::ApiController
     mime_type = @version.source_metadata['mime_type']
     send_file(path, type: mime_type, disposition: 'inline')
   end
+
+  # This is just a placeholder so the router can build a URL for file_storage.
+  def index
+    head 404
+  end
 end

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -42,7 +42,6 @@ class Api::V0::VersionsController < Api::V0::ApiController
     elsif !Archiver.already_archived?(@version.uri) || !@version.version_hash
       result = Archiver.archive(@version.uri, expected_hash: @version.version_hash)
       @version.version_hash = result[:hash]
-      # TODO: set the uri to the raw path if result is a local file.
       @version.uri = result[:url]
     end
 

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -30,10 +30,8 @@ class Api::V0::VersionsController < Api::V0::ApiController
     # TODO: only return a local file if a bucket isn't set. Otherwise redirect to bucket
     # TODO: don't hardcode path
     path = '/app/tmp/storage/archive/' + @version.version_hash
-    # handy for testing since it renders html, but pretty mucks with the content.
-    #render file: '/app/tmp/storage/archive/' + @version.version_hash
-    # TODO: sniff mime type
-    send_file(path)
+    mime_type = @version.source_metadata['mime_type']
+    send_file(path, type: mime_type, disposition: 'inline')
   end
 
   def create

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -27,11 +27,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
 
   def raw
     @version ||= version_collection.find(params[:id])
-    # TODO: only return a local file if a bucket isn't set. Otherwise redirect to bucket
-    # TODO: don't hardcode path
-    path = '/app/tmp/storage/archive/' + @version.version_hash
-    mime_type = @version.source_metadata['mime_type']
-    send_file(path, type: mime_type, disposition: 'inline')
+    redirect_to @version.uri and return
   end
 
   def create

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -27,7 +27,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
 
   def raw
     @version ||= version_collection.find(params[:id])
-    redirect_to @version.uri and return
+    redirect_to @version.uri, status: 301 and return
   end
 
   def create

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,12 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Set the default url host so that we can use polymorphic URLs outside of
+  # action controllers.
+  Rails.application.routes.default_url_options = {
+    :host => ENV.fetch('HOST_URL', 'localhost:3000')
+  }
+
   # Mailers
   config.action_mailer.default_url_options = {
     :host => ENV.fetch('HOST_URL', 'localhost:3000')

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,6 +69,12 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "webpage_versions_db_#{Rails.env}"
 
+  # Set the default url host so that we can use polymorphic URLs outside of
+  # action controllers.
+  Rails.application.routes.default_url_options = {
+    :host => ENV.fetch('HOST_URL', 'api.monitoring.envirodatagov.org')
+  }
+
   # Action Mailer configuration
   config.action_mailer.default_url_options = {
     host: ENV.fetch('HOST_URL', 'api.monitoring.envirodatagov.org')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,6 +30,12 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory
   config.active_storage.service = :test
 
+  # Set the default url host so that we can use polymorphic URLs outside of
+  # action controllers.
+  Rails.application.routes.default_url_options = {
+    :host => ENV.fetch('HOST_URL', 'localhost')
+  }
+
   config.action_mailer.perform_caching = false
 
   # Action Mailer host default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
       resources :versions, only: [:show] do
         get 'raw', on: :member
       end
+      resources :raw, only: [:show]
       resources :imports, only: [:create, :show], format: :json
       resources :maintainers, except: [:new, :edit, :destroy], format: :json
       resources :tags, except: [:new, :edit, :destroy], format: :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,8 @@ Rails.application.routes.draw do
       resources :versions, only: [:show] do
         get 'raw', on: :member
       end
-      resources :raw, only: [:show]
+      # raw:index is just a placeholder so we can build a URL for file_storage.
+      resources :raw, only: [:index, :show]
       resources :imports, only: [:create, :show], format: :json
       resources :maintainers, except: [:new, :edit, :destroy], format: :json
       resources :tags, except: [:new, :edit, :destroy], format: :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,8 +31,7 @@ Rails.application.routes.draw do
       resources :versions, only: [:show] do
         get 'raw', on: :member
       end
-      # raw:index is just a placeholder so we can build a URL for file_storage.
-      resources :raw, only: [:index, :show]
+      resources :raw, only: [:show]
       resources :imports, only: [:create, :show], format: :json
       resources :maintainers, except: [:new, :edit, :destroy], format: :json
       resources :tags, except: [:new, :edit, :destroy], format: :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,9 @@ Rails.application.routes.draw do
       end
 
       resources :versions, only: [:index, :show], format: :json
+      resources :versions, only: [:show] do
+        get 'raw', on: :member
+      end
       resources :imports, only: [:create, :show], format: :json
       resources :maintainers, except: [:new, :edit, :destroy], format: :json
       resources :tags, except: [:new, :edit, :destroy], format: :json

--- a/lib/file_storage/local_file.rb
+++ b/lib/file_storage/local_file.rb
@@ -38,9 +38,9 @@ module FileStorage
     end
 
     def contains_url?(url_string)
-      if url_string.starts_with? 'file://'
-        path = url_string[7..-1]
-        File.exist? path
+      if url_string.starts_with?('http://') || url_string.starts_with?('https://')
+        path = url_string.split('/')[-1]
+        File.exist? full_path(path)
       else
         false
       end

--- a/lib/file_storage/local_file.rb
+++ b/lib/file_storage/local_file.rb
@@ -29,7 +29,12 @@ module FileStorage
     end
 
     def url_for_file(path)
-      "file://#{full_path(path)}"
+      if ENV['HOST_URL'].starts_with?('http://') || ENV['HOST_URL'].starts_with?('https://')
+        base_url = ENV['HOST_URL']
+      else
+        base_url = "http://#{ENV['HOST_URL']}"
+      end
+      "#{base_url}/api/v0/raw/#{path}"
     end
 
     def contains_url?(url_string)

--- a/lib/file_storage/local_file.rb
+++ b/lib/file_storage/local_file.rb
@@ -32,8 +32,7 @@ module FileStorage
     end
 
     def url_for_file(path)
-      raw_index_url = polymorphic_url('api_v0_raw_index')
-      "#{raw_index_url}/#{path}"
+      polymorphic_url('api_v0_raw', id: path)
     end
 
     def contains_url?(url_string)

--- a/lib/file_storage/local_file.rb
+++ b/lib/file_storage/local_file.rb
@@ -1,3 +1,6 @@
+include ActionDispatch::Routing::UrlFor
+include Rails.application.routes.url_helpers
+
 module FileStorage
   # Store and retrieve files from the local filesystem.
   class LocalFile
@@ -29,12 +32,8 @@ module FileStorage
     end
 
     def url_for_file(path)
-      if ENV['HOST_URL'].starts_with?('http://') || ENV['HOST_URL'].starts_with?('https://')
-        base_url = ENV['HOST_URL']
-      else
-        base_url = "http://#{ENV['HOST_URL']}"
-      end
-      "#{base_url}/api/v0/raw/#{path}"
+      raw_index_url = polymorphic_url('api_v0_raw_index')
+      "#{raw_index_url}/#{path}"
     end
 
     def contains_url?(url_string)

--- a/test/lib/archiver/archiver_test.rb
+++ b/test/lib/archiver/archiver_test.rb
@@ -1,6 +1,15 @@
 require 'test_helper'
 
 class Archiver::ArchiverTest < ActiveSupport::TestCase
+
+  if ENV['HOST_URL'].starts_with?('http://') || ENV['HOST_URL'].starts_with?('https://')
+    base_url = "#{ENV['HOST_URL']}"
+  else
+    base_url = "http://#{ENV['HOST_URL']}"
+  end
+
+  base_url = "#{base_url}/api/v0/raw"
+
   def setup
     @original_storage = Archiver.store
     path = Rails.root.join('tmp/test/storage')
@@ -19,7 +28,7 @@ class Archiver::ArchiverTest < ActiveSupport::TestCase
       .to_return(body: 'Hello!', status: 200)
 
     result = Archiver.archive('http://example.com')
-    expected_url = "file://#{Rails.root.join('tmp/test/storage', hash)}"
+    expected_url = "#{base_url}/#{hash}"
     assert_equal(expected_url, result[:url])
     assert_equal(hash, result[:hash])
     assert_equal('Hello!', Archiver.store.get_file(hash))

--- a/test/lib/archiver/archiver_test.rb
+++ b/test/lib/archiver/archiver_test.rb
@@ -1,14 +1,10 @@
 require 'test_helper'
+include ActionDispatch::Routing::UrlFor
+include Rails.application.routes.url_helpers
 
 class Archiver::ArchiverTest < ActiveSupport::TestCase
 
-  if ENV['HOST_URL'].starts_with?('http://') || ENV['HOST_URL'].starts_with?('https://')
-    base_url = "#{ENV['HOST_URL']}"
-  else
-    base_url = "http://#{ENV['HOST_URL']}"
-  end
-
-  base_url = "#{base_url}/api/v0/raw"
+  raw_index_url = polymorphic_url('api_v0_raw_index')
 
   def setup
     @original_storage = Archiver.store
@@ -28,7 +24,7 @@ class Archiver::ArchiverTest < ActiveSupport::TestCase
       .to_return(body: 'Hello!', status: 200)
 
     result = Archiver.archive('http://example.com')
-    expected_url = "#{base_url}/#{hash}"
+    expected_url = "#{raw_index_url}/#{hash}"
     assert_equal(expected_url, result[:url])
     assert_equal(hash, result[:hash])
     assert_equal('Hello!', Archiver.store.get_file(hash))

--- a/test/lib/archiver/archiver_test.rb
+++ b/test/lib/archiver/archiver_test.rb
@@ -4,8 +4,6 @@ include Rails.application.routes.url_helpers
 
 class Archiver::ArchiverTest < ActiveSupport::TestCase
 
-  raw_index_url = polymorphic_url('api_v0_raw_index')
-
   def setup
     @original_storage = Archiver.store
     path = Rails.root.join('tmp/test/storage')
@@ -24,7 +22,7 @@ class Archiver::ArchiverTest < ActiveSupport::TestCase
       .to_return(body: 'Hello!', status: 200)
 
     result = Archiver.archive('http://example.com')
-    expected_url = "#{raw_index_url}/#{hash}"
+    expected_url = polymorphic_url('api_v0_raw', id: hash)
     assert_equal(expected_url, result[:url])
     assert_equal(hash, result[:hash])
     assert_equal('Hello!', Archiver.store.get_file(hash))

--- a/test/lib/file_storage/local_file_test.rb
+++ b/test/lib/file_storage/local_file_test.rb
@@ -1,15 +1,10 @@
 require 'test_helper'
+include ActionDispatch::Routing::UrlFor
+include Rails.application.routes.url_helpers
 
 class FileStorage::LocalFileTest < ActiveSupport::TestCase
   storage_path = Rails.root.join('tmp/test/storage')
-
-  if ENV['HOST_URL'].starts_with?('http://') || ENV['HOST_URL'].starts_with?('https://')
-    base_url = "#{ENV['HOST_URL']}"
-  else
-    base_url = "http://#{ENV['HOST_URL']}"
-  end
-
-  base_url = "#{base_url}/api/v0/raw"
+  raw_index_url = polymorphic_url('api_v0_raw_index')
 
   def setup
     @storage = nil
@@ -40,7 +35,7 @@ class FileStorage::LocalFileTest < ActiveSupport::TestCase
   end
 
   test 'does not match non-existant local URLs' do
-    nowhere_url = "#{base_url}/nowhere"
+    nowhere_url = "#{raw_index_url}/nowhere"
     assert_not storage.contains_url?(nowhere_url)
   end
 
@@ -49,7 +44,7 @@ class FileStorage::LocalFileTest < ActiveSupport::TestCase
   end
 
   test 'can generate a local URL' do
-    whatever_url = "#{base_url}/whatever"
+    whatever_url = "#{raw_index_url}/whatever"
     assert_equal whatever_url, storage(path: storage_path).url_for_file('whatever')
   end
 end

--- a/test/lib/file_storage/local_file_test.rb
+++ b/test/lib/file_storage/local_file_test.rb
@@ -4,7 +4,6 @@ include Rails.application.routes.url_helpers
 
 class FileStorage::LocalFileTest < ActiveSupport::TestCase
   storage_path = Rails.root.join('tmp/test/storage')
-  raw_index_url = polymorphic_url('api_v0_raw_index')
 
   def setup
     @storage = nil
@@ -35,7 +34,7 @@ class FileStorage::LocalFileTest < ActiveSupport::TestCase
   end
 
   test 'does not match non-existant local URLs' do
-    nowhere_url = "#{raw_index_url}/nowhere"
+    nowhere_url = polymorphic_url('api_v0_raw', id: 'nowhere')
     assert_not storage.contains_url?(nowhere_url)
   end
 
@@ -44,7 +43,7 @@ class FileStorage::LocalFileTest < ActiveSupport::TestCase
   end
 
   test 'can generate a local URL' do
-    whatever_url = "#{raw_index_url}/whatever"
+    whatever_url = polymorphic_url('api_v0_raw', id: 'whatever')
     assert_equal whatever_url, storage(path: storage_path).url_for_file('whatever')
   end
 end

--- a/test/lib/file_storage/local_file_test.rb
+++ b/test/lib/file_storage/local_file_test.rb
@@ -3,6 +3,14 @@ require 'test_helper'
 class FileStorage::LocalFileTest < ActiveSupport::TestCase
   storage_path = Rails.root.join('tmp/test/storage')
 
+  if ENV['HOST_URL'].starts_with?('http://') || ENV['HOST_URL'].starts_with?('https://')
+    base_url = "#{ENV['HOST_URL']}"
+  else
+    base_url = "http://#{ENV['HOST_URL']}"
+  end
+
+  base_url = "#{base_url}/api/v0/raw"
+
   def setup
     @storage = nil
   end
@@ -27,16 +35,21 @@ class FileStorage::LocalFileTest < ActiveSupport::TestCase
     assert storage.contains_url?(url)
   end
 
-  test 'does not match non-file URLs' do
+  test 'does not match external URLs' do
     assert_not storage.contains_url?('http://somewhere.com')
   end
 
-  test 'does not match file URLs that are not in its directory' do
+  test 'does not match non-existant local URLs' do
+    nowhere_url = "#{base_url}/nowhere"
+    assert_not storage.contains_url?(nowhere_url)
+  end
+
+  test 'does not match file URLs' do
     assert_not storage.contains_url?('file:///nowhere')
   end
 
-  test 'can generate a file URL' do
-    whatever_url = "file://#{storage_path.join 'whatever'}"
+  test 'can generate a local URL' do
+    whatever_url = "#{base_url}/whatever"
     assert_equal whatever_url, storage(path: storage_path).url_for_file('whatever')
   end
 end


### PR DESCRIPTION
I believe this fixes #431, though I implemented it differently than @Mr0grog suggested in that issue. This PR provides a couple of new routes and some changes to `FileStorage::LocalFile`:

### A route that serves up a raw response body from local storage.

- `/api/v0/raw/{hash}`
- `FileStorage::LocalFile.url_for_file` now returns this value instead of a `file://` URL
- file storage and archiver tests now check for these urls

I created this route so that LocalFile could mint usable URLs without knowing about UUIDs. All new locally stored versions are now accessible via the network.

### A shortcut route that redirects to the URI for a version:

- `/api/v0/versions/{uuid}/raw`
- Returns a 301 to whatever location is specified in that version's URI field.

Compared to the suggested implementation, I've reduced this route to a simple shortcut. Local files are the only case of inaccessible snapshots that I am addressing here, and this code assumes that since those are now accessible, all URIs are accessible. That could be wrong. Also, it is adding an extra request for every local file served. If that's a problem, this route could directly return the body as well, although then it would provide two canonical locations for identical content.