### PR TITLE
Document `ALLOWED_ARCHIVE_HOSTS` and S3 Buckets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,13 @@ MAIL_SENDER='some-email-account@example.com'
 # MAIL_SMTP_PASSWORD='XXX'
 # MAIL_SMTP_TLS='true'
 
-# Controls URLs that won't be downloaded and re-hosted when importing versions
+# URLs that won't be downloaded and re-hosted when importing versions.
+# When new page or version data is imported (e.g. via `POST /api/v0/imports`),
+# the `uri` field points to a location where the raw HTTP response body is
+# stored. If the `uri` host does *not* match one of the values in
+# `ALLOWED_ARCHIVE_HOSTS`, the application downloads the data from `uri` and
+# stores it (see `lib/archiver` for more). That way, we can ensure data is
+# always available to API users from a reliable public location.
 ALLOWED_ARCHIVE_HOSTS='https://edgi-web-monitoring-db.s3.amazonaws.com/ https://edgi-wm-versionista.s3.amazonaws.com/ https://edgi-wm-versionista.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-wm-versionista/ https://edgi-versionista-archive.s3.amazonaws.com/ https://edgi-versionista-archive.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-versionista-archive/'
 
 # OPTIONAL: Uncomment & fill in to use S3 for storage instead of your local

--- a/README.md
+++ b/README.md
@@ -245,16 +245,16 @@ There are several other kinds of objects, but they are subservient to the ones a
 
 - **Imports** model requests to import new data and the results of the import operation.
 
-- **Users** model people (both human and bots) who can view, import, and annotate data. You currently have to have a user account to do anything in  the application, though we hope accounts will not be needed to view public data in the future.
+- **Users** model people (both human and bots) who can view, import, and annotate data. You currently have to have a user account to do anything in the application, though we hope accounts will not be needed to view public data in the future.
 
 
 ### How Data Gets Loaded
 
-The web-monitoring-db project does not actually monitor or scrape actual pages on the web. Instead, we rely on importing data from other services, like [the Internet Archive](https://archive.org). Each day, a script queries other services for historical snapshots and sends the results to the `/api/v0/imports` endpoint.
+The web-monitoring-db project does not actually monitor or scrape pages on the web. Instead, we rely on importing data from other services, like [the Internet Archive](https://archive.org). Each day, a script queries other services for historical snapshots and sends the results to the `/api/v0/imports` endpoint.
 
 Most of the data sent to `/api/v0/imports` matches up directly with the structure of the [`Version` model](https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/master/app/models/version.rb). However, the `uri` field in an import is treated specially. If the `uri` host matches one of the hosts listed in the [`ALLOWED_ARCHIVE_HOSTS` environment variable](https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/master/.env.example), the application simply stores that as the version’s `uri`. If it doesn’t match, the application downloads the content from `uri` and stores it in its `FileStorage`. The intent is to make sure data winds up at a reliably available location, ensuring that anyone who can access the API can also access the raw response body for any version. The application’s storage area can be the local disk or it can be S3, depending on configuration. The component can take pluggable configurations, so we can support other storage types or locations in the future.
 
-You can see more about this process in the overview repo’s [“architecture” document](https://github.com/edgi-govdata-archiving/web-monitoring/blob/master/ARCHITECTURE.md#web-page-snapshottingcapturing-workflow)
+You can see more about this process in the overview repo’s [“architecture” document](https://github.com/edgi-govdata-archiving/web-monitoring/blob/master/ARCHITECTURE.md#web-page-snapshottingcapturing-workflow).
 
 
 ### File Storage
@@ -267,7 +267,7 @@ At current, the application creates two `FileStorage` instances:
 
 2. “Working storage” is used to store internal data, such as raw import data and import logs. Under a default configuration, this is your local disk in development and S3 in production. You can configure the S3 bucket used for it with the `AWS_WORKING_BUCKET` environment variable. **Everything in this storage area should be considered private and you should not expose it to the public web.**
 
-3. For historical reasons, EDGI’s deployment includes a third S3 bucket that is not directly accessed by the application. It’s where we store HTTP response bodies collected from [Versionista][https://versionista.com], a service we previously used for scraping government web pages. You can see it listed in [the example settings for `ALLOWED_ARCHIVE_HOSTS`](https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/master/.env.example).
+3. For historical reasons, EDGI’s deployment includes a third S3 bucket that is not directly accessed by the application. It’s where we store HTTP response bodies collected from [Versionista](https://versionista.com), a service we previously used for scraping government web pages. You can see it listed in [the example settings for `ALLOWED_ARCHIVE_HOSTS`](https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/master/.env.example).
 
 
 ## Code of Conduct


### PR DESCRIPTION
Add more explanation to `.env.example` and to the README about how data is managed and stored in the application. Also explain the overall data model and document the public access user on staging (see edgi-govdata-archiving/web-monitoring-ui#220).

Hopefully this is clarifying and not confusing! See here for a full render of the new README instead of a diff, if that helps: https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/249-469-explain-just-who-gets-trusted-to-hold-your-gooses-golden-eggs-and-where/README.md

Fixes #249.
Fixes #469.