### PR TITLE
Fix rubocop ignoring most ruby files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
 inherit_from: .rubocop_todo.yml
 require: rubocop-performance
+inherit_mode:
+  merge:
+    - Exclude
+    - Include
 
 AllCops:
   Include:
@@ -35,6 +39,11 @@ Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/controllers/api/v0/pages_controller.rb'
     - 'app/lib/surt/canonicalize.rb'
+    - 'app/jobs/import_versions_job.rb'
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'app/jobs/import_versions_job.rb'
 
 Naming/MemoizedInstanceVariableName:
   Exclude:
@@ -59,6 +68,9 @@ Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/NumericPredicate:
   Enabled: false
 
 Layout/EmptyLines:

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -46,8 +46,8 @@ class Api::V0::ApiController < ApplicationController
     code || begin
       error_name = error.class.name
       ActionDispatch::ExceptionWrapper.status_code_for_exception(error_name)
-    rescue StandardError => _
-      500
+            rescue StandardError => _error
+              500
     end
   end
 
@@ -59,8 +59,10 @@ class Api::V0::ApiController < ApplicationController
 
   def boolean_param(param, presence_implies_true: true, default: false)
     return default unless params.key?(param)
+
     value = params[param]
     return true if value.nil? && presence_implies_true
+
     /^(true|t|1)$/i.match? value
   end
 
@@ -76,8 +78,9 @@ class Api::V0::ApiController < ApplicationController
 
   def parse_date!(date)
     raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d\:\d\d(\:\d\d(\.\d+)?)?(Z|([+\-]\d\d:?\d\d)))?$/)
+
     Time.parse date
-  rescue StandardError => _
+  rescue StandardError => _error
     raise Api::InputError, "Invalid date: '#{date}'"
   end
 

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -44,11 +44,11 @@ class Api::V0::ApiController < ApplicationController
     code = error.try(:status_code)
 
     code || begin
-      error_name = error.class.name
-      ActionDispatch::ExceptionWrapper.status_code_for_exception(error_name)
+              error_name = error.class.name
+              ActionDispatch::ExceptionWrapper.status_code_for_exception(error_name)
             rescue StandardError => _error
               500
-    end
+            end
   end
 
   def message_for(error)

--- a/app/controllers/api/v0/changes_controller.rb
+++ b/app/controllers/api/v0/changes_controller.rb
@@ -28,6 +28,7 @@ class Api::V0::ChangesController < Api::V0::ApiController
 
   def page
     return nil unless params.key? :page_id
+
     @page ||= Page.find(params[:page_id])
   end
 

--- a/app/controllers/api/v0/diff_controller.rb
+++ b/app/controllers/api/v0/diff_controller.rb
@@ -33,7 +33,7 @@ class Api::V0::DiffController < Api::V0::ApiController
 
     unless error_details.empty?
       raise Api::InputError,
-        "Raw content is not available for #{error_details.join ' and '}"
+            "Raw content is not available for #{error_details.join ' and '}"
     end
   end
 

--- a/app/controllers/api/v0/maintainers_controller.rb
+++ b/app/controllers/api/v0/maintainers_controller.rb
@@ -88,6 +88,7 @@ class Api::V0::MaintainersController < Api::V0::ApiController
 
   def page
     return nil unless params.key? :page_id
+
     @page ||= Page.find(params[:page_id])
   end
 

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -191,13 +191,13 @@ class Api::V0::PagesController < Api::V0::ApiController
   def format_page_json(page)
     page['maintainers'] = page.delete('maintainerships').collect do |item|
       item['maintainer']
-        .reject {|k, _| k == 'created_at' || k == 'updated_at'}
+        .reject {|k, _| ['created_at', 'updated_at'].include?(k)}
         .merge('assigned_at' => item['created_at'])
     end
 
     page['tags'] = page.delete('taggings').collect do |item|
       item['tag']
-        .reject {|k, _| k == 'created_at' || k == 'updated_at'}
+        .reject {|k, _| ['created_at', 'updated_at'].include?(k)}
         .merge('assigned_at' => item['created_at'])
     end
   end

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -1,6 +1,8 @@
 class Api::V0::PagesController < Api::V0::ApiController
   include SortingConcern
 
+  OMITTABLE_ATTRIBUTES = ['created_at', 'updated_at'].freeze
+
   def index
     query = page_collection
     id_query = filter_maintainers_and_tags(query)
@@ -190,15 +192,13 @@ class Api::V0::PagesController < Api::V0::ApiController
 
   def format_page_json(page)
     page['maintainers'] = page.delete('maintainerships').collect do |item|
-      item['maintainer']
-        .reject {|k, _| ['created_at', 'updated_at'].include?(k)}
-        .merge('assigned_at' => item['created_at'])
+      item['maintainer'].except!(OMITTABLE_ATTRIBUTES)
+                        .merge!('assigned_at' => item['created_at'])
     end
 
     page['tags'] = page.delete('taggings').collect do |item|
-      item['tag']
-        .reject {|k, _| ['created_at', 'updated_at'].include?(k)}
-        .merge('assigned_at' => item['created_at'])
+      item['tag'].except!(OMITTABLE_ATTRIBUTES)
+                 .merge!('assigned_at' => item['created_at'])
     end
   end
 

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -193,12 +193,12 @@ class Api::V0::PagesController < Api::V0::ApiController
   def format_page_json(page)
     page['maintainers'] = page.delete('maintainerships').collect do |item|
       item['maintainer'].except!(OMITTABLE_ATTRIBUTES)
