### PR TITLE
Fix deprecation warning for `DeviseHelper.devise_error_messages!`

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Sign up</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render 'devise/shared/error_messages' %>
 
   <div class="field">
     <% if @invitation_error %>


### PR DESCRIPTION
This PR fixes a deprecation warning from Devise:

```bash
DEPRECATION WARNING: [Devise] `DeviseHelper.devise_error_messages!`
is deprecated and it will be removed in the next major version.
To customize the errors styles please run `rails g devise:views` and modify the
`devise/shared/error_messages` partial.
 (called from block in _app_views_users_registrations_new_html_erb___2844399626396461444_70316102091520 at /Users/bensheldon/Repositories/edgi-govdata-archiving/web-monitoring-db/app/views/users/registrations/new.html.erb:4)
```

It looks like this change has previously been made in another template:

https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/3cba9a45e10430270f245d658e3c736974eb8708/app/views/users/registrations/edit.html.erb#L3-L5
