### PR TITLE
Only track a version as added if it was new

### DIFF
--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -100,7 +100,7 @@ class ImportVersionsJob < ApplicationJob
     version.update_different_attribute(save: false)
     version.save
 
-    @added << version
+    @added << version if !existing
   end
 
   def version_for_record(record, existing_version = nil, update_behavior = 'replace')


### PR DESCRIPTION
We were previously tracking versions as added (and thus triggering auto-analysis) if we touched the version in any way. In reality, we should probably only automatically trigger a new analysis if it was actually a new version we *created.*

This is a proposed fix for #458. Should we add some other criteria here? Are there kinds of *updates* that should also trigger analysis? If so, what?