-                        .merge!('assigned_at' => item['created_at'])
+        .merge!('assigned_at' => item['created_at'])
     end
 
     page['tags'] = page.delete('taggings').collect do |item|
       item['tag'].except!(OMITTABLE_ATTRIBUTES)
-                 .merge!('assigned_at' => item['created_at'])
+        .merge!('assigned_at' => item['created_at'])
     end
   end
 

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -1,6 +1,9 @@
 class Api::V0::PagesController < Api::V0::ApiController
   include SortingConcern
 
+  # Omit these attributes from tags and maintainers (we care about when the
+  # related item was *assigned*, not when it was created). Used only with
+  # lightweight_query.
   OMITTABLE_ATTRIBUTES = ['created_at', 'updated_at'].freeze
 
   def index
@@ -192,12 +195,14 @@ class Api::V0::PagesController < Api::V0::ApiController
 
   def format_page_json(page)
     page['maintainers'] = page.delete('maintainerships').collect do |item|
-      item['maintainer'].except!(*OMITTABLE_ATTRIBUTES)
+      item['maintainer']
+        .except!(*OMITTABLE_ATTRIBUTES)
         .merge!('assigned_at' => item['created_at'])
     end
 
     page['tags'] = page.delete('taggings').collect do |item|
-      item['tag'].except!(*OMITTABLE_ATTRIBUTES)
+      item['tag']
+        .except!(*OMITTABLE_ATTRIBUTES)
         .merge!('assigned_at' => item['created_at'])
     end
   end

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -192,12 +192,12 @@ class Api::V0::PagesController < Api::V0::ApiController
 
   def format_page_json(page)
     page['maintainers'] = page.delete('maintainerships').collect do |item|
-      item['maintainer'].except!(OMITTABLE_ATTRIBUTES)
+      item['maintainer'].except!(*OMITTABLE_ATTRIBUTES)
         .merge!('assigned_at' => item['created_at'])
     end
 
     page['tags'] = page.delete('taggings').collect do |item|
-      item['tag'].except!(OMITTABLE_ATTRIBUTES)
+      item['tag'].except!(*OMITTABLE_ATTRIBUTES)
         .merge!('assigned_at' => item['created_at'])
     end
   end

--- a/app/controllers/api/v0/tags_controller.rb
+++ b/app/controllers/api/v0/tags_controller.rb
@@ -65,6 +65,7 @@ class Api::V0::TagsController < Api::V0::ApiController
 
   def page
     return nil unless params.key? :page_id
+
     @page ||= Page.find(params[:page_id])
   end
 

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -67,6 +67,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
 
   def page
     return nil unless params.key? :page_id
+
     @page ||= Page.find(params[:page_id])
   end
 

--- a/app/controllers/concerns/same_origin_sessions_concern.rb
+++ b/app/controllers/concerns/same_origin_sessions_concern.rb
@@ -29,8 +29,9 @@ module SameOriginSessionsConcern
 
   def referring_host
     return nil unless request.referer
+
     URI.parse(request.referer).host
-  rescue StandardError => _
+  rescue StandardError => _error
     '[invalid host]'
   end
 end

--- a/app/controllers/concerns/sorting_concern.rb
+++ b/app/controllers/concerns/sorting_concern.rb
@@ -19,6 +19,7 @@ module SortingConcern
     unless sanitized.match?(/^\w+$/)
       raise Api::InputError, "'#{field}' is not a valid attribute name for sorting"
     end
+
     sanitized.to_sym
   end
 
@@ -28,6 +29,7 @@ module SortingConcern
     unless ['asc', 'desc'].include?(sanitized)
       raise Api::InputError, "'#{direction}' is not a valid sort direction. It must be either 'asc' or 'desc'"
     end
+
     sanitized.to_sym
   end
 

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -16,6 +16,6 @@ class HealthcheckController < ApplicationController
       queues = error.to_s
     end
 
-    render json: {app: 'ok', db: db, queues: queues}
+    render json: { app: 'ok', db: db, queues: queues }
   end
 end

--- a/app/lib/numeric_interval.rb
+++ b/app/lib/numeric_interval.rb
@@ -7,6 +7,7 @@ class NumericInterval
   def initialize(string_interval)
     components = string_interval.match(/^\s*(\[|\()?\s*(\d*(?:\.\d+)?)\s*(?:,|\.\.)\s*(\d*(?:\.\d+)?)\s*(\]|\))?\s*$/)
     raise ArgumentError, "Invalid interval format: '#{string_interval}'" unless components
+
     @start = components[2].present? ? components[2].to_f : nil
     @end = components[3].present? ? components[3].to_f : nil
     @start_open = components[1] == '('

--- a/app/lib/surt/canonicalize.rb
+++ b/app/lib/surt/canonicalize.rb
@@ -61,8 +61,8 @@ module Surt::Canonicalize
     /^(.*)(?:xtor=[^&])(?:&(.*))?$/i
   ].freeze
 
