### PR TITLE
Log queue size to elasticsearch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,14 @@ jobs:
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle-test_test
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.2
+        environment:
+          - cluster.name: elasticsearch
+          - xpack.security.enabled: false
+          - transport.host: localhost
+          - network.host: 127.0.0.1
+          - http.port: 9200
+          - discovery.type: single-node
     steps:
       - checkout
       - restore_cache:

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ HOST_URL='web-monitoring-db.dev'
 # OPTIONAL: only set this if your Redis is at a non-standard location
 # REDIS_URL=redis://user:password@localhost:6379
 
+# OPTIONAL: only set this if your Elasticsearch is at a non-standard location
+# ELASTICSEARCH_URL=http://localhost:9200
+
 # E-mail address to use as the "from" address
 MAIL_SENDER='some-email-account@example.com'
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,22 @@ It’s a Rails app that:
     $ apt-get install redis
     ```
 
-4. Ensure you have a JavaScript Runtime
+4. Ensure you have [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html).
+
+    On MacOS:
+
+    ```sh
+    $ brew tap elastic/tap
+    $ brew install elastic/tap/elasticsearch-full
+    ```
+
+    On Debian Linux:
+
+    ```sh
+    $ apt-get install elasticsearch
+    ```
+
+5. Ensure you have a JavaScript Runtime
 
     On MacOS:
 
@@ -46,21 +61,21 @@ It’s a Rails app that:
     ```
     If you wish to use another runtime you can use one listed [here](https://github.com/rails/execjs/blob/master/README.md).
 
-5. Clone this repo
+6. Clone this repo
 
-6. If you don’t have the `bundler` Ruby gem, install it:
+7. If you don’t have the `bundler` Ruby gem, install it:
 
     ```sh
     $ gem install bundler
     ```
 
-7. Wherever you cloned the repo, go to that directory and install dependencies:
+8. Wherever you cloned the repo, go to that directory and install dependencies:
 
     ```sh
     $ bundle install --without production
     ```
 
-8. Copy the .env.example file to .env - this allows for easy configuration locally.
+9. Copy the .env.example file to .env - this allows for easy configuration locally.
 
     ```sh
     $ cp .env.example .env
@@ -68,7 +83,7 @@ It’s a Rails app that:
 
     Take a moment to look through the variables here and change any that make sense for your local environment. If you need set variables differently when running tests, make a `.env.test` file that has your test-specific variables.
 
-9. Set up your database.
+10. Set up your database.
 
     - If your Postgres install trusts local users and you have a superuser (this is the normal situation with Postgres.app), run:
 
@@ -140,7 +155,7 @@ It’s a Rails app that:
 
             For more on this last step, see [manual postgres setup](#manual-postgres-setup) below.
 
-10. Start the server!
+11. Start the server!
 
     ```sh
     $ bundle exec rails server
@@ -148,7 +163,7 @@ It’s a Rails app that:
 
     You should now have a server running and can visit it at http://localhost:3000/. Open that up in a browser and go to town!
 
-11. Bulk importing, automated analysis, and e-mail invitations all run as asynchronous jobs, managed by a Redis queue. If you plan to use any of these features, you must also start a Redis server and worker.
+12. Bulk importing, automated analysis, and e-mail invitations all run as asynchronous jobs, managed by a Redis queue. If you plan to use any of these features, you must also start a Redis server and worker.
 
     Start redis:
 

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -3,7 +3,7 @@ require 'httparty'
 
 class ElasticLogger
   include HTTParty
-  base_uri ENV.fetch('ELASTICSEARCH_URL')
+  base_uri ENV.fetch('ELASTICSEARCH_URL', 'http://localhost:9200')
 
   def report_size(size)
     response = self.class.post(

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -8,8 +8,9 @@ class ElasticLogger
   def report_size(size)
     response = self.class.post(
       '/import_queue/_doc/',
-      :body => { size: size }.to_json,
-      :headers => {'Content-Type' => 'application/json'} )
+      body: { size: size }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
     puts response
   end
 end
@@ -19,7 +20,7 @@ end
 
 class ImportVersionsJob < ApplicationJob
   queue_as :import
-  ELASTIC_LOGGER = ElasticLogger.new()
+  ELASTIC_LOGGER = ElasticLogger.new
 
   # TODO: wrap in transaction?
   def perform(import)


### PR DESCRIPTION
This now produces data which is accessible in Kibana:

![image](https://user-images.githubusercontent.com/2279598/63393486-5a093700-c389-11e9-916c-0d13096781b0.png)

Open questions;
- Should elasticsearch be a required dependency (simpler code) or an optional one (simpler installation)?
- As a related question, should we submit messages to elasticsearch in all environments or only in production?
- At what other times during the import job lifecycle should we log the queue size? In this example, where I ran `rake db:seed` to run import jobs, the `size` is always `0` (at the end of a given job) so the logs are not very interesting. Perhaps we should log at the start of each job as well?
- What additional information should we include in the message? To start, a `timestamp` seems like a good idea. What else?