### PR TITLE
Change `Version#different` to ignore source_type

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -51,18 +51,12 @@ class Version < ApplicationRecord
   end
 
   def update_different_attribute(save: true)
-    previous = page.versions
-      .where(source_type: self.source_type)
-      .where('capture_time < ?', self.capture_time)
-      .reorder(capture_time: :desc)
-      .first
-
+    previous = self.previous
     self.different = previous.nil? || previous.version_hash != version_hash
     self.save if save
 
     if self.different?
       following = page.versions
-        .where(source_type: self.source_type)
         .where('capture_time > ?', self.capture_time)
         .reorder(capture_time: :asc)
 

--- a/lib/tasks/data/20181204_set_version_status.rake
+++ b/lib/tasks/data/20181204_set_version_status.rake
@@ -99,6 +99,8 @@ namespace :data do
       values << "('#{item.uuid}', #{changes.join(', ')})"
     end
 
+    return 0 if values.empty?
+
     setters = fields.collect {|field| "#{field} = valueset.#{field}"}.join(', ')
 
     collection.connection.execute(

--- a/lib/tasks/data/20181205_update_version_different.rake
+++ b/lib/tasks/data/20181205_update_version_different.rake
@@ -1,0 +1,112 @@
+namespace :data do
+  desc 'Set the `different` field on all versions.'
+  task :'20181205_update_version_different', [] => [:environment] do |_t|
+    ActiveRecord::Migration.say_with_time('Updating `different` on versions, this will take a while...') do
+      with_activerecord_log_level(:error) do
+        update_different_by_page
+      end
+    end
+  end
+
+  def update_different_by_page
+    ordered_pages = Page.all.order(uuid: :asc)
+    total_pages = ordered_pages.count
+
+    last_update = Time.now - 10
+    page_count = 0
+    version_count = 0
+    iterate_each(ordered_pages) do |page|
+      # This is a more strictly correct method for updating the `different`
+      # flag, but it is infeasibly slow for production (~4000 versions/minute)
+      # page.versions.reorder(capture_time: :asc)[1..-1].each do |version|
+      #   version.update_different_attribute
+      #   version_count += 1
+      # end
+
+      # Use a custom method for setting `different`. This isn't great, but I'm
+      # not sure how to best modify Version#update_different_attribute to make
+      # it remotely performant for large updates :\
+      previous = nil
+      bulk_update(page.versions.reorder(capture_time: :asc), [:different]) do |version|
+        is_different = previous.nil? || previous.version_hash != version.version_hash
+        previous = version
+        if is_different != version.different?
+          version_count += 1
+          [is_different]
+        end
+      end
+
+      page_count += 1
+      if page_count == total_pages || Time.now - last_update > 2
+        print "  Updated #{page_count} of #{total_pages} pages (#{version_count} versions, date: #{page.created_at})\r"
+        STDOUT.flush
+        last_update = Time.now
+      end
+    end
+
+    # Move to the next line
+    puts ''
+  end
+
+  def with_activerecord_log_level(level = :error)
+    original_level = ActiveRecord::Base.logger.level
+    ActiveRecord::Base.logger.level = level
+    yield
+  ensure
+    ActiveRecord::Base.logger.level = original_level
+  end
+
+  # Kind of like find_each, but allows for ordered queries. We need this since
+  # a) UUIDs are not really ordered and b) we are still live inserting data.
+  def iterate_each(collection, batch_size: 500)
+    offset = 0
+    loop do
+      items = collection.limit(batch_size).offset(offset)
+      items.each {|item| yield item}
+      break if items.count.zero?
+
+      offset += batch_size
+    end
+  end
+
+  # Update many records with different values at once. (But it must update the
+  # same *attributes* on each record.) This takes an ActiveRecord collection to
+  # iterate over and gather the updates, then a list of the attributes that
+  # will be updated.
+  #
+  # The given block must yield an array containing the new value for each of
+  # the specified attributes. If it yields nil, the record won't be updated.
+  #
+  # NOTE: this only works with Postgres.
+  def bulk_update(collection, fields)
+    model_type = collection.model
+    connection = collection.connection
+
+    values = []
+    collection.each do |item|
+      changes = yield item
+      next if changes.nil? || changes.empty?
+
+      changes = changes.collect {|value| connection.quote(value)}
+      values << "('#{item.uuid}', #{changes.join(', ')})"
+    end
+
+    return 0 if values.empty?
+
+    setters = fields.collect {|field| "#{field} = valueset.#{field}"}.join(', ')
+
+    collection.connection.execute(
+      <<-QUERY
+        UPDATE
+          #{model_type.table_name}
+        SET
+          #{setters},
+          updated_at = #{connection.quote(Time.now)}
+        FROM
+          (values #{values.join(',')}) as valueset(uuid, #{fields.join(', ')})
+        WHERE
+          #{model_type.table_name}.uuid = valueset.uuid::uuid
+      QUERY
+    )
+  end
+end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -692,9 +692,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     now = Time.now
     page_versions = [
       { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
-      { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
-      { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
-      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days }
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days }
     ].collect {|data| pages(:home_page).versions.create(data)}
     page_versions.each(&:update_different_attribute)
 
@@ -706,8 +704,6 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
 
     assert_includes(uuids, page_versions[0].uuid)
     assert_not_includes(uuids, page_versions[1].uuid)
-    assert_not_includes(uuids, page_versions[2].uuid)
-    assert_not_includes(uuids, page_versions[3].uuid)
   end
 
   test 'includes active and inactive pages if ?active not present' do

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -704,8 +704,8 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(@response.body)
     uuids = body['data'].collect {|page| page['latest'].try(:[], 'uuid')}
 
-    assert_not_includes(uuids, page_versions[0].uuid)
-    assert_includes(uuids, page_versions[1].uuid)
+    assert_includes(uuids, page_versions[0].uuid)
+    assert_not_includes(uuids, page_versions[1].uuid)
     assert_not_includes(uuids, page_versions[2].uuid)
     assert_not_includes(uuids, page_versions[3].uuid)
   end

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -225,9 +225,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     now = Time.now
     page_versions = [
       { version_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
-      { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
-      { version_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
-      { version_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days }
+      { version_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days }
     ].collect {|data| pages(:home_page).versions.create(data)}
     page_versions.each(&:update_different_attribute)
 
@@ -239,8 +237,6 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_includes(uuids, page_versions[0].uuid)
     assert_not_includes(uuids, page_versions[1].uuid)
-    assert_not_includes(uuids, page_versions[2].uuid)
-    assert_not_includes(uuids, page_versions[3].uuid)
   end
 
   test 'lists versions regardless if different from the previous version if ?different=false' do

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -238,7 +238,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     uuids = body['data'].collect {|version| version['uuid']}
 
     assert_includes(uuids, page_versions[0].uuid)
-    assert_includes(uuids, page_versions[1].uuid)
+    assert_not_includes(uuids, page_versions[1].uuid)
     assert_not_includes(uuids, page_versions[2].uuid)
     assert_not_includes(uuids, page_versions[3].uuid)
   end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -24,23 +24,16 @@ class VersionTest < ActiveSupport::TestCase
   test 'update_different_attribute' do
     page = Page.create(url: 'http://somerandomsite.com/')
     a1 = page.versions.create(source_type: 'a', version_hash: 'abc', capture_time: Time.now - 3.days)
-    b1 = page.versions.create(source_type: 'b', version_hash: 'abc', capture_time: Time.now - 2.9.days)
+    b1 = page.versions.create(source_type: 'b', version_hash: 'abc', capture_time: Time.now - 2.days)
     a1.update_different_attribute
     b1.update_different_attribute
     assert(a1.different?, 'The first version should have been different')
-    assert_not(b1.different?, 'The second version should not have been different, regardless of source_type')
+    assert_not(b1.different?, 'The second version should not have been different')
 
-    a2 = page.versions.create(source_type: 'a', version_hash: 'abc', capture_time: Time.now - 1.days)
-    b2 = page.versions.create(source_type: 'b', version_hash: 'abc', capture_time: Time.now - 0.9.days)
+    a2 = page.versions.create(source_type: 'a', version_hash: 'def', capture_time: Time.now - 2.5.days)
     a2.update_different_attribute
-    b2.update_different_attribute
-    assert_not(a2.different?, 'A version with the same hash is not different')
-    assert_not(b2.different?, 'A version with the same hash but different source_type is not different')
-
-    a3 = page.versions.create(source_type: 'a', version_hash: 'def', capture_time: Time.now - 2.days)
-    a3.update_different_attribute
-    assert(a3.different?, 'A version with a different hash is different')
-    assert(Version.find(a2.uuid).different?, 'Updating a version inserted before an existing version updates the existing version, too')
+    assert(a2.different?, 'A version with a different hash is different')
+    assert(Version.find(b1.uuid).different?, 'Updating a version inserted before an existing version updates the existing version, too')
   end
 
   test 'version titles should be single lines with no outside spaces' do

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -27,24 +27,20 @@ class VersionTest < ActiveSupport::TestCase
     b1 = page.versions.create(source_type: 'b', version_hash: 'abc', capture_time: Time.now - 2.9.days)
     a1.update_different_attribute
     b1.update_different_attribute
-    assert(a1.different?, 'The first version is different')
-    assert(b1.different?, 'The first version of a given source_type is different')
+    assert(a1.different?, 'The first version should have been different')
+    assert_not(b1.different?, 'The second version should not have been different, regardless of source_type')
 
     a2 = page.versions.create(source_type: 'a', version_hash: 'abc', capture_time: Time.now - 1.days)
     b2 = page.versions.create(source_type: 'b', version_hash: 'abc', capture_time: Time.now - 0.9.days)
     a2.update_different_attribute
     b2.update_different_attribute
     assert_not(a2.different?, 'A version with the same hash is not different')
-    assert_not(b2.different?, 'A version of a given source_type with the same hash is not different')
+    assert_not(b2.different?, 'A version with the same hash but different source_type is not different')
 
     a3 = page.versions.create(source_type: 'a', version_hash: 'def', capture_time: Time.now - 2.days)
-    b3 = page.versions.create(source_type: 'b', version_hash: 'def', capture_time: Time.now - 1.9.days)
     a3.update_different_attribute
-    b3.update_different_attribute
     assert(a3.different?, 'A version with a different hash is different')
-    assert(b3.different?, 'A version of a given source_type with a different hash is different')
     assert(Version.find(a2.uuid).different?, 'Updating a version inserted before an existing version updates the existing version, too')
-    assert(Version.find(b2.uuid).different?, 'Updating a version inserted before an existing version updates the existing version for a given source_type, too')
   end
 
   test 'version titles should be single lines with no outside spaces' do


### PR DESCRIPTION
I originally thought it might be important to differentiate between the same content from multiple sources. That was probably wrong in retrospect, and especially so not that we are more actively using data from multiple sources and not attempting to differentiate much between them in pretty much any context.

Fixes #454.