### PR TITLE
Add `active` flag to Pages

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -64,6 +64,16 @@ class Api::V0::ApiController < ApplicationController
     /^(true|t|1)$/i.match? value
   end
 
+  # Returns a boolean OR nil for this param Unlike boolean params above, this
+  # will return nil for `?param` and `?param=`. To get a true or false, the
+  # querystring must explicitly set it. (`?param=true`, `?param=false`, etc.)
+  def nullable_boolean_param(param)
+    value = params[param]
+    return nil unless value.present?
+
+    /^(true|t|1)$/i.match?(value.downcase.strip)
+  end
+
   def parse_date!(date)
     raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d\:\d\d(\:\d\d(\.\d+)?)?(Z|([+\-]\d\d:?\d\d)))?$/)
     Time.parse date

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -141,6 +141,9 @@ class Api::V0::PagesController < Api::V0::ApiController
       end
     end
 
+    active_test = nullable_boolean_param(:active)
+    collection = collection.where(active: active_test) unless active_test.nil?
+
     # If any queries create implicit joins, ensure we get a list of unique pages
     collection = collection.distinct.order(updated_at: :desc)
 

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -63,6 +63,10 @@ class ImportVersionsJob < ApplicationJob
       warn "Skipped unknown URL: #{record['page_url']}@#{record['capture_time']}"
       return
     end
+    unless page.active?
+      warn "Skipped inactive URL: #{page.url}"
+      return
+    end
 
     existing = page.versions.find_by(
       capture_time: record['capture_time'],

--- a/db/migrate/20181128194410_add_active_to_pages.rb
+++ b/db/migrate/20181128194410_add_active_to_pages.rb
@@ -1,0 +1,5 @@
+class AddActiveToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180418061850) do
+ActiveRecord::Schema.define(version: 2018_11_28_194410) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
   enable_extension "citext"
   enable_extension "pgcrypto"
+  enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "annotations", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 20180418061850) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "url_key"
+    t.boolean "active", default: true
     t.index ["site"], name: "index_pages_on_site"
     t.index ["url"], name: "index_pages_on_url"
     t.index ["url_key"], name: "index_pages_on_url_key"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -85,7 +85,7 @@ paths:
           description: >-
             If true, add a latest key to the each item with the latest version.
           required: false
-          type: string
+          type: boolean
           default: false
         - name: source_type
           in: query
@@ -147,7 +147,15 @@ paths:
             is, you get all pages that have any of the tags
             requested, not only pages that have all of the
             tags listed.
-
+        - name: active
+          in: query
+          description: >-
+            If set, only include pages that are either active (when set to
+            `true`) or inactive (when set to `false`). (If unset, you get all
+            pages.) “Inactive” pages are pages that are no longer updated with
+            new versions in the database.
+          required: false
+          type: boolean
       responses:
         '200':
           description: successful operation

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -700,4 +700,31 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes(uuids, page_versions[2].uuid)
     assert_not_includes(uuids, page_versions[3].uuid)
   end
+
+  test 'includes active and inactive pages if ?active not present' do
+    sign_in users(:alice)
+    get(api_v0_pages_url)
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert(body['data'].any? {|page| page['active'] == true})
+    assert(body['data'].any? {|page| page['active'] == false})
+  end
+
+  test 'includes only active pages if ?active=true' do
+    sign_in users(:alice)
+    get(api_v0_pages_url(params: { active: true }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert(body['data'].any? {|page| page['active'] == true})
+    assert(!body['data'].any? {|page| page['active'] == false})
+  end
+
+  test 'includes only inactive pages if ?active=false' do
+    sign_in users(:alice)
+    get(api_v0_pages_url(params: { active: false }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert(!body['data'].any? {|page| page['active'] == true})
+    assert(body['data'].any? {|page| page['active'] == false})
+  end
 end

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -27,3 +27,8 @@ other_page_one:
   title: 'Page One'
   agency: 'Department of Whatever'
   site: 'http://example3.com/'
+
+inactive_page:
+  url: 'http://example-inactive.com/'
+  title: 'Some Page We Do Not Want!'
+  active: false


### PR DESCRIPTION
This flag is *mainly* meant to be used as a signal to ETL tools pulling in data from other systems (e.g. Versionista, Wayback) to not worry about pulling in data for a given URL. It lets us stop worry about expending resources monitoring pages we no longer think are worthwhile.

It also causes the import job to ignore data and not create a version if the page it would be associated with is inactive (so a dumb ETL script can safely send data for inactive pages and have it ignored).