### PR TITLE
Check `different` flag in `version.next/previous` and associated methods

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -18,32 +18,38 @@ class Version < ApplicationRecord
     self.page.versions.reorder(capture_time: :asc).first
   end
 
-  def previous
-    self.page.versions.where('capture_time < ?', self.capture_time).first
+  def previous(different: true)
+    self.page.versions
+      .where('capture_time < ?', self.capture_time)
+      .where(different: different)
+      .first
   end
 
-  def next
-    self.page.versions.where('capture_time > ?', self.capture_time).last
+  def next(different: true)
+    self.page.versions
+      .where('capture_time > ?', self.capture_time)
+      .where(different: different)
+      .last
   end
 
-  def change_from_previous
-    Change.between(from: previous, to: self, create: nil)
+  def change_from_previous(different: true)
+    Change.between(from: previous(different: different), to: self, create: nil)
   end
 
-  def change_from_next
-    Change.between(from: self, to: self.next, create: nil)
+  def change_from_next(different: true)
+    Change.between(from: self, to: self.next(different: different), create: nil)
   end
 
   def change_from_earliest
     Change.between(from: earliest, to: self, create: nil)
   end
 
-  def ensure_change_from_previous
-    Change.between(from: previous, to: self, create: :new)
+  def ensure_change_from_previous(different: true)
+    Change.between(from: previous(different: different), to: self, create: :new)
   end
 
-  def ensure_change_from_next
-    Change.between(from: self, to: self.next, create: :new)
+  def ensure_change_from_next(different: true)
+    Change.between(from: self, to: self.next(different: different), create: :new)
   end
 
   def ensure_change_from_earliest


### PR DESCRIPTION
When looking for the `next` or `previous` version, we should almost always be looking for the next/previous version that was *different*. This was causing a lot of issues with calculating links for analysts, because new, non-different versions would be inserted after an analysis was done, and the analysis would be lost (because we'd try and retrieve it for the current vs. "previous" version, but "previous" was no longer the right thing).

This makes the default behavior one in which we check the different flag, but optionally lets you say `next(different: false)` to get the next version regardless of whether it's different.

This will also have the happy byproduct of making sure we are always analyzing versions that are different—it looks like we may have frequently been doing relatively pointless analyses before.

Fixes #576.