-  OCTAL_IP = /^(0[0-7]*)(\.[0-7]+)?(\.[0-7]+)?(\.[0-7]+)?$/
-  WWW_SUBDOMAIN = /(^|\.)www\d*\./
+  OCTAL_IP = /^(0[0-7]*)(\.[0-7]+)?(\.[0-7]+)?(\.[0-7]+)?$/.freeze
+  WWW_SUBDOMAIN = /(^|\.)www\d*\./.freeze
 
 
   # TODO: Internet Archive's SURT uses this crazy charcater set, but only one

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -19,6 +19,7 @@ class Change < ApplicationRecord
       create == :new || create == :create || create.nil?
 
     return nil if from.nil? || to.nil?
+
     change_definition = {
       uuid_from: from.is_a?(Version) ? from.uuid : from,
       uuid_to: to.is_a?(Version) ? to.uuid : to

--- a/app/models/maintainer.rb
+++ b/app/models/maintainer.rb
@@ -8,13 +8,13 @@ class Maintainer < ApplicationRecord
   has_many :pages, through: :maintainerships
 
   belongs_to :parent,
-    class_name: 'Maintainer',
-    foreign_key: :parent_uuid,
-    optional: true,
-    inverse_of: :children
+             class_name: 'Maintainer',
+             foreign_key: :parent_uuid,
+             optional: true,
+             inverse_of: :children
 
   has_many :children,
-    class_name: 'Maintainer',
-    foreign_key: :parent_uuid,
-    inverse_of: :parent
+           class_name: 'Maintainer',
+           foreign_key: :parent_uuid,
+           inverse_of: :parent
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -4,33 +4,33 @@ class Page < ApplicationRecord
   include SimpleTitle
 
   has_many :versions,
-    -> { order(capture_time: :desc) },
-    foreign_key: 'page_uuid',
-    inverse_of: :page
+           -> { order(capture_time: :desc) },
+           foreign_key: 'page_uuid',
+           inverse_of: :page
   has_one :earliest,
-    (lambda do
-      # DISTINCT ON requires the first ORDER to be the distinct column(s)
-      relation = order('versions.page_uuid')
-      # HACK: This is not public API, but I couldn't find a better way. The
-      # `DISTINCT ON` statement has to be at the start of the WHERE clause, but
-      # all public methods append to the end.
-      relation.select_values = ['DISTINCT ON (versions.page_uuid) versions.*']
-      relation.order('versions.capture_time ASC')
-    end),
-    foreign_key: 'page_uuid',
-    class_name: 'Version'
+          (lambda do
+            # DISTINCT ON requires the first ORDER to be the distinct column(s)
+            relation = order('versions.page_uuid')
+            # HACK: This is not public API, but I couldn't find a better way. The
+            # `DISTINCT ON` statement has to be at the start of the WHERE clause, but
+            # all public methods append to the end.
+            relation.select_values = ['DISTINCT ON (versions.page_uuid) versions.*']
+            relation.order('versions.capture_time ASC')
+          end),
+          foreign_key: 'page_uuid',
+          class_name: 'Version'
   has_one :latest,
-    (lambda do
-      # DISTINCT ON requires the first ORDER to be the distinct column(s)
-      relation = order('versions.page_uuid')
-      # HACK: This is not public API, but I couldn't find a better way. The
-      # `DISTINCT ON` statement has to be at the start of the WHERE clause, but
-      # all public methods append to the end.
-      relation.select_values = ['DISTINCT ON (versions.page_uuid) versions.*']
-      relation.order('versions.capture_time DESC').where(different: true)
-    end),
-    foreign_key: 'page_uuid',
-    class_name: 'Version'
+          (lambda do
+            # DISTINCT ON requires the first ORDER to be the distinct column(s)
+            relation = order('versions.page_uuid')
+            # HACK: This is not public API, but I couldn't find a better way. The
+            # `DISTINCT ON` statement has to be at the start of the WHERE clause, but
+            # all public methods append to the end.
+            relation.select_values = ['DISTINCT ON (versions.page_uuid) versions.*']
+            relation.order('versions.capture_time DESC').where(different: true)
+          end),
+          foreign_key: 'page_uuid',
+          class_name: 'Version'
   # This needs a funky name because `changes` is a an activerecord method
   has_many :tracked_changes, through: :versions
 
@@ -42,8 +42,8 @@ class Page < ApplicationRecord
   before_save :normalize_url
   validate :url_must_have_domain
   validates :status,
-    allow_nil: true,
-    inclusion: { in: 100...600, message: 'is not between 100 and 599' }
+            allow_nil: true,
+            inclusion: { in: 100...600, message: 'is not between 100 and 599' }
 
   def self.find_by_url(raw_url)
     url = normalize_url(raw_url)
@@ -52,6 +52,7 @@ class Page < ApplicationRecord
 
   def self.normalize_url(url)
     return if url.nil?
+
     if url.match?(/^[\w\+\-\.]+:\/\//)
       url
     else

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -5,14 +5,14 @@ class Version < ApplicationRecord
   belongs_to :page, foreign_key: :page_uuid, required: true, inverse_of: :versions, touch: true
   has_many :tracked_changes, class_name: 'Change', foreign_key: 'uuid_to'
   has_many :invalid_changes,
-    ->(version) { where.not(uuid_from: version.previous.uuid) },
-    class_name: 'Change',
-    foreign_key: 'uuid_to'
+           ->(version) { where.not(uuid_from: version.previous.uuid) },
+           class_name: 'Change',
+           foreign_key: 'uuid_to'
 
   after_create :sync_page_title
   validates :status,
-    allow_nil: true,
-    inclusion: { in: 100...600, message: 'is not between 100 and 599' }
+            allow_nil: true,
+            inclusion: { in: 100...600, message: 'is not between 100 and 599' }
 
   def earliest
     self.page.versions.reorder(capture_time: :asc).first

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+include FileUtils
+
+# path to your application root.
+APP_ROOT = File.expand_path('..', __dir__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+chdir APP_ROOT do
+  puts '== Rubocop Auto Correct =='
+  system! 'bundle exec rubocop --safe-auto-correct'
+end

--- a/db/migrate/20170425211418_add_missing_page_schemes.rb
+++ b/db/migrate/20170425211418_add_missing_page_schemes.rb
@@ -5,6 +5,6 @@ class AddMissingPageSchemes < ActiveRecord::Migration[5.0]
 
   def down
     raise ActiveRecord::IrreversibleMigration,
-      'This migration modifies existing bad data and cannot be reversed.'
+          'This migration modifies existing bad data and cannot be reversed.'
   end
 end

--- a/db/migrate/20180207061655_copy_agency_and_site_fields_to_associated_models.rb
+++ b/db/migrate/20180207061655_copy_agency_and_site_fields_to_associated_models.rb
@@ -18,6 +18,7 @@ class CopyAgencyAndSiteFieldsToAssociatedModels < ActiveRecord::Migration[5.1]
       items = collection.limit(batch_size).offset(offset)
       items.each {|item| yield item}
       break if items.count.zero?
+
       offset += batch_size
     end
   end

--- a/db/migrate/20180212043742_dedupe_pages_with_multiple_agencies_or_sites.rb
+++ b/db/migrate/20180212043742_dedupe_pages_with_multiple_agencies_or_sites.rb
@@ -40,6 +40,6 @@ class DedupePagesWithMultipleAgenciesOrSites < ActiveRecord::Migration[5.1]
 
   def down
     raise ActiveRecord::IrreversibleMigration,
-      'This migration removed information and cannot be reversed.'
+          'This migration removed information and cannot be reversed.'
   end
 end

--- a/db/migrate/20180227021126_add_capture_url_to_version.rb
+++ b/db/migrate/20180227021126_add_capture_url_to_version.rb
@@ -26,6 +26,7 @@ class AddCaptureUrlToVersion < ActiveRecord::Migration[5.1]
       items = collection.limit(batch_size).offset(offset)
       items.each {|item| yield item}
       break if items.count.zero?
+
       offset += batch_size
     end
   end

--- a/db/migrate/20180227024610_add_url_key_to_page.rb
+++ b/db/migrate/20180227024610_add_url_key_to_page.rb
@@ -25,6 +25,7 @@ class AddUrlKeyToPage < ActiveRecord::Migration[5.1]
       items = collection.limit(batch_size).offset(offset)
       items.each {|item| yield item}
       break if items.count.zero?
+
       offset += batch_size
     end
   end

--- a/lib/archiver/archiver.rb
+++ b/lib/archiver/archiver.rb
@@ -13,6 +13,7 @@ module Archiver
 
   def self.store
     raise StandardError, 'You must set store before archiving.' unless @store
+
     @store
   end
 
@@ -22,6 +23,7 @@ module Archiver
     unless hosts.is_a?(Enumerable) && hosts.all? {|host| host.is_a?(String)}
       raise StandardError, 'Allowed hosts must be a string or enumerable of strings'
     end
+
     @allowed_hosts = hosts
   end
 

--- a/lib/differ/differ.rb
+++ b/lib/differ/differ.rb
@@ -14,7 +14,7 @@ module Differ
 
   def self.for_type!(type)
     for_type(type) || (raise Api::NotImplementedError,
-      "There is no registered differ for '#{type}'")
+                             "There is no registered differ for '#{type}'")
   end
 
   # If configured, create a default/fallback differ for a given type.

--- a/lib/differ/simple_diff.rb
+++ b/lib/differ/simple_diff.rb
@@ -80,7 +80,7 @@ module Differ
           raise error if attempt >= tries
         end
 
-        sleep((attempt - 1) ** 2)
+        sleep((attempt - 1)**2)
       end
     end
 

--- a/lib/file_storage/s3.rb
+++ b/lib/file_storage/s3.rb
@@ -44,7 +44,7 @@ module FileStorage
 
     private
 
-    S3_HOST_PATTERN = /^(?:([^.]+)\.)?s3(?:-([^.]+))?\.amazonaws\.com$/
+    S3_HOST_PATTERN = /^(?:([^.]+)\.)?s3(?:-([^.]+))?\.amazonaws\.com$/.freeze
 
     # Determine bucket, path, region info from URIs in the forms:
     # - s3://bucket/file/path.extension

--- a/lib/jwt_tools/jwt_auth_strategy.rb
+++ b/lib/jwt_tools/jwt_auth_strategy.rb
@@ -6,8 +6,10 @@ module JwtTools
 
     def authenticate!
       return pass unless claims && claims.key?('sub')
+
       user_id = claims['sub'].match(/^User:(\d+)$/).try(:[], 1)
       return pass unless user_id
+
       user = User.find_by_id(user_id)
       if user
         success! user

--- a/lib/jwt_tools/jwt_coder.rb
+++ b/lib/jwt_tools/jwt_coder.rb
@@ -38,7 +38,7 @@ module JwtTools
         # TODO: raise up expiration errors so we can return a special response?
         decoded = JWT.decode(token, @public_key, true, algorithm: 'RS256')
         decoded.first
-      rescue StandardError => _
+      rescue StandardError => _error
         nil
       end
     end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,6 +1,6 @@
-require "test_helper"
+require 'test_helper'
 
-Capybara::save_path = Rails.root.join('tmp')
+Capybara.save_path = Rails.root.join('tmp')
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ActiveJob::TestHelper

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -7,32 +7,32 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'promote user to admin format JSON' do
-    user = User.create(email: "test@email.com", password: "password", password_confirmation: "password")
+    user = User.create(email: 'test@email.com', password: 'password', password_confirmation: 'password')
 
-    put '/admin/promote_user_to_admin', params: { id: user.id, format: "json" }
+    put '/admin/promote_user_to_admin', params: { id: user.id, format: 'json' }
 
     user.reload
     parsed_response = JSON.parse(response.body)
     assert_equal 'application/json', @response.content_type
-    assert parsed_response["data"]["success"]
+    assert parsed_response['data']['success']
     assert user.admin?
   end
 
   test 'demote user from admin format JSON' do
-    user = User.create(email: "test@email.com", password: "password", password_confirmation: "password", admin: true)
+    user = User.create(email: 'test@email.com', password: 'password', password_confirmation: 'password', admin: true)
 
-    put '/admin/demote_user_from_admin', params: { id: user.id, format: "json" }
+    put '/admin/demote_user_from_admin', params: { id: user.id, format: 'json' }
 
     user.reload
     parsed_response = JSON.parse(response.body)
     assert_response :success
     assert_equal 'application/json', @response.content_type
-    assert parsed_response["data"]["success"]
+    assert parsed_response['data']['success']
     refute user.admin?
   end
 
   test 'promote user to admin format HTML' do
-    user = User.create(email: "test@email.com", password: "password", password_confirmation: "password")
+    user = User.create(email: 'test@email.com', password: 'password', password_confirmation: 'password')
 
     put '/admin/promote_user_to_admin', params: { id: user.id }
 
@@ -42,7 +42,7 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'demote user from admin format HTML' do
-    user = User.create(email: "test@email.com", password: "password", password_confirmation: "password", admin: true)
+    user = User.create(email: 'test@email.com', password: 'password', password_confirmation: 'password', admin: true)
 
     put '/admin/demote_user_from_admin', params: { id: user.id }
 

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -5,7 +5,7 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
   class MockDiffer
-    def diff(change, options = nil)
+    def diff(_change, _options = nil)
       {
         'change_count' => 2,
         'diff' => [

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -75,9 +75,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, pages(:home_page).uuid,
-      'Results did not include pages for the filtered site'
+                    'Results did not include pages for the filtered site'
     assert_not_includes ids, pages(:home_page_site2).uuid,
-      'Results included pages not matching filtered site'
+                        'Results included pages not matching filtered site'
   end
 
   test 'can filter pages by agency' do
@@ -88,9 +88,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, pages(:dot_home_page).uuid,
-      'Results did not include pages for the filtered agency'
+                    'Results did not include pages for the filtered agency'
     assert_not_includes ids, pages(:home_page_site2).uuid,
-      'Results included pages not matching filtered agency'
+                        'Results included pages not matching filtered agency'
   end
 
   test 'can filter pages by title' do
@@ -101,9 +101,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, pages(:home_page).uuid,
-      'Results did not include pages for the filtered site'
+                    'Results did not include pages for the filtered site'
     assert_not_includes ids, pages(:home_page_site2).uuid,
-      'Results included pages not matching filtered site'
+                        'Results included pages not matching filtered site'
   end
 
   test 'can filter pages by URL' do
@@ -114,11 +114,11 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, pages(:home_page).uuid,
-      'Results did not include the page with the filtered URL'
+                    'Results did not include the page with the filtered URL'
     assert_not_includes ids, pages(:home_page_site2).uuid,
-      'Results included pages not matching filtered URL'
+                        'Results included pages not matching filtered URL'
     assert_not_includes ids, pages(:sub_page).uuid,
-      'Results included pages with similar but not same filtered URL'
+                        'Results included pages with similar but not same filtered URL'
   end
 
   test 'can filter pages by URL with "*" wildcard' do
@@ -129,11 +129,11 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, pages(:home_page).uuid,
-      'Results did not include the page with the filtered URL'
+                    'Results did not include the page with the filtered URL'
     assert_includes ids, pages(:sub_page).uuid,
-      'Results did not include the page with the filtered URL'
+                    'Results did not include the page with the filtered URL'
     assert_not_includes ids, pages(:home_page_site2).uuid,
-      'Results included pages not matching filtered URL'
+                        'Results included pages not matching filtered URL'
   end
 
   test 'can filter pages by version source_type' do
@@ -144,9 +144,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     ids = body['data'].pluck 'uuid'
 
     assert_includes ids, pages(:home_page).uuid,
-      'Results did not include pages with versions captured by pagefreezer'
+                    'Results did not include pages with versions captured by pagefreezer'
     assert_not_includes ids, pages(:home_page_site2).uuid,
-      'Results included pages with versions not captured by pagreezer'
+                        'Results included pages with versions not captured by pagreezer'
   end
 
   test 'can filter pages by version hash' do
@@ -156,9 +156,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     ids = body['data'].pluck 'uuid'
 
     assert_includes ids, pages(:sub_page).uuid,
-      'Results did not include pages with versions matching the given hash'
+                    'Results did not include pages with versions matching the given hash'
     assert_not_includes ids, pages(:home_page_site2).uuid,
-      'Results included pages with versions not matching the given hash'
+                        'Results included pages with versions not matching the given hash'
   end
 
   test 'can filter pages by version capture_time' do
@@ -170,9 +170,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, pages(:home_page).uuid,
-      'Results did not include pages with versions captured in the filtered date range'
+                    'Results did not include pages with versions captured in the filtered date range'
     assert_not_includes ids, pages(:home_page_site2).uuid,
-      'Results included pages with versions not captured in the filtered date range'
+                        'Results included pages with versions not captured in the filtered date range'
   end
 
   test 'includes earliest version if include_earliest = true' do
@@ -210,7 +210,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
 
     home_page = results.find {|page| page['uuid'] == pages(:home_page).uuid}
     assert_equal pages(:home_page).versions.count, home_page['versions'].length,
-      '"Home page" didn’t include all versions'
+                 '"Home page" didn’t include all versions'
   end
 
   test 'includes only versions if include_versions = true and include_latest = true' do
@@ -721,7 +721,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response(:success)
     body = JSON.parse(@response.body)
     assert(body['data'].any? {|page| page['active'] == true})
-    assert(!body['data'].any? {|page| page['active'] == false})
+    assert(body['data'].none? {|page| page['active'] == false})
   end
 
   test 'includes only inactive pages if ?active=false' do
@@ -729,7 +729,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     get(api_v0_pages_url(params: { active: false }))
     assert_response(:success)
     body = JSON.parse(@response.body)
-    assert(!body['data'].any? {|page| page['active'] == true})
+    assert(body['data'].none? {|page| page['active'] == true})
     assert(body['data'].any? {|page| page['active'] == false})
   end
 

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -60,7 +60,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, target.uuid,
-      'Results did not include versions for the filtered hash'
+                    'Results did not include versions for the filtered hash'
   end
 
   test 'can filter versions by exact date' do
@@ -73,9 +73,9 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, versions(:page1_v1).uuid,
-      'Results did not include versions captured on the filtered date'
+                    'Results did not include versions captured on the filtered date'
     assert_not_includes ids, versions(:page1_v2).uuid,
-      'Results included versions not captured on the filtered date'
+                        'Results included versions not captured on the filtered date'
   end
 
   test 'returns meaningful error for bad dates' do
@@ -89,7 +89,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     body_json = JSON.parse @response.body
     assert body_json.key?('errors'), 'Response should have an "errors" property'
     assert_match(/date/i, body_json['errors'][0]['title'],
-      'Error does not mention date')
+                 'Error does not mention date')
   end
 
   test 'can filter versions by date range' do
@@ -102,9 +102,9 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, versions(:page1_v1).uuid,
-      'Results did not include versions captured in the filtered date range'
+                    'Results did not include versions captured in the filtered date range'
     assert_not_includes ids, versions(:page1_v2).uuid,
-      'Results included versions not captured in the filtered date range'
+                        'Results included versions not captured in the filtered date range'
   end
 
   test 'can filter versions captured before a date' do
@@ -117,9 +117,9 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, versions(:page1_v1).uuid,
-      'Results did not include versions captured in the filtered date range'
+                    'Results did not include versions captured in the filtered date range'
     assert_not_includes ids, versions(:page1_v2).uuid,
-      'Results included versions not captured in the filtered date range'
+                        'Results included versions not captured in the filtered date range'
   end
 
   test 'can filter versions captured after a date' do
@@ -132,9 +132,9 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, versions(:page1_v2).uuid,
-      'Results did not include versions captured in the filtered date range'
+                    'Results did not include versions captured in the filtered date range'
     assert_not_includes ids, versions(:page1_v1).uuid,
-      'Results included versions not captured in the filtered date range'
+                        'Results included versions not captured in the filtered date range'
   end
 
   test 'returns meaningful error for bad date ranges' do
@@ -148,7 +148,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     body_json = JSON.parse @response.body
     assert body_json.key?('errors'), 'Response should have an "errors" property'
     assert_match(/date/i, body_json['errors'][0]['title'],
-      'Error does not mention date')
+                 'Error does not mention date')
   end
 
   test 'can filter versions by source_type' do

--- a/test/controllers/healthcheck_controller_test.rb
+++ b/test/controllers/healthcheck_controller_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 require 'minitest/mock'
 
 class Api::V0::DiffControllerTest < ActionDispatch::IntegrationTest
-
   test 'healthcheck responds with success' do
     get '/healthcheck'
     assert_response :success

--- a/test/lib/file_storage/s3_test.rb
+++ b/test/lib/file_storage/s3_test.rb
@@ -40,10 +40,10 @@ class FileStorage::S3Test < ActiveSupport::TestCase
   end
 
   test 's3 storage can determine whether an S3 URI matches it' do
-    stub_request(:head, "https://test-bucket.s3.us-west-2.amazonaws.com/something.txt")
-      .to_return(status: 200, body: "", headers: {})
-    stub_request(:head, "https://test-bucket.s3.us-west-2.amazonaws.com/does-not-exist.txt")
-      .to_return(status: 404, body: "", headers: {})
+    stub_request(:head, 'https://test-bucket.s3.us-west-2.amazonaws.com/something.txt')
+      .to_return(status: 200, body: '', headers: {})
+    stub_request(:head, 'https://test-bucket.s3.us-west-2.amazonaws.com/does-not-exist.txt')
+      .to_return(status: 404, body: '', headers: {})
 
     storage = test_storage
     assert storage.contains_url?('s3://test-bucket/something.txt')
@@ -53,10 +53,10 @@ class FileStorage::S3Test < ActiveSupport::TestCase
   end
 
   test 's3 storage can determine whether an S3 URL matches it' do
-    stub_request(:head, "https://test-bucket.s3.us-west-2.amazonaws.com/something.txt")
-      .to_return(status: 200, body: "", headers: {})
-    stub_request(:head, "https://test-bucket.s3.us-west-2.amazonaws.com/does-not-exist.txt")
-      .to_return(status: 404, body: "", headers: {})
+    stub_request(:head, 'https://test-bucket.s3.us-west-2.amazonaws.com/something.txt')
+      .to_return(status: 200, body: '', headers: {})
+    stub_request(:head, 'https://test-bucket.s3.us-west-2.amazonaws.com/does-not-exist.txt')
+      .to_return(status: 404, body: '', headers: {})
 
     storage = test_storage
     assert storage.contains_url?('https://test-bucket.s3.amazonaws.com/something.txt')

--- a/test/mailers/invitation_mailer_test.rb
+++ b/test/mailers/invitation_mailer_test.rb
@@ -7,23 +7,23 @@ class InvitationMailerTest < ActionMailer::TestCase
   include Rails.application.routes.url_helpers
   def mail_url(route, options = nil)
     url_for([
-      route,
-      Rails.application.config.action_mailer.default_url_options.merge(options)
-    ])
+              route,
+              Rails.application.config.action_mailer.default_url_options.merge(options)
+            ])
   end
 
   def test_send_invitation_email
