### PR TITLE
Add indexes for commonly searched fields on Version

### DIFF
--- a/db/migrate/20190617231901_add_common_indexes_to_versions.rb
+++ b/db/migrate/20190617231901_add_common_indexes_to_versions.rb
@@ -1,0 +1,11 @@
+class AddCommonIndexesToVersions < ActiveRecord::Migration[5.2]
+  # Add indexes to support some common queries we do that should be faster.
+  def change
+    # Our default sorting is by created_at:asc.
+    add_index :versions, :created_at
+    # By default, we only search for records where `different = true`.
+    add_index :versions, :different
+    # We also search by source_type pretty frequently.
+    add_index :versions, :source_type
+  end
+end

--- a/db/migrate/20190617231901_add_common_indexes_to_versions.rb
+++ b/db/migrate/20190617231901_add_common_indexes_to_versions.rb
@@ -3,9 +3,18 @@ class AddCommonIndexesToVersions < ActiveRecord::Migration[5.2]
   def change
     # Our default sorting is by created_at:asc.
     add_index :versions, :created_at
-    # By default, we only search for records where `different = true`.
-    add_index :versions, :different
     # We also search by source_type pretty frequently.
     add_index :versions, :source_type
+
+    # In most cases, we only search for records where different = true.
+    # However, an index for `different` or a compound index featuring it
+    # will almost never get used in practice! Instead, create partial
+    # indexes, which do get used.
+    add_index :versions, :capture_time,
+              where: 'different = true',
+              name: 'index_different_versions_on_capture_time'
+    add_index :versions, :created_at,
+              where: 'different = true',
+              name: 'index_different_versions_on_created_at'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_175430) do
+ActiveRecord::Schema.define(version: 2019_06_17_231901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -152,7 +152,10 @@ ActiveRecord::Schema.define(version: 2019_05_31_175430) do
     t.boolean "different", default: true
     t.integer "status"
     t.index ["capture_time"], name: "index_versions_on_capture_time"
+    t.index ["created_at"], name: "index_versions_on_created_at"
+    t.index ["different"], name: "index_versions_on_different"
     t.index ["page_uuid"], name: "index_versions_on_page_uuid"
+    t.index ["source_type"], name: "index_versions_on_source_type"
     t.index ["version_hash"], name: "index_versions_on_version_hash"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -151,9 +151,10 @@ ActiveRecord::Schema.define(version: 2019_06_17_231901) do
     t.string "capture_url"
     t.boolean "different", default: true
     t.integer "status"
+    t.index ["capture_time"], name: "index_different_versions_on_capture_time", where: "(different = true)"
     t.index ["capture_time"], name: "index_versions_on_capture_time"
+    t.index ["created_at"], name: "index_different_versions_on_created_at", where: "(different = true)"
     t.index ["created_at"], name: "index_versions_on_created_at"
-    t.index ["different"], name: "index_versions_on_different"
     t.index ["page_uuid"], name: "index_versions_on_page_uuid"
     t.index ["source_type"], name: "index_versions_on_source_type"
     t.index ["version_hash"], name: "index_versions_on_version_hash"


### PR DESCRIPTION
We frequently filter Versions by several fields that don't have indexes, and that causes some real slowdowns. This adds indexes for them.

In local development, this hasn’t been a problem, but our Versions table in production has gotten big enough that we are seeing some real slowdowns. There’s also probably other optimizations we could make here, but I am no Postgres expert and this is a good start for now.