### PR TITLE
Only include totals in list endpoints if `?include_total=true`

### DIFF
--- a/app/assets/data/swagger.yaml
+++ b/app/assets/data/swagger.yaml
@@ -30,6 +30,38 @@ parameters:
       `title:asc,url:desc`. You can sort by any field on the result
       objects.
 
+  chunk:
+    name: chunk
+    in: query
+    description: pagination parameter
+    required: false
+    type: integer
+    default: 1
+
+  chunk_size:
+    name: chunk_size
+    in: query
+    description: number of items per chunk
+    required: false
+    type: integer
+    default: 100
+
+  include_total:
+    name: include_total
+    in: query
+    required: false
+    type: boolean
+    default: false
+    description: >
+      If true, inlude the number of total results across all chunks as a field
+      called `meta.total_results`. For example, querying
+      `/api/v0/pages?include_total` would show the total number of page
+      records in the database in that field.
+
+      Note that `links.last` will only be populated if you are already on the
+      last chunk *unless this parameter is set to true* (the URL of the
+      “last” chunk can’t be determined without counting all possible results).
+
 paths:
   /pages:
     get:
@@ -42,18 +74,9 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: chunk
-          in: query
-          description: pagination parameter
-          required: false
-          type: integer
-          default: 1
-        - name: chunk_size
-          in: query
-          description: number of items per chunk
-          required: false
-          type: integer
-          default: 100
+        - $ref: '#/parameters/chunk'
+        - $ref: '#/parameters/chunk_size'
+        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
         - name: site
           in: query
@@ -214,18 +237,9 @@ paths:
           required: true
           type: string
           format: uuid4
-        - name: chunk
-          in: query
-          description: pagination parameter
-          required: false
-          type: integer
-          default: 1
-        - name: chunk_size
-          in: query
-          description: number of items per chunk
-          required: false
-          type: integer
-          default: 100
+        - $ref: '#/parameters/chunk'
+        - $ref: '#/parameters/chunk_size'
+        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
         - name: capture_time
           in: query
@@ -408,19 +422,10 @@ paths:
           required: true
           type: string
           format: uuid4
-        - name: chunk
-          in: query
-          description: pagination parameter
-          required: false
-          type: integer
-          default: 1
+        - $ref: '#/parameters/chunk'
+        - $ref: '#/parameters/chunk_size'
+        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
-        - name: chunk_size
-          in: query
-          description: number of items per chunk
-          required: false
-          type: integer
-          default: 100
         - name: priority
           in: query
           description: Only include changes with a matching `priority`. This can be a number (to get an exact match) or an interval using standard mathematical syntax, e.g. `[0.3,0.6)` for `0.3 <= priority < 0.6`. You can leave out the start or end, e.g. `[0.3,]` for `priority >= 0.3`.
@@ -501,6 +506,9 @@ paths:
           required: true
           type: string
           format: uuid4
+        - $ref: '#/parameters/chunk'
+        - $ref: '#/parameters/chunk_size'
+        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
       responses:
         '200':
@@ -694,18 +702,9 @@ paths:
           required: true
           type: string
           format: uuid4
-        - name: chunk
-          in: query
-          description: pagination parameter
-          required: false
-          type: integer
-          default: 1
-        - name: chunk_size
-          in: query
-          description: number of items per chunk
-          required: false
-          type: integer
-          default: 100
+        - $ref: '#/parameters/chunk'
+        - $ref: '#/parameters/chunk_size'
+        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
         - name: parent
           in: query
@@ -824,18 +823,9 @@ paths:
           required: true
           type: string
           format: uuid4
-        - name: chunk
-          in: query
-          description: pagination parameter
-          required: false
-          type: integer
-          default: 1
-        - name: chunk_size
-          in: query
-          description: number of items per chunk
-          required: false
-          type: integer
-          default: 100
+        - $ref: '#/parameters/chunk'
+        - $ref: '#/parameters/chunk_size'
+        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
       responses:
         '200':
@@ -941,18 +931,9 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: chunk
-          in: query
-          description: pagination parameter
-          required: false
-          type: integer
-          default: 1
-        - name: chunk_size
-          in: query
-          description: number of items per chunk
-          required: false
-          type: integer
-          default: 100
+        - $ref: '#/parameters/chunk'
+        - $ref: '#/parameters/chunk_size'
+        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
         - name: capture_time
           in: query
@@ -1145,18 +1126,9 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: chunk
-          in: query
-          description: pagination parameter
-          required: false
-          type: integer
-          default: 1
-        - name: chunk_size
-          in: query
-          description: number of items per chunk
-          required: false
-          type: integer
-          default: 100
+        - $ref: '#/parameters/chunk'
+        - $ref: '#/parameters/chunk_size'
+        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
         - name: parent
           in: query
