### PR TITLE
Only auto-analyze versions that were different

### DIFF
--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -11,7 +11,7 @@ class ImportVersionsJob < ApplicationJob
     begin
       import_raw_data(@import.load_data)
       @added.uniq {|version| version.uuid}.each do |version|
-        AnalyzeChangeJob.perform_later(version)
+        AnalyzeChangeJob.perform_later(version) if version.different?
       end
     rescue StandardError => error
       @import.processing_errors << if Rails.env.development?


### PR DESCRIPTION
If a version had the same content as the version that preceded it, then there's not a whole lot of point in auto-analyzing it -- there's nothing useful in the change between it and preceeding version or between it and the first version (because that change will be the same as between the preceeding version and the first version). Don't queue these versions for auto-analysis.

Noticed this while dealing with the massive number of analyses we queued up when I backfilled a month’s worth of Wayback versions yesterday. It wouldn’t have made a *huge* difference (maybe 10%; I didn’t do a deep analysis), but still seems like a worthwhile optimization.