### PR TITLE
Quote title text in data migration

### DIFF
--- a/lib/tasks/data/20181124_normalize_titles.rake
+++ b/lib/tasks/data/20181124_normalize_titles.rake
@@ -21,7 +21,8 @@ namespace :data do
     updated = 0
     loop do
       values = query.limit(500).collect do |model|
-        "('#{model.uuid}', '#{model_type.normalize_title_string(model.title)}')"
+        new_title = model_type.normalize_title_string(model.title)
+        "('#{model.uuid}', #{Version.connection.quote(new_title)})"
       end
 
       updated += values.length


### PR DESCRIPTION
I failed to properly escape the new `title` field value in the data migration for #436, resulting in https://sentry.io/environmental-data-governance-/db-prod/issues/787187315/activity/

This is pretty simple — just make sure we `Version.connection.quote` the new title.