### PR TITLE
Add system tests for user lifecycle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             bundle exec rake db:schema:load
       - run:
           name: Tests
-          command: bundle exec rake test
+          command: bin/rails test:system test
       - run:
           name: Code linting
           command: bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'letter_opener'
   gem 'listen', '~> 3.1'
   gem 'pry-rails'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'letter_opener'
   gem 'listen', '~> 3.1'
   gem 'pry-rails'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
@@ -60,6 +61,8 @@ group :development do
 end
 
 group :test do
+  gem 'capybara'
+  gem 'capybara-email'
   gem 'webmock', '~> 3.5'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,10 +131,6 @@ GEM
     jmespath (1.4.0)
     json (2.2.0)
     jwt (2.1.0)
-    launchy (2.4.3)
-      addressable (~> 2.3)
-    letter_opener (1.7.0)
-      launchy (~> 2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -332,7 +328,6 @@ DEPENDENCIES
   hiredis
   httparty
   jwt (~> 2.1)
-  letter_opener
   listen (~> 3.1)
   oj (~> 3.7)
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,17 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
+    capybara (3.19.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
+    capybara-email (3.0.1)
+      capybara (>= 2.4, < 4.0)
+      mail
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -120,6 +131,10 @@ GEM
     jmespath (1.4.0)
     json (2.2.0)
     jwt (2.1.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -209,6 +224,7 @@ GEM
     redis (4.1.0)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
+    regexp_parser (1.4.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -297,6 +313,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -306,12 +324,15 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.36)
   bootsnap (>= 1.3.1)
   byebug
+  capybara
+  capybara-email
   devise
   dotenv-rails
   google-api-client
   hiredis
   httparty
   jwt (~> 2.1)
+  letter_opener
   listen (~> 3.1)
   oj (~> 3.7)
   pg (~> 1.1)

--- a/bin/worker_dev
+++ b/bin/worker_dev
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+QUEUE=* VERBOSE=1 RESQUE_PRE_SHUTDOWN_TIMEOUT=10 RESQUE_TERM_TIMEOUT=10 bundle exec rake environment resque:work

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = {
     host: ENV.fetch('HOST_URL', 'localhost:3000').chomp('/')
   }
-  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.delivery_method = :sendmail
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = {
     host: ENV.fetch('HOST_URL', 'localhost:3000').chomp('/')
   }
-  config.action_mailer.delivery_method = :sendmail
+  config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -12,6 +12,9 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     @original_queue_adapter = ActiveJob::Base.queue_adapter
     ActiveJob::Base.queue_adapter = :test
 
+    @original_mailer_options = ActionMailer::Base.default_url_options
+    ActionMailer::Base.default_url_options = { host: Capybara.server_host }
+
     clear_enqueued_jobs
     clear_performed_jobs
     clear_emails
@@ -22,5 +25,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     clear_performed_jobs
     clear_emails
     ActiveJob::Base.queue_adapter = @original_queue_adapter
+    ActionMailer::Base.default_url_options = @original_mailer_options
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+Capybara::save_path = Rails.root.join('tmp')
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  include ActiveJob::TestHelper
+  include Capybara::Email::DSL
+
+  driven_by :rack_test
+
+  def setup
+    @original_queue_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+
+    clear_enqueued_jobs
+    clear_performed_jobs
+    clear_emails
+  end
+
+  def teardown
+    clear_enqueued_jobs
+    clear_performed_jobs
+    clear_emails
+    ActiveJob::Base.queue_adapter = @original_queue_adapter
+  end
+end

--- a/test/fixtures/invitations.yml
+++ b/test/fixtures/invitations.yml
@@ -7,3 +7,4 @@
 with_email:
   email: test-unknown@example.com
   code: abc
+  expires_on: <%= 10.days.from_now %>

--- a/test/system/user_test.rb
+++ b/test/system/user_test.rb
@@ -1,0 +1,103 @@
+require "application_system_test_case"
+
+class UsersTest < ApplicationSystemTestCase
+  test "Invite, register, confirm, promote, demote, delete" do
+    admin = users(:admin_user)
+    viewer_email = 'viewer@example.com'
+
+    Capybara.using_session(:admin) do
+      visit root_path
+
+      click_on "Login"
+
+      fill_in 'Email', with: admin.email
+      fill_in 'Password', with: 'testpassword'
+      click_on 'Log in'
+
+      assert page.has_content? "Logged in as #{admin.email}"
+      click_on 'Admin'
+
+      perform_enqueued_jobs do
+        fill_in 'E-mail:', with: viewer_email
+        click_on 'Generate Invitation'
+      end
+    end
+
+    Capybara.using_session(:viewer) do
+      open_email(viewer_email)
+      current_email.find('a[href*="invitation"]').click
+      clear_emails
+
+      fill_in 'Password', with: 'testpassword'
+      fill_in 'Password confirmation', with: 'testpassword'
+      click_on 'Sign up'
+
+      open_email(viewer_email)
+      current_email.click_link 'Confirm my account'
+      clear_emails
+
+      fill_in 'Email', with: viewer_email
+      fill_in 'Password', with: 'testpassword'
+      click_on 'Log in'
+
+      assert page.has_content? "Logged in as viewer@example.com"
+    end
+
+    Capybara.using_session(:admin) do
+      visit admin_path
+      assert page.has_content? "Logged in as #{admin.email}"
+
+      user_row = page.all('tr').find { |tr| tr.has_content? viewer_email }
+      within user_row do
+        click_on 'Promote to admin'
+      end
+    end
+
+    Capybara.using_session(:viewer) do
+      visit root_path
+
+      # TODO: Signing in again should not be necessary.
+      click_on 'Login'
+      fill_in 'Email', with: viewer_email
+      fill_in 'Password', with: 'testpassword'
+      click_on 'Log in'
+
+      assert page.has_content? 'Admin'
+    end
+
+    Capybara.using_session(:admin) do
+      visit admin_path
+      assert page.has_content? "Logged in as #{admin.email}"
+
+      user_row = page.all('tr').find { |tr| tr.has_content? viewer_email }
+      within user_row do
+        click_on 'Demote from admin'
+      end
+    end
+
+    Capybara.using_session(:viewer) do
+      visit root_path
+      refute page.has_content? 'Admin'
+    end
+
+    Capybara.using_session(:admin) do
+      visit admin_path
+
+      user_row = page.all('tr').find { |tr| tr.has_content? viewer_email }
+      within user_row do
+        click_on 'Delete Account'
+      end
+    end
+
+    Capybara.using_session(:viewer) do
+      visit root_path
+      click_on 'Login'
+
+      fill_in 'Email', with: viewer_email
+      fill_in 'Password', with: 'testpassword'
+      click_on 'Log in'
+
+      assert page.has_content? 'Invalid Email or password.'
+    end
+  end
+end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -8,7 +8,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     # Administrator sends a user invitation
     #
-    Capybara.using_session('admin') do
+    Capybara.using_session(:admin) do
       visit root_path
 
       click_on "Login"
@@ -29,7 +29,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     # User accepts the invitation and creates and confirms their account
     #
-    Capybara.using_session('user') do
+    Capybara.using_session(:user) do
       open_email(viewer_email)
       current_email.find('a[href*="invitation"]').click
       clear_emails
@@ -52,7 +52,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     # Administrator promotes the User to have the "admin" permission
     #
-    Capybara.using_session('admin') do
+    Capybara.using_session(:admin) do
       visit admin_path
 
       user_row = page.all('tr').find { |tr| tr.has_content? viewer_email }
@@ -64,7 +64,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     # User verifies that they have received the "admin" permission
     #
-    Capybara.using_session('user') do
+    Capybara.using_session(:user) do
       visit root_path
 
       assert page.has_link?('Admin'), "User should have admin permissions"
@@ -73,7 +73,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     # Administrator removes the User's "admin" permission
     #
-    Capybara.using_session('admin') do
+    Capybara.using_session(:admin) do
       visit admin_path
 
       user_row = page.all('tr').find { |tr| tr.has_content? viewer_email }
@@ -85,7 +85,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     # User verifies that the admin permission has been removed
     #
-    Capybara.using_session('user') do
+    Capybara.using_session(:user) do
       visit root_path
       refute page.has_link?('Admin'), "User should not have admin permissions"
     end
@@ -93,7 +93,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     # Administrator deletes the User's account
     #
-    Capybara.using_session('admin') do
+    Capybara.using_session(:admin) do
       visit admin_path
 
       user_row = page.all('tr').find { |tr| tr.has_content? viewer_email }
@@ -105,9 +105,11 @@ class UsersTest < ApplicationSystemTestCase
     #
     # User is logged out from the deleted account and prevented from logging back in
     #
-    Capybara.using_session('user') do
+    Capybara.using_session(:user) do
       visit root_path
       refute page.has_content?("Logged in as #{viewer_email}"), "User should NOT have an active session"
+
+      # click_on 'Login'
 
       fill_in 'Email', with: viewer_email
       fill_in 'Password', with: 'testpassword'

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -109,7 +109,7 @@ class UsersTest < ApplicationSystemTestCase
       visit root_path
       refute page.has_content?("Logged in as #{viewer_email}"), "User should NOT have an active session"
 
-      # click_on 'Login'
+      click_on 'Login'
 
       fill_in 'Email', with: viewer_email
       fill_in 'Password', with: 'testpassword'


### PR DESCRIPTION
- Sets up Rails system tests, including capybara and capybara-email
- Creates a first system test that tests inviting a new user, confirmation, promotion to admin, demotion, and deletion
- ~~Within the development environment, replaces Sendmail delivery with letter_opener gem~~ unrelated to the system testing and removed
- Creates a binstub to start the job worker process during development

Note: I am using `rack_test` instead of Selenium Chromedriver because that has more complicated setup than I wanted to tackle right now.

This is a first step towards #34 by wrapping the existing auth system with tests.