@@ -1267,18 +1239,9 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: chunk
-          in: query
-          description: pagination parameter
-          required: false
-          type: integer
-          default: 1
-        - name: chunk_size
-          in: query
-          description: number of items per chunk
-          required: false
-          type: integer
-          default: 100
+        - $ref: '#/parameters/chunk'
+        - $ref: '#/parameters/chunk_size'
+        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
       responses:
         '200':

--- a/app/controllers/api/v0/annotations_controller.rb
+++ b/app/controllers/api/v0/annotations_controller.rb
@@ -6,11 +6,11 @@ class Api::V0::AnnotationsController < Api::V0::ApiController
   def index
     annotations = sort_using_params(parent_change.annotations)
     paging = pagination(annotations)
-    annotations = annotations.limit(paging[:chunk_size]).offset(paging[:offset])
+    annotations = paging[:query]
 
     render json: {
       links: paging[:links],
-      meta: { total_results: paging[:total_items] },
+      meta: paging[:meta],
       data: annotations.as_json(
         include: { author: { only: [:id, :email] } },
         except: :author_id

--- a/app/controllers/api/v0/changes_controller.rb
+++ b/app/controllers/api/v0/changes_controller.rb
@@ -4,11 +4,11 @@ class Api::V0::ChangesController < Api::V0::ApiController
   def index
     query = changes_collection
     paging = pagination(query)
-    changes = query.limit(paging[:chunk_size]).offset(paging[:offset])
+    changes = paging[:query]
 
     render json: {
       links: paging[:links],
-      meta: { total_results: paging[:total_items] },
+      meta: paging[:meta],
       data: changes.as_json(methods: :current_annotation)
     }
   end

--- a/app/controllers/api/v0/maintainers_controller.rb
+++ b/app/controllers/api/v0/maintainers_controller.rb
@@ -4,11 +4,11 @@ class Api::V0::MaintainersController < Api::V0::ApiController
   def index
     query = maintainer_collection
     paging = pagination(query)
-    maintainers = query.limit(paging[:chunk_size]).offset(paging[:offset])
+    maintainers = paging[:query]
 
     render json: {
       links: paging[:links],
-      meta: { total_results: paging[:total_items] },
+      meta: paging[:meta],
       data: maintainers
     }
   end

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -10,9 +10,10 @@ class Api::V0::PagesController < Api::V0::ApiController
     query = page_collection
     id_query = filter_maintainers_and_tags(query)
     paging = pagination(id_query)
-    id_query = id_query.limit(paging[:chunk_size]).offset(paging[:offset])
+    id_query = paging[:query]
 
     # NOTE: need to get :updated_at here because it's used for ordering
+    # We've already applied the actual sorting in page_collection.
     order_attributes =
       if sorting_params.present?
         sorting_params.collect {|sorting| sorting.keys.first}
@@ -88,7 +89,7 @@ class Api::V0::PagesController < Api::V0::ApiController
 
     render json: Oj.dump({
       links: paging[:links],
-      meta: { total_results: paging[:total_items] },
+      meta: paging[:meta],
       data: result_data
     }, mode: oj_mode)
   end

--- a/app/controllers/api/v0/tags_controller.rb
+++ b/app/controllers/api/v0/tags_controller.rb
@@ -4,11 +4,11 @@ class Api::V0::TagsController < Api::V0::ApiController
   def index
     query = tag_collection
     paging = pagination(query)
-    tags = query.limit(paging[:chunk_size]).offset(paging[:offset])
+    tags = paging[:query]
 
     render json: {
       links: paging[:links],
-      meta: { total_results: paging[:total_items] },
+      meta: paging[:meta],
       data: tags
     }
   end

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -4,11 +4,11 @@ class Api::V0::VersionsController < Api::V0::ApiController
   def index
     query = version_collection
     paging = pagination(query)
-    versions = query.limit(paging[:chunk_size]).offset(paging[:offset])
+    versions = paging[:query]
 
     render json: {
       links: paging[:links],
-      meta: { total_results: paging[:total_items] },
+      meta: paging[:meta],
       data: versions.collect {|version| serialize_version(version)}
     }
   end

--- a/test/controllers/api/v0/annotations_controller_test.rb
+++ b/test/controllers/api/v0/annotations_controller_test.rb
@@ -208,7 +208,7 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
     assert(body_json['data'].is_a?(Array), 'Data should be an array')
   end
 
-  test 'meta property should have a total_results field that contains total results across all chunks' do
+  test 'meta.total_results should be the total results across all chunks' do
     page = pages(:home_page)
     change_id = page.versions[0].uuid
 
@@ -229,7 +229,10 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
     )
     assert_response :success
 
-    get(api_v0_page_change_annotations_path(page, "..#{change_id}", params: { chunk_size: 1 }))
+    get(api_v0_page_change_annotations_path(page, "..#{change_id}", params: {
+      chunk_size: 1,
+      include_total: true
+    }))
 
     assert_response :success
     body_json = JSON.parse @response.body

--- a/test/controllers/api/v0/changes_controller_test.rb
+++ b/test/controllers/api/v0/changes_controller_test.rb
@@ -120,10 +120,10 @@ class Api::V0::ChangesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'meta property should have a total_results field that contains total results across all chunks' do
+  test 'meta.total_results should be the total results across all chunks' do
     sign_in users(:alice)
     page = pages(:home_page)
-    get(api_v0_page_changes_path(page))
+    get(api_v0_page_changes_path(page, params: { include_total: true }))
 
     assert_response :success
     assert_equal 'application/json', @response.content_type

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -409,9 +409,9 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'meta property should have a total_results field that contains total results across all chunks' do
+  test 'meta.total_results should be the total results across all chunks' do
     sign_in users(:alice)
-    get api_v0_pages_path
+    get api_v0_pages_path, params: { include_total: true }
     assert_response :success
     assert_equal 'application/json', @response.content_type
     body_json = JSON.parse @response.body
@@ -506,7 +506,6 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     get api_v0_pages_path(params: { tags: ['frequently updated'] })
     assert_response :success
     body = JSON.parse(@response.body)
-    assert_equal(2, body['meta']['total_results'])
     assert_equal(2, body['data'].length)
 
     sub_page = body['data'].find {|page| page['uuid'] == pages(:sub_page).uuid}
@@ -524,7 +523,10 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     pages(:home_page_site2).add_tag('home page')
 
     sign_in users(:alice)
-    get api_v0_pages_path(params: { tags: ['frequently updated', 'home page'] })
+    get api_v0_pages_path(params: {
+      tags: ['frequently updated', 'home page'],
+      include_total: true
+    })
     assert_response :success
     body = JSON.parse(@response.body)
     assert_equal(3, body['meta']['total_results'])
@@ -539,7 +541,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     pages(:home_page_site2).add_maintainer('Unicorn Department')
 
     sign_in users(:alice)
-    get api_v0_pages_path(params: { maintainers: ['Unicorn Department'] })
+    get api_v0_pages_path(params: { maintainers: ['Unicorn Department'], include_total: true })
     assert_response :success
     body = JSON.parse(@response.body)
     assert_equal(2, body['meta']['total_results'])
@@ -561,7 +563,8 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
 
     sign_in users(:alice)
     get api_v0_pages_path(params: {
-      maintainers: ['Unicorn Department', 'EPA']
+      maintainers: ['Unicorn Department', 'EPA'],
+      include_total: true
     })
     assert_response :success
     body = JSON.parse(@response.body)

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -210,11 +210,11 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test 'meta property should have a total_results field that contains total results across all chunks' do
+  test 'meta.total_results should be the total results across all chunks' do
     sign_in users(:alice)
     page = pages(:home_page)
 
-    get(api_v0_page_versions_url(page))
+    get(api_v0_page_versions_url(page, params: { include_total: true }))
     assert_response(:success)
     assert_equal('application/json', @response.content_type)
     body_json = JSON.parse(@response.body)


### PR DESCRIPTION
For large tables, counting the number of possible results (in order to determine the URL for the *last* chunk in a result set) turns out to be extremly expensive. (For example, in our production `versions` table, the main query takes < 20 milliseconds, but counting the totals takes 18,000 milliseconds.) Instead, only count the total results and only include the URL for the last chunk if a user explicitly requests it.

In the future, we might move to an entirely different paging structure (that's not offset-based). See #579 for more.

NOTE: we need to update and redeploy scripts that use the `meta.total_results` before merging and deploying this:

- [x] [IA healthcheck](https://github.com/edgi-govdata-archiving/web-monitoring-processing/blob/master/scripts/ia_healthcheck) in web-monitoring-processing
- [x] [Analyst task sheet generation](https://github.com/edgi-govdata-archiving/web-monitoring-versionista-scraper/blob/master/bin/query-db-and-email) in web-monitoring-versionista-scraper (edgi-govdata-archiving/web-monitoring-versionista-scraper#237)
- [x] Update documentation