### PR TITLE
Add `status` fields to versions and pages

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -135,6 +135,7 @@ class Api::V0::PagesController < Api::V0::ApiController
       'versions.capture_time',
       &method(:parse_date!)
     )
+    collection = where_in_interval_param(collection, :status)
 
     version_params = params.permit(:hash, :source_type)
     if version_params.present?

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -107,6 +107,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
     end
 
     collection = where_in_range_param(collection, :capture_time, &method(:parse_date!))
+    collection = where_in_interval_param(collection, :status)
 
     sort_using_params(collection)
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -38,6 +38,9 @@ class Page < ApplicationRecord
   before_create :ensure_url_key
   before_save :normalize_url
   validate :url_must_have_domain
+  validates :status,
+    allow_nil: true,
+    inclusion: { in: 100...600, message: 'is not between 100 and 599' }
 
   def self.find_by_url(raw_url)
     url = normalize_url(raw_url)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -10,6 +10,9 @@ class Version < ApplicationRecord
     foreign_key: 'uuid_to'
 
   after_create :sync_page_title
+  validates :status,
+    allow_nil: true,
+    inclusion: { in: 100...600, message: 'is not between 100 and 599' }
 
   def earliest
     self.page.versions.reorder(capture_time: :asc).first

--- a/db/migrate/20181204192154_add_status_to_versions_and_pages.rb
+++ b/db/migrate/20181204192154_add_status_to_versions_and_pages.rb
@@ -1,0 +1,6 @@
+class AddStatusToVersionsAndPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :versions, :status, :integer, null: true
+    add_column :pages, :status, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_28_194410) do
+ActiveRecord::Schema.define(version: 2018_12_04_192154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2018_11_28_194410) do
     t.datetime "updated_at", null: false
     t.string "url_key"
     t.boolean "active", default: true
+    t.integer "status"
     t.index ["site"], name: "index_pages_on_site"
     t.index ["url"], name: "index_pages_on_url"
     t.index ["url_key"], name: "index_pages_on_url_key"
@@ -149,6 +150,7 @@ ActiveRecord::Schema.define(version: 2018_11_28_194410) do
     t.string "title"
     t.string "capture_url"
     t.boolean "different", default: true
+    t.integer "status"
     t.index ["capture_time"], name: "index_versions_on_capture_time"
     t.index ["page_uuid"], name: "index_versions_on_page_uuid"
     t.index ["version_hash"], name: "index_versions_on_version_hash"

