### PR TITLE
Update Rails binstubs

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run


### PR DESCRIPTION
I was having trouble running `rails generate migration`, and it turns out it's because binstubs were out of date. This is basically just the result of running `bundle exec rake rails:update:bin`. I’m not sure what exactly changed about Spring usage here, but it seems to fix the issue.