### PR TITLE
Use relative host for swagger; place actual file in app/assets

### DIFF
--- a/app/assets/data/swagger.yaml
+++ b/app/assets/data/swagger.yaml
@@ -9,7 +9,6 @@ info:
     name: GPL 3
     url: >-
       https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/master/LICENSE
-host: api.monitoring.envirodatagov.org
 basePath: /api/v0
 tags:
   - name: pages and versions
@@ -18,8 +17,6 @@ tags:
     description: comparisons between two Versions
   - name: imports
     description: Bulk-importing Versions
-schemes:
-  - https
 
 parameters:
   sort:

--- a/app/assets/data/swagger.yml
+++ b/app/assets/data/swagger.yml
@@ -1,1 +1,0 @@
-../../../swagger.yaml

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,0 +1,1 @@
+app/assets/data/swagger.yaml


### PR DESCRIPTION
- Removes hardcoded host and protocol which are [optional in the swagger spec](https://swagger.io/docs/specification/2-0/api-host-and-base-path/#host) to fix #292 
- Places the actual `swagger.yml` file in `app/assets` and places a symlink in the project root to fix #455