### PR TITLE
Delete a newly created page if the version import fails

### DIFF
--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -106,7 +106,7 @@ class ImportVersionsJob < ApplicationJob
       @added << version unless existing
     rescue StandardError
       # Delete a newly created page if the version import fails
-      if page.uuid_previously_changed? && page.versions.empty?
+      if page.uuid_previously_changed? && page.versions.count.zero?
         page.maintainers = []
         page.destroy!
       end

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -70,7 +70,13 @@ class ImportVersionsJobTest < ActiveJob::TestCase
         ImportVersionsJob.perform_now(import)
 
         imported_page = Page.find_by(url: bad_page_url)
-        assert_nil imported_page, 'Should not import page with bad versions'
+        assert_nil imported_page, 'Should delete newly created page on version error'
+
+        Page.create! url: bad_page_url
+        ImportVersionsJob.perform_now(import)
+
+        imported_page = Page.find_by(url: bad_page_url)
+        assert imported_page, 'Should NOT delete existing page on version error'
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 require 'rails/test_help'
+require 'minitest/autorun'
 require 'webmock/minitest'
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
This fixes #192.

This PR is a broad wrapping of the import behavior with a rescue block because I'm not quite sure what the failure behavior is of importing. It's possible to target more specific import failures if you can point me in that direction. 

I also considered wrapping it in a transaction but I wanted to suggest the rescue block first. If I changed to a transaction, I'd want to do a bit of reordering in that method so I could open the transaction _after_ the API call so that the open transaction is as brief as possible.