--- a/lib/tasks/data/20181204_set_version_status.rake
+++ b/lib/tasks/data/20181204_set_version_status.rake
@@ -1,0 +1,119 @@
+namespace :data do
+  desc 'Set the `status` field on all versions based on `source_metadata`.'
+  task :'20181204_set_version_status', [] => [:environment] do |_t|
+    ActiveRecord::Migration.say_with_time('Updating `status` on versions') do
+      with_activerecord_log_level(:error) do
+        set_version_statuses()
+      end
+    end
+  end
+
+  def set_version_statuses()
+    query = Version
+      .where(source_type: 'versionista')
+      .where("versions.source_metadata ? 'error_code'")
+      .order(created_at: :desc)
+
+    for_each_batch(query, 1000, 'Updating {n} versionista versions...') do |collection|
+      bulk_update(collection, [:status]) do |version|
+        [version.source_metadata['error_code'].to_i]
+      end
+    end
+
+    query = Version
+      .where(source_type: 'internet_archive')
+      .order(created_at: :desc)
+
+    for_each_batch(query, 1000, 'Updating {n} wayback versions...') do |collection|
+      bulk_update(collection, [:status]) do |version|
+        [version.source_metadata['status_code'].to_i]
+      end
+    end
+  end
+
+  def with_activerecord_log_level(level = :error)
+    original_level = ActiveRecord::Base.logger.level
+    ActiveRecord::Base.logger.level = level
+    yield
+  ensure
+    ActiveRecord::Base.logger.level = original_level
+  end
+
+  # Blocks an ActiveRecord query into batches of N records, then calls a block
+  # with the query for each batch. Optionally accepts a message to log before
+  # each batch. "{n}" in the message will be replaced with the number of items
+  # in the batch.
+  #
+  # The given block can yield a new query, which is useful in cases where the
+  # block modifies records in a way that would change what would be in the next
+  # batch.
+  def for_each_batch(query, batch_size, message = nil)
+    total = 0
+    offset = 0
+    loop do
+      items = query.limit(batch_size).offset(offset)
+      count = items.count
+      offset += batch_size
+      total += count
+
+      if message
+        if count > 0
+          print "  #{message.gsub('{n}', count.to_s)}\r"
+        else
+          print "\n"
+        end
+        STDOUT.flush
+      end
+
+      break if count.zero?
+
+      next_query = yield items
+      if !next_query.nil? && next_query.respond_to?(:limit) && next_query.respond_to?(:offset)
+        query = next_query
+        offset = 0
+      end
+    end
+
+    total
+  end
+
+  # Update many records with different values at once. (But it must update the
+  # same *attributes* on each record.) This takes an ActiveRecord collection to
+  # iterate over and gather the updates, then a list of the attributes that
+  # will be updated.
+  #
+  # The given block must yield an array containing the new value for each of
+  # the specified attributes. If it yields nil, the record won't be updated.
+  #
+  # NOTE: this only works with Postgres.
+  def bulk_update(collection, fields)
+    model_type = collection.model
+    connection = collection.connection
+
+    values = []
+    collection.each do |item|
+      changes = yield item
+      next if changes.nil? || changes.empty?
+
+      changes = changes.collect {|value| connection.quote(value)}
+      values << "('#{item.uuid}', #{changes.join(', ')})"
+    end
+
+    setters = fields.collect {|field| "#{field} = valueset.#{field}"}.join(', ')
+    valueset = "valueset(uuid, #{fields.join(', ')})"
+
+    collection.connection.execute(
+      <<-QUERY
+        UPDATE
+          #{model_type.table_name}
+        SET
+          #{setters},
+          updated_at = #{connection.quote(Time.now)}
+        FROM
+          (values #{values.join(',')}) as valueset(uuid, #{fields.join(', ')})
+        WHERE
+          #{model_type.table_name}.uuid = valueset.uuid::uuid
+      QUERY
+    )
+  end
+end

--- a/lib/tasks/data/20181204_set_version_status.rake
+++ b/lib/tasks/data/20181204_set_version_status.rake
@@ -3,12 +3,12 @@ namespace :data do
   task :'20181204_set_version_status', [] => [:environment] do |_t|
     ActiveRecord::Migration.say_with_time('Updating `status` on versions') do
       with_activerecord_log_level(:error) do
-        set_version_statuses()
+        set_version_statuses
       end
     end
   end
 
-  def set_version_statuses()
+  def set_version_statuses
     query = Version
       .where(source_type: 'versionista')
       .where("versions.source_metadata ? 'error_code'")
@@ -57,7 +57,7 @@ namespace :data do
       total += count
 
       if message
-        if count > 0
+        if count.positive?
           print "  #{message.gsub('{n}', count.to_s)}\r"
         else
           print "\n"
@@ -100,7 +100,6 @@ namespace :data do
     end
 
     setters = fields.collect {|field| "#{field} = valueset.#{field}"}.join(', ')
-    valueset = "valueset(uuid, #{fields.join(', ')})"
 
     collection.connection.execute(
       <<-QUERY

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -163,6 +163,16 @@ paths:
             new versions in the database.
           required: false
           type: boolean
+        - name: status
+          in: query
+          type: string
+          required: false
+          description: >-
+            Include only pages with the given HTTP status code, e.g. `200` or
+            `404`. You may also specify a range using standard mathematical
+            notation for intervals. For example, to get pages with 4XX statuses:
+
+                ?status=[400,500)
       responses:
         '200':
           description: successful operation
@@ -264,6 +274,16 @@ paths:
             If present, include a `change_from_earliest` field in the result
             that represents a change object between this version and the
             earliest version of this page.
+        - name: status
+          in: query
+          type: string
+          required: false
+          description: >-
+            Include only versions with the given HTTP status code, e.g. `200` or
+            `404`. You may also specify a range using standard mathematical
+            notation for intervals. For example, to get all 4XX status versions:
+
+                ?status=[400,500)
       responses:
         '200':
           description: successful operation
@@ -983,6 +1003,16 @@ paths:
             If present, include a `change_from_earliest` field in the result
             that represents a change object between this version and the
             earliest version of this page.
+        - name: status
+          in: query
+          type: string
+          required: false
+          description: >-
+            Include only versions with the given HTTP status code, e.g. `200` or
+            `404`. You may also specify a range using standard mathematical
+            notation for intervals. For example, to get all 4XX status versions:
+
+                ?status=[400,500)
       responses:
         '200':
           description: successful operation

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -736,4 +736,20 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert(!body['data'].any? {|page| page['active'] == true})
     assert(body['data'].any? {|page| page['active'] == false})
   end
+
+  test 'filters by status using ?status=code' do
+    sign_in users(:alice)
+    get(api_v0_pages_url(params: { status: 404 }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert(body['data'].all? {|page| page['status'] == 404})
+  end
+
+  test 'filters by status interval using ?status=interval' do
+    sign_in users(:alice)
+    get(api_v0_pages_url(params: { status: '[400,500)' }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert(body['data'].all? {|page| page['status'] >= 400 && page['status'] < 500})
+  end
 end

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -264,4 +264,20 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     assert_includes(uuids, page_versions[2].uuid)
     assert_includes(uuids, page_versions[3].uuid)
   end
+
+  test 'filters by status using ?status=code' do
+    sign_in users(:alice)
+    get(api_v0_versions_url(params: { status: 404 }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert(body['data'].all? {|item| item['status'] == 404})
+  end
+
+  test 'filters by status interval using ?status=interval' do
+    sign_in users(:alice)
+    get(api_v0_versions_url(params: { status: '[400,500)' }))
+    assert_response(:success)
+    body = JSON.parse(@response.body)
+    assert(body['data'].all? {|item| item['status'] >= 400 && item['status'] < 500})
+  end
 end

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -3,6 +3,7 @@ home_page:
   title: 'Page One'
   agency: 'Department of Examples'
   site: 'http://example1.com/'
+  status: 200
 
 sub_page:
   url: 'http://example1.com/page2.html'
@@ -15,18 +16,21 @@ home_page_site2:
   title: 'Site 2, yo!'
   agency: 'Department of Examples'
   site: 'http://example2.com/'
+  status: 404
 
 dot_home_page:
   url: 'http://depart-of-testing.com/index.html'
   title: 'Welcome to the Department of Testing'
   agency: 'Department of Testing'
   site: 'DOT - Home Site'
+  status: 403
 
 other_page_one:
   url: 'http://example3.com/'
   title: 'Page One'
   agency: 'Department of Whatever'
   site: 'http://example3.com/'
+  status: 500
 
 inactive_page:
   url: 'http://example-inactive.com/'

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -9,6 +9,7 @@ page1_v1:
   uri: 'http://example1.com/page1_v1'
   capture_time: '2017-03-01T00:00:00Z'
   version_hash: 'abc'
+  status: 200
   source_type: 'versionista'
   source_metadata: {
     account: 'test@example.com',
@@ -27,6 +28,7 @@ page2_v1:
   uri: 'http://example1.com/page2_v1'
   capture_time: '2017-03-01T00:00:01Z'
   version_hash: 'def'
+  status: 200
   source_type: 'versionista'
   source_metadata: {
     account: 'test@example.com',
@@ -45,6 +47,7 @@ page1_v2:
   uri: 'http://example1.com/page1_v2'
   capture_time: '2017-03-02T00:00:00Z'
   version_hash: 'ghi'
+  status: 403
   source_type: 'versionista'
   source_metadata: {
     account: 'test@example.com',
@@ -80,6 +83,7 @@ page1_v3:
   page: home_page
   capture_time: '2017-03-03T00:00:00Z'
   version_hash: 'mno'
+  status: 404
   source_type: 'versionista'
   source_metadata: {
     account: 'test@example.com',
@@ -97,6 +101,7 @@ page1_v4:
   page: home_page
   capture_time: '2017-03-04T00:00:00Z'
   version_hash: 'pqr'
+  status: 500
   source_type: 'pagefreezer'
   source_metadata: {
     account: 'test@example.com',

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -124,4 +124,19 @@ class PageTest < ActiveSupport::TestCase
     page = Page.create(url: 'http://sub.EXAMPLE.com/somewhere')
     assert_equal('com,example,sub)/somewhere', page.url_key)
   end
+
+  test 'page status must be a valid status code or nil' do
+    page = pages(:home_page)
+    page.status = nil
+    assert(page.valid?, 'A nil status was not valid')
+
+    page.status = 200
+    assert(page.valid?, 'A 200 status was not valid')
+
+    page.status = 1000
+    assert_not(page.valid?, 'A 1000 status was valid')
+
+    page.status = 'whats this now'
+    assert_not(page.valid?, 'A text status was valid')
+  end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -56,4 +56,19 @@ class VersionTest < ActiveSupport::TestCase
     )
     assert_equal('This is the title', version.title, 'The title was not normalized')
   end
+
+  test 'version status must be a valid status code or nil' do
+    version = versions(:page1_v1)
+    version.status = nil
+    assert(version.valid?, 'A nil status was not valid')
+
+    version.status = 200
+    assert(version.valid?, 'A 200 status was not valid')
+
+    version.status = 1000
+    assert_not(version.valid?, 'A 1000 status was valid')
+
+    version.status = 'whats this now'
+    assert_not(version.valid?, 'A text status was valid')
+  end
 end


### PR DESCRIPTION
This fixes #450, and does some of #451:

- Adds `status` as a nullable integer field to page and version records.
- Sets up validation so we get nice importing behavior.
- Adds a data migration for filling in `status` on *versions* (but not pages). Note we shouldn’t *run* this migration until all our ETL tooling starts sending `status` as a top-level field instead of in `source_metadata`; that way we only have to run it once.
- Adds querying via `?status={value}`, where `{value}` is an interval. We added interval support in #104 for `priority` and `significance` on annotations. It lets you do some nice stuff using standard mathematical notation:
    - `?status=404` filter by an exact status
    - `?status=[400,500)` get all 4xx statuses by using an interval with an inclusive start and an exclusive end
    - `?status=[400,)` get all error statuses by using an interval with an inclusive start and an open end
    - `?status=(,400)` get all success statuses by using an interval with an open start and an exclusive end

I think this is good to go and I do *not* intend to do all of #451 here. I’ll do a separate PR for migrating data on pages and for automatically updating page statues on a schedule/on import, since that’s significantly more complicated.