### PR TITLE
Upgrade bundler to v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,11 @@ jobs:
           key: web-monitoring-db-{{ arch }}-{{ checksum "Gemfile.lock" }}
 
       # Bundle install dependencies
-      - run: bundle install --path vendor/bundle
+      - run:
+          name: Install Dependencies
+          command: |
+            gem install bundler
+            bundle install --path vendor/bundle
 
       # Store bundle cache
       - save_cache:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,4 +355,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.3
+   2.0.1


### PR DESCRIPTION
Manage gems with v2 of Bundler. This is a bit of a major upgrade, and since bundler is what manages our dependencies, people will have to update their local Bundler install manually. That should be as simple as `gem install bundler` on the command line.

NOTE: this depends on #490.