### PR TITLE
Add migration to drop the `admin` column for users

### DIFF
--- a/db/migrate/20190531175430_remove_admin_from_users.rb
+++ b/db/migrate/20190531175430_remove_admin_from_users.rb
@@ -1,0 +1,10 @@
+class RemoveAdminFromUsers < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :users, :admin
+  end
+
+  def down
+    add_column :users, :admin, :boolean, default: false
+    execute "UPDATE users SET admin = TRUE WHERE 'manage_users' = ANY(permissions);"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_18_154841) do
+ActiveRecord::Schema.define(version: 2019_05_31_175430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -133,7 +133,6 @@ ActiveRecord::Schema.define(version: 2019_05_18_154841) do
     t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "admin", default: false
     t.string "permissions", default: [], array: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
Fixes #34 (Most of the work was by @bensheldon in #533, this just cleans up the last bit!)