### PR TITLE
Rails test fixtures require postgres superuser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,15 @@ It’s a Rails app that:
 
         If you’d like to do the setup manually or don’t want sample data, see [manual postgres setup](#manual-postgres-setup) below.
 
-    - If you’d like to configure your Postgres DB to be more secure and require a non-superuser for your databases, you’ll need to do a little more work:
+    - If you’d like to configure your Postgres DB to use a specific user, you’ll need to do a little more work:
 
         1. Log into `psql` and create a new user for your databases. Change the username and password to whatever you’d like:
 
             ```sql
-            CREATE USER wm_dev_user PASSWORD 'wm_dev_password';
+            CREATE USER wm_dev_user WITH SUPERUSER PASSWORD 'wm_dev_password';
             ```
+            Unfortunately,
+           [Rails' test fixtures require nothing less than superuser privileges in PostgreSQL](https://edgeguides.rubyonrails.org/testing.html#fixtures-in-action).
 
         2. (Still in `psql`) Create a development and a test database:
 


### PR DESCRIPTION
It's unclear whether this has *always* been true, but at least the
version of Rails we use now needs postgres to have superuser
privileges to run the tests. @Mr0Grog and I tried several other
invocations, and as the documentation says the fixtures really do
need full superuser permissions.