-    invitation = Invitation.create(email: "test@email.com")
-    invitation.update_attributes(code: "eff7df8ccc0cd0256619")
+    invitation = Invitation.create(email: 'test@email.com')
+    invitation.update_attributes(code: 'eff7df8ccc0cd0256619')
     email = InvitationMailer.invitation_email(invitation)
 
     assert_emails 1 do
       email.deliver_now
     end
 
-    assert_equal "Welcome to EDGI web monitoring", email.subject
+    assert_equal 'Welcome to EDGI web monitoring', email.subject
     assert_equal [ENV.fetch('MAIL_SENDER', 'web-monitoring-db@envirodatagov.org')], email.from
-    assert_equal ["test@email.com"], email.to
+    assert_equal ['test@email.com'], email.to
 
     invite_url = mail_url(:new_user_registration, invitation: invitation.code)
     assert_includes email.html_part.body.to_s, invite_url

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -1,7 +1,7 @@
-require "application_system_test_case"
+require 'application_system_test_case'
 
 class UsersTest < ApplicationSystemTestCase
-  test "Invite, register, confirm, promote, demote, delete" do
+  test 'Invite, register, confirm, promote, demote, delete' do
     admin = users(:admin_user)
     viewer_email = 'user@example.com'
 
@@ -11,13 +11,13 @@ class UsersTest < ApplicationSystemTestCase
     Capybara.using_session(:admin) do
       visit root_path
 
