### PR TITLE
Upgrade Bootsnap to 1.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     aws-sigv4 (1.0.3)
     bcrypt (3.1.12)
     bindex (0.5.0)
-    bootsnap (1.3.2)
+    bootsnap (1.4.0)
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
@@ -140,7 +140,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     mono_logger (1.1.0)
-    msgpack (1.2.4)
+    msgpack (1.2.6)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -336,4 +336,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.17.3


### PR DESCRIPTION
Ever since I finally upgraded to MacOS 10.14 last month, I've been having issues with the Rails console. Turns out it's a problem with Bootsnap that seems to have gotten fixed in the latest version.

I’m going to go ahead and merge this straightaway, since it’s a minor dependency update that fixes immediate issues.