### PR TITLE
Tag pages with domain, second-level domain

### DIFF
--- a/lib/tasks/data/20190112_add_page_domain_tags.rake
+++ b/lib/tasks/data/20190112_add_page_domain_tags.rake
@@ -1,0 +1,31 @@
+namespace :data do
+  desc 'Set `domain:` and `2l-domain` tags on all pages.'
+  task :'20190112_add_page_domain_tags', [] => [:environment] do |_t|
+    ActiveRecord::Migration.say_with_time('Updating domain tags on pages...') do
+      with_activerecord_log_level(:error) do
+        iterate_each(Page.all.order(created_at: :asc), &:ensure_domain_tags)
+      end
+    end
+  end
+
+  def with_activerecord_log_level(level = :error)
+    original_level = ActiveRecord::Base.logger.level
+    ActiveRecord::Base.logger.level = level
+    yield
+  ensure
+    ActiveRecord::Base.logger.level = original_level
+  end
+
+  # Kind of like find_each, but allows for ordered queries. We need this since
+  # a) UUIDs are not really ordered and b) we are still live inserting data.
+  def iterate_each(collection, batch_size: 500)
+    offset = 0
+    loop do
+      items = collection.limit(batch_size).offset(offset)
+      items.each {|item| yield item}
+      break if items.count.zero?
+
+      offset += batch_size
+    end
+  end
+end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -139,4 +139,11 @@ class PageTest < ActiveSupport::TestCase
     page.status = 'whats this now'
     assert_not(page.valid?, 'A text status was valid')
   end
+
+  test 'pages tag themselves by domain when created' do
+    new_page = Page.create(url: 'https://whatever.subdmain.noaa.gov/something')
+    tags = new_page.tags.pluck(:name)
+    assert_includes(tags, 'domain:whatever.subdmain.noaa.gov')
+    assert_includes(tags, '2l-domain:noaa.gov')
+  end
 end


### PR DESCRIPTION
When pages are first created, they now automatically tag themselves with two tags:

- `domain:{domain name}` (e.g. `domain:www.nmfs.noaa.gov`)
- `2l-domain:{second-level domain name}` (e.g. `2l-domain:noaa.gov`)

Fixes #470.

---

NOTE: I *could* do a bit more work here and use `around_save` to ensure the tags always match `url` field, even if the `url` changes, but:

- We *shouldn’t* be changing that field
- In a far future where pages have multiple URLs through time, we’d still be *adding* to a list and therefore probably *adding* domain tags

Based on that, complicated code to remove old tags if necessary and add new ones seemed like non-useful complexity at this point. Please say the word if you think I should add support re-writing the domain tags if `url` changes.