### PR TITLE
Ensure default URL host never has a trailing `/`

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
 
   # Mailers
   config.action_mailer.default_url_options = {
-    :host => ENV.fetch('HOST_URL', 'localhost:3000')
+    host: ENV.fetch('HOST_URL', 'localhost:3000').chomp('/')
   }
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
 
   # Action Mailer configuration
   config.action_mailer.default_url_options = {
-    host: ENV.fetch('HOST_URL', 'api.monitoring.envirodatagov.org')
+    host: ENV.fetch('HOST_URL', 'api.monitoring.envirodatagov.org').chomp('/')
   }
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,7 +33,9 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Action Mailer host default
-  config.action_mailer.default_url_options = { :host => ENV.fetch('HOST_URL', 'localhost') }
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch('HOST_URL', 'localhost').chomp('/')
+  }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the


### PR DESCRIPTION
A while back I did this funky thing where the environment variable that controls the default *host* in all the URL helpers is called `HOST_URL`, which implies it’s a URL, and then stuck things like `https://api.monitoring.envirodatagov.org/` in it, which, well, is a URL, but definitely not a host, and further confused things.

It turns out Rails will happily use the scheme provided in there anyway (!), so that was really convenient. But what it failed to do was handle the trailing slash—an absolute path also starts with one, so you wind up getting URLs like `https://api.monitoring.envirodatagov.org//whatever` (not the double slash at the start of the path). While we should have more correct configuration, we could also gracefully handle incorrect configuration by removing trailing slashes, which is what this PR does.

Fixes #301.