### PR TITLE
Add logging to seed data import (in Development only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ This project wouldn’t exist without a lot of amazing people’s help. Thanks t
 | [💻](# "Code") [📖](# "Documentation") | [Krzysztof Madejski](https://github.com/KrzysztofMadejski) |
 | [📖](# "Documentation") [📋](# "Organizer") [📢](# "Talks") | [Matt Price](https://github.com/titaniumbones) |
 | [📋](# "Organizer") [🔍](# "Funding/Grant Finder") | [Toly Rinberg](https://github.com/trinberg) |
+| [💻](# "Code") | [Ben Sheldon](https://github.com/bensheldon) |
 | [🚇](# "Infrastructure")  | [Frederik Spang](https://github.com/frederikspang) |
 | [💻](# "Code") | [Max Tedford](https://github.com/maxtedford) |
 | [📖](# "Documentation") [📋](# "Organizer") | [Dawn Walker](https://github.com/dcwalk) |

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -29,11 +29,9 @@ class ImportVersionsJob < ApplicationJob
 
   def import_raw_data(raw_data)
     last_update = Time.now
-    total_rows = raw_data.split("\n").length
     each_json_line(raw_data) do |record, row, row_count|
       begin
-        i = row + 1
-        Rails.logger.info("Importing row #{i}/#{row_count}...") if (i % 25).zero?
+        Rails.logger.info("Importing row #{row}/#{row_count}...") if Rails.env.development? && (row % 25).zero?
         import_record(record)
       rescue Api::ApiError => error
         @import.processing_errors << "Row #{row}: #{error.message}"

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -32,7 +32,7 @@ class ImportVersionsJob < ApplicationJob
     total_rows = raw_data.split("\n").length
     each_json_line(raw_data) do |record, row|
       begin
-        puts "Importing row #{row+1}/#{total_rows}..." if ((row+1) % 25 == 0)
+        Rails.logger.info("Importing row #{row+1}/#{total_rows}...") if ((row+1) % 25 == 0)
         import_record(record)
       rescue Api::ApiError => error
         @import.processing_errors << "Row #{row}: #{error.message}"

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -29,8 +29,10 @@ class ImportVersionsJob < ApplicationJob
 
   def import_raw_data(raw_data)
     last_update = Time.now
+    total_rows = raw_data.split("\n").length
     each_json_line(raw_data) do |record, row|
       begin
+        puts "Importing row #{row+1}/#{total_rows}..." if ((row+1) % 25 == 0)
         import_record(record)
       rescue Api::ApiError => error
         @import.processing_errors << "Row #{row}: #{error.message}"

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -32,7 +32,8 @@ class ImportVersionsJob < ApplicationJob
     total_rows = raw_data.split("\n").length
     each_json_line(raw_data) do |record, row|
       begin
-        Rails.logger.info("Importing row #{row+1}/#{total_rows}...") if ((row+1) % 25 == 0)
+        i = row + 1
+        Rails.logger.info("Importing row #{i}/#{total_rows}...") if (i % 25).zero?
         import_record(record)
       rescue Api::ApiError => error
         @import.processing_errors << "Row #{row}: #{error.message}"

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -30,10 +30,10 @@ class ImportVersionsJob < ApplicationJob
   def import_raw_data(raw_data)
     last_update = Time.now
     total_rows = raw_data.split("\n").length
-    each_json_line(raw_data) do |record, row|
+    each_json_line(raw_data) do |record, row, row_count|
       begin
         i = row + 1
-        Rails.logger.info("Importing row #{i}/#{total_rows}...") if (i % 25).zero?
+        Rails.logger.info("Importing row #{i}/#{row_count}...") if (i % 25).zero?
         import_record(record)
       rescue Api::ApiError => error
         @import.processing_errors << "Row #{row}: #{error.message}"
@@ -175,12 +175,13 @@ class ImportVersionsJob < ApplicationJob
       record_set = raw_json.split("\n")
     end
 
+    row_count = record_set.length
     record_set.each_with_index do |line, row|
       if line.is_a? String
         next if line.empty?
-        yield JSON.parse(line), row
+        yield JSON.parse(line), row, row_count
       else
-        yield line, row
+        yield line, row, row_count
       end
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,5 +33,6 @@ import = Import.create(
 
 fs_default = FileStorage.default
 FileStorage.default = FileStorage::LocalFile.new(path: Rails.root.join('db'))
+"--- Importing seed data from db/seed_import.json..."
 ImportVersionsJob.perform_now(import)
 FileStorage.default = fs_default

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,10 +36,10 @@ FileStorage.default = FileStorage::LocalFile.new(path: Rails.root.join('db'))
 
 logger = Logger.new(STDOUT)
 logger.level = Logger::INFO
-logger.formatter = -> (severity, time, progname, msg) { "--- #{msg}\n" }
+logger.formatter = ->(_severity, _time, _progname, msg) { "--- #{msg}\n" }
 Rails.logger.extend(ActiveSupport::Logger.broadcast(logger))
 
-Rails.logger.info "Importing seeds from db/seed_import.json..."
+Rails.logger.info 'Importing seeds from db/seed_import.json...'
 ImportVersionsJob.perform_now(import)
 
 FileStorage.default = fs_default

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,6 +33,13 @@ import = Import.create(
 
 fs_default = FileStorage.default
 FileStorage.default = FileStorage::LocalFile.new(path: Rails.root.join('db'))
-"--- Importing seed data from db/seed_import.json..."
+
+logger = Logger.new(STDOUT)
+logger.level = Logger::INFO
+logger.formatter = -> (severity, time, progname, msg) { "--- #{msg}\n" }
+Rails.logger.extend(ActiveSupport::Logger.broadcast(logger))
+
+Rails.logger.info "Importing seeds from db/seed_import.json..."
 ImportVersionsJob.perform_now(import)
+
 FileStorage.default = fs_default


### PR DESCRIPTION
This PR finishes the work of @patcon in https://github.com/edgi-govdata-archiving/web-monitoring-db/pull/293 by printing out the progress of the import when seeding the database.

In addition to rebasing the commits, this integrates @Mr0grog's feedback and only prints lines in Development to prevent cluttering up the production logs.