### PR TITLE
Follow new recommendation for i18n config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
After updating, Bundler helpfully gave me the following message:

    HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
    But that may break your application.

    Please check your Rails app for 'config.i18n.fallbacks = true'.
    If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
    'config.i18n.fallbacks = [I18n.default_locale]'.
    If not, fallbacks will be broken in your app by I18n 1.1.x.

We don't currently use i18n, but we should make sure it's correctly set up in case we do in the future.