### PR TITLE
Give new users view and annotate permissions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ApplicationRecord
   has_one :invitation, class_name: 'Invitation', foreign_key: 'redeemer_id', inverse_of: :redeemer
 
   validates :permissions, contains_only: PERMISSIONS
+  before_create :set_defaults
 
   # We need to enforce some additional constraints on the invitation
   # relationship. This isn't great, but the best way I can see for now.
@@ -57,6 +58,12 @@ class User < ApplicationRecord
     if self.invitation
       self.invitation.destroy
       self.invitation = nil
+    end
+  end
+
+  def set_defaults
+    if self.permissions.empty?
+      self.permissions << VIEW_PERMISSION << ANNOTATE_PERMISSION
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
   has_one :invitation, class_name: 'Invitation', foreign_key: 'redeemer_id', inverse_of: :redeemer
 
   validates :permissions, contains_only: PERMISSIONS
-  before_create :set_defaults
+  attribute :permissions, :string, array: true, default: [VIEW_PERMISSION, ANNOTATE_PERMISSION]
 
   # We need to enforce some additional constraints on the invitation
   # relationship. This isn't great, but the best way I can see for now.
@@ -58,12 +58,6 @@ class User < ApplicationRecord
     if self.invitation
       self.invitation.destroy
       self.invitation = nil
-    end
-  end
-
-  def set_defaults
-    if self.permissions.empty?
-      self.permissions << VIEW_PERMISSION << ANNOTATE_PERMISSION
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -60,4 +60,16 @@ class UserTest < ActiveSupport::TestCase
     user.permissions << User::MANAGE_USERS_PERMISSION
     assert user.can_manage_users?, 'User should be able to manage users'
   end
+
+  test 'user has view and annotate permissions by default' do
+    user = User.create(email: 'new-user@example.com', password: 'PASSWORD')
+    assert user.can_view?
+    assert user.can_annotate?
+  end
+
+  test 'user default permissions do not override explicit permissions' do
+    user = User.create(email: 'new-user@example.com', password: 'PASSWORD', permissions: [User::VIEW_PERMISSION])
+    assert user.can_view?
+    assert !user.can_annotate?
+  end
 end


### PR DESCRIPTION
When users are first created, make sure they are granted `view` and `annotate` permissions.

Fixes #549.