### PR TITLE
Add `?include_earliest` query param for pages

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -80,10 +80,17 @@ paths:
             performance.
           required: false
           type: string
+        - name: include_earliest
+          in: query
+          description: >-
+            If true, add an `earliest` key to each page with the earliest version of it. (Note this is not affected by `capture_time`, which only modifies which *pages* are returned.)
+          required: false
+          type: string
+          default: false
         - name: include_latest
           in: query
           description: >-
-            If true, add a latest key to the each item with the latest version.
+            If true, add a `latest` key to each page with the latest version of it. (Note this is not affected by `capture_time`, which only modifies which *pages* are returned.)
           required: false
           type: string
           default: false

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -175,6 +175,15 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
       'Results included pages with versions not captured in the filtered date range'
   end
 
+  test 'includes earliest version if include_earliest = true' do
+    sign_in users(:alice)
+    get api_v0_pages_path(include_earliest: true)
+    body = JSON.parse @response.body
+    results = body['data']
+
+    assert_kind_of Hash, results[0]['earliest'], '"earliest" property was not a hash'
+  end
+
   test 'includes latest version if include_latest = true' do
     sign_in users(:alice)
     get api_v0_pages_path(include_latest: true)


### PR DESCRIPTION
We already had an `?include_latest` and this adds an `?include_earliest` to match. This comes without an issue discussing it because repeated recent failures in our analyst sheet generation have made the need for this abundantly clear (otherwise we wind up making *thousands* of queries to `/api/v0/pages/{id}/versions?chunk_size=1&sort=capture_time:asc` to get the earliest version of each page on each sheet generation run).