### PR TITLE
Ensure `/pages/{id}/changes` lists correct changes

### DIFF
--- a/app/controllers/api/v0/changes_controller.rb
+++ b/app/controllers/api/v0/changes_controller.rb
@@ -44,7 +44,8 @@ class Api::V0::ChangesController < Api::V0::ApiController
   end
 
   def changes_collection
-    collection = Change.order(created_at: :asc)
+    collection = page ? page.tracked_changes : Change
+    collection = collection.order(created_at: :asc)
     collection = where_in_interval_param(collection, :priority)
     collection = where_in_interval_param(collection, :significance)
     sort_using_params(collection)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -31,6 +31,8 @@ class Page < ApplicationRecord
     end),
     foreign_key: 'page_uuid',
     class_name: 'Version'
+  # This needs a funky name because `changes` is a an activerecord method
+  has_many :tracked_changes, through: :versions
 
   has_many :maintainerships, foreign_key: :page_uuid
   has_many :maintainers, through: :maintainerships

--- a/test/controllers/api/v0/changes_controller_test.rb
+++ b/test/controllers/api/v0/changes_controller_test.rb
@@ -14,6 +14,12 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
     assert body.key?('data'), 'Response should have a "data" property'
     assert body.key?('meta'), 'Response should have a "meta" property'
     assert(body['data'].is_a?(Array), 'Data should be an array')
+
+    foreign_change_id = changes(:page2_change_1_2).uuid
+    assert_not(
+      body['data'].any? {|change| change['uuid'] == foreign_change_id},
+      'Response included a change from a different page'
+    )
   end
 
   test 'can get a single change by version IDs' do
@@ -123,9 +129,9 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'application/json', @response.content_type
     body = JSON.parse @response.body
     assert_equal(
-      Change.count,
+      page.tracked_changes.count,
       body['meta']['total_results'],
-      'Should contain count of total results across all pages'
+      'Should contain count of total results across all chunks'
     )
   end
 

--- a/test/fixtures/changes.yml
+++ b/test/fixtures/changes.yml
@@ -15,3 +15,9 @@ page1_change_4_5:
   version: page1_v5
   priority: 0.75
   significance: 0.5
+
+page2_change_1_2:
+  from_version: page2_v1
+  version: page2_v2
+  priority: 0.5,
+  significance: 0.5

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -93,6 +93,24 @@ page1_v3:
     diff_hash: '749ab2c0d06c42ae3b841b79e79875f02b3a042e43c92378cd28bd444c04d284'
   }
 
+page2_v3:
+  page: sub_page
+  uri: 'http://example1.com/page2_v3'
+  capture_time: '2017-03-03T00:00:01Z'
+  version_hash: 'vwx'
+  source_type: 'versionista'
+  source_metadata: {
+    account: 'test@example.com',
+    site_id: 1,
+    page_id: 12,
+    version_id: 123,
+    page_url: 'http://versionista.com/1/12/',
+    diff_with_previous_url: 'http://versionista.com/1/12/123/',
+    diff_with_first_url: nil,
+    diff_length: 1234678,
+    diff_hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+  }
+
 page1_v4:
   page: home_page
   capture_time: '2017-03-04T00:00:00Z'

--- a/test/models/change_test.rb
+++ b/test/models/change_test.rb
@@ -76,21 +76,21 @@ class ChangeTest < ActiveSupport::TestCase
   end
 
   test 'annotate should create an annotation' do
-    change = versions(:page2_v2).ensure_change_from_previous
+    change = versions(:page2_v3).ensure_change_from_previous
     change.annotate({ test_field: 'test_value' }, users(:alice))
 
     assert_equal 1, change.annotations.length, 'The wrong number of annotations were added!'
   end
 
   test 'adding an annotation should update current_annotation' do
-    change = versions(:page2_v2).ensure_change_from_previous
+    change = versions(:page2_v3).ensure_change_from_previous
     change.annotate({ test_field: 'test_value' }, users(:alice))
 
     assert_equal({ 'test_field' => 'test_value' }, change.current_annotation)
   end
 
   test 'annotations should merge by including omitted properties and removing null properties' do
-    change = versions(:page2_v2).ensure_change_from_previous
+    change = versions(:page2_v3).ensure_change_from_previous
 
     change.annotate({ one: 'a', two: 'b', three: 'c' }, users(:admin_user))
     change.annotate({ one: 'new!', three: nil }, users(:alice))
@@ -99,7 +99,7 @@ class ChangeTest < ActiveSupport::TestCase
   end
 
   test 'annotating a new change should persist it' do
-    change = versions(:page2_v2).ensure_change_from_previous
+    change = versions(:page2_v3).ensure_change_from_previous
     assert_not change.persisted?, 'The change we are testing was not newly created'
 
     change.annotate({ test_field: 'test_value' }, users(:alice))
@@ -107,7 +107,7 @@ class ChangeTest < ActiveSupport::TestCase
   end
 
   test 'subsequent annotations by the same user should replace the existing annotation' do
-    change = versions(:page2_v2).ensure_change_from_previous
+    change = versions(:page2_v3).ensure_change_from_previous
 
     change.annotate({ one: 'a', two: 'b', three: 'c' }, users(:alice))
     change.annotate({ one: 'new!', three: nil }, users(:alice))
@@ -118,7 +118,7 @@ class ChangeTest < ActiveSupport::TestCase
   end
 
   test 'subsequent annotations with different users should create new annotations' do
-    change = versions(:page2_v2).ensure_change_from_previous
+    change = versions(:page2_v3).ensure_change_from_previous
 
     change.annotate({ one: 'a', two: 'b', three: 'c' }, users(:alice))
     change.annotate({ one: 'new!', three: nil }, users(:admin_user))
@@ -127,13 +127,13 @@ class ChangeTest < ActiveSupport::TestCase
   end
 
   test 'annotating with `priority` should update #priority' do
-    change = versions(:page2_v2).ensure_change_from_previous
+    change = versions(:page2_v3).ensure_change_from_previous
     change.annotate({ priority: 1 }, users(:alice))
     assert_equal(1, change.priority, '#priority was not updated')
   end
 
   test 'annotating with `significance` should update #significance' do
-    change = versions(:page2_v2).ensure_change_from_previous
+    change = versions(:page2_v3).ensure_change_from_previous
     change.annotate({ significance: 1 }, users(:alice))
     assert_equal(1, change.significance, '#significance was not updated')
   end


### PR DESCRIPTION
It turns out we were spuriously listing ALL changes (not just the changes for a specified page) at `/api/v0/pages/{page_id}/changes`, which is totally and completely wrong. We also had a wrong test verifying wrong behavior. Don't know how this ever made it in, but it's fixed now.