-      click_on "Login"
+      click_on 'Login'
 
       fill_in 'Email', with: admin.email
       fill_in 'Password', with: 'testpassword'
       click_on 'Log in'
 
-      assert page.has_content?("Logged in as #{admin.email}"), "Admin should have an active session"
+      assert page.has_content?("Logged in as #{admin.email}"), 'Admin should have an active session'
       click_on 'Admin'
 
       perform_enqueued_jobs do
@@ -46,7 +46,7 @@ class UsersTest < ApplicationSystemTestCase
       fill_in 'Password', with: 'testpassword'
       click_on 'Log in'
 
-      assert page.has_content?("Logged in as #{viewer_email}"), "User should have an active session"
+      assert page.has_content?("Logged in as #{viewer_email}"), 'User should have an active session'
     end
 
     #
@@ -67,7 +67,7 @@ class UsersTest < ApplicationSystemTestCase
     Capybara.using_session(:user) do
       visit root_path
 
-      assert page.has_link?('Admin'), "User should have admin permissions"
+      assert page.has_link?('Admin'), 'User should have admin permissions'
     end
 
     #
@@ -87,7 +87,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     Capybara.using_session(:user) do
       visit root_path
-      refute page.has_link?('Admin'), "User should not have admin permissions"
+      refute page.has_link?('Admin'), 'User should not have admin permissions'
     end
 
     #
@@ -107,7 +107,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     Capybara.using_session(:user) do
       visit root_path
-      refute page.has_content?("Logged in as #{viewer_email}"), "User should NOT have an active session"
+      refute page.has_content?("Logged in as #{viewer_email}"), 'User should NOT have an active session'
 
       click_on 'Login'
 
@@ -115,7 +115,7 @@ class UsersTest < ApplicationSystemTestCase
       fill_in 'Password', with: 'testpassword'
       click_on 'Log in'
 
-      assert page.has_content?('Invalid Email or password.'), "User should not be able to log in"
+      assert page.has_content?('Invalid Email or password.'), 'User should not be able to log in'
     end
   end
 end


### PR DESCRIPTION
Rubocop Documentation: https://docs.rubocop.org/en/stable/configuration/#merging-arrays-using-inherit_mode

I discovered that most ruby files were being ignored by Rubocop because `inherit_mode` was not set, so it was not picking up the expected files from plugins like `rubocop-rails`. Here is what was being checked using the `-L` flag:

```bash
[bensheldon@Bens-MBP-CfA:~/Repositories/edgi-govdata-archiving/web-monitoring-db](permissions_system)$ bundle exec rubocop -L
config.ru
Rakefile
lib/tasks/cache_diffs.rake
lib/tasks/invitations.rake
lib/tasks/rename_site.rake
lib/tasks/import_from_sheets.rake
lib/tasks/copy_data.rake
lib/tasks/analyze_changes.rake
lib/tasks/data/20181204_set_version_status.rake
lib/tasks/data/20181124_normalize_titles.rake
lib/tasks/data/20190112_add_page_domain_tags.rake
lib/tasks/data/20181205_update_version_different.rake
lib/tasks/data/20180926_move_versionista_s3_data.rake
```

Subsequently I ran `bundle exec rubocop --safe-auto-correct`, which caught `125 files inspected, 172 offenses detected, 158 offenses corrected`

Here are the 14 issues I fixed manually (or ignored: CyclomaticComplexity, NumericPredicate):

```
Offenses:

app/jobs/import_versions_job.rb:13:19: C: Style/SymbolProc: Pass &:uuid as an argument to uniq instead of a block.
      @added.uniq {|version| version.uuid}.each do |version|
                  ^^^^^^^^^^^^^^^^^^^^^^^^
app/jobs/import_versions_job.rb:61:3: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for import_record is too high. [13/12]
  def import_record(record) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^
app/jobs/import_versions_job.rb:61:3: C: Metrics/PerceivedComplexity: Perceived complexity for import_record is too high. [14/12]
  def import_record(record) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^
app/jobs/analyze_change_job.rb:61:5: W: Layout/EndAlignment: end at 61, 4 is not aligned with if at 57, 13.
    end
    ^^^
app/jobs/analyze_change_job.rb:80:55: C: Style/NumericPredicate: Use (operation[0]).zero? instead of operation[0] == 0.
    text_diff_changes = text_diff.reject {|operation| operation[0] == 0}
                                                      ^^^^^^^^^^^^^^^^^
app/jobs/analyze_change_job.rb:87:52: C: Style/NumericPredicate: Use (operation[0]).zero? instead of operation[0] == 0.
    diff_changes = source_diff.reject {|operation| operation[0] == 0}
                                                   ^^^^^^^^^^^^^^^^^
app/jobs/analyze_change_job.rb:104:51: C: Style/NumericPredicate: Use (operation[0]).zero? instead of operation[0] == 0.
    diff_changes = links_diff.reject {|operation| operation[0] == 0}
                                                  ^^^^^^^^^^^^^^^^^
app/jobs/analyze_change_job.rb:133:66: C: Style/NumericPredicate: Use (operations[0]).zero? instead of operations[0] == 0.
    return 0.0 if operations.empty? || operations.length == 1 && operations[0] == 0
                                                                 ^^^^^^^^^^^^^^^^^^
app/jobs/analyze_change_job.rb:141:5: C: Style/NumericPredicate: Use (characters[1]).zero? instead of characters[1] == 0.
    characters[1] == 0 ? 0.0 : (characters[0] / characters[1].to_f).round(4)
    ^^^^^^^^^^^^^^^^^^
app/jobs/analyze_change_job.rb:208:5: W: Layout/EndAlignment: end at 208, 4 is not aligned with if at 204, 11.
    end
    ^^^
app/jobs/analyze_change_job.rb:224:5: C: Style/MultipleComparison: Avoid comparing a variable with multiple items in a conditional, use Array#include? instead.
    text == 'true' || text == 't' || text == '1'
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/jobs/analyze_change_job.rb:237:73: W: Lint/ShadowingOuterLocalVariable: Shadowing outer local variable - texts.
    texts = text_diff.each_with_object(old: '', new: '') do |operation, texts|
                                                                        ^^^^^
app/controllers/api/v0/pages_controller.rb:194:25: C: Style/MultipleComparison: Avoid comparing a variable with multiple items in a conditional, use Array#include? instead.
        .reject {|k, _| k == 'created_at' || k == 'updated_at'}
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/api/v0/pages_controller.rb:200:25: C: Style/MultipleComparison: Avoid comparing a variable with multiple items in a conditional, use Array#include? instead.
        .reject {|k, _| k == 'created_at' || k == 'updated_at'}
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

125 files inspected, 14 offenses detected
```