### PR TITLE
Add CircleCI job to run seeds script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
           docker push envirodgi/db-status-update-job:$CIRCLE_SHA1
           docker push envirodgi/db-status-update-job:latest
 
+
 workflows:
   version: 2.1
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,6 @@ jobs:
           docker push envirodgi/db-status-update-job:$CIRCLE_SHA1
           docker push envirodgi/db-status-update-job:latest
 
-
 workflows:
   version: 2.1
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,14 @@
 version: 2.1
-jobs:
-  build:
+
+executors:
+  rails_executor:
     working_directory: ~/web-monitoring-db
     docker:
       - image: circleci/ruby:2.6.3-node
         environment:
-          BUNDLE_PATH: 'vendor/bundle'
           RAILS_ENV: test
           RACK_ENV: test
+          BUNDLE_PATH: vendor/bundle
           PGHOST: 127.0.0.1
           PGUSER: root
           HOST_URL: 'web-monitoring-db.test'
@@ -16,37 +17,58 @@ jobs:
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle-test_test
+
+commands:
+  setup_bundler:
+    description: "Set up Bundler dependencies"
     steps:
-      - checkout
+      - run:
+          name: Install bundler with appropriate version
+          command: gem install bundler -v $(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -1 | tr -d " ")
       - restore_cache:
           keys:
             - web-monitoring-db-{{ arch }}-{{ checksum "Gemfile.lock" }}
             - web-monitoring-db-{{ arch }}-
-
-      # Bundle install dependencies
-      - run:
-          name: Install Dependencies
-          command: |
-            gem install bundler
-            bundle install
-
-      # Store bundle cache
+      - run: bundle install --frozen && bundle clean
       - save_cache:
           key: web-monitoring-db-{{ arch }}-{{ checksum "Gemfile.lock" }}
           paths:
-            - vendor/bundle
-      # Database setup
+            - ~/.bundle
+            - ./vendor/bundle
+
+jobs:
+  install_dependencies:
+    executor: rails_executor
+    steps:
+      - checkout
+      - setup_bundler
+
+  build:
+    executor: rails_executor
+    steps:
+      - checkout
+      - setup_bundler
       - run:
-          name: Setup Database Setup
-          command: |
-            bundle exec rake db:create
-            bundle exec rake db:schema:load
+          name: Setup Database
+          command: bin/rails db:create db:schema:load
       - run:
           name: Tests
           command: bin/rails test:system test
       - run:
           name: Code linting
           command: bundle exec rubocop
+
+  test_seed:
+    executor: rails_executor
+    steps:
+      - checkout
+      - setup_bundler
+      - run:
+          name: Setup Database
+          command: bin/rails db:create db:schema:load
+      - run:
+          name: Test seeds setup
+          command: bin/rails db:seed
 
   publish_docker:
     machine: true
@@ -75,7 +97,19 @@ workflows:
   version: 2.1
   build:
     jobs:
+      - install_dependencies:
+          filters:
+            branches:
+              ignore: release
       - build:
+          requires:
+            - install_dependencies
+          filters:
+            branches:
+              ignore: release
+      - test_seed:
+          requires:
+            - install_dependencies
           filters:
             branches:
               ignore: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ commands:
           command: gem install bundler -v $(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -1 | tr -d " ")
       - restore_cache:
           keys:
-            - web-monitoring-db-{{ arch }}-{{ checksum "Gemfile.lock" }}
-            - web-monitoring-db-{{ arch }}-
+            - v1-bundler-{{ arch }}-{{ checksum "Gemfile.lock" }}
+            - v1-bundler-{{ arch }}-
       - run: bundle install --frozen && bundle clean
       - save_cache:
-          key: web-monitoring-db-{{ arch }}-{{ checksum "Gemfile.lock" }}
+          key: v1-bundler-{{ arch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - ~/.bundle
             - ./vendor/bundle

--- a/app/jobs/analyze_change_job.rb
+++ b/app/jobs/analyze_change_job.rb
@@ -51,6 +51,14 @@ class AnalyzeChangeJob < ApplicationJob
     '.zip'
   ].freeze
 
+  # Determine whether this job is supported with the current configuration
+  def self.supported?
+    ENV['AUTO_ANNOTATION_USER'].present? &&
+      Differ.for_type('html_text_dmp').present? &&
+      Differ.for_type('html_source_dmp').present? &&
+      Differ.for_type('links_json').present?
+  end
+
   def perform(to_version, from_version = nil, compare_earliest = true)
     # This is a very narrow-purpose prototype! Most of the work should probably
     # move to web-monitoring-processing.

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -31,6 +31,8 @@ class ImportVersionsJob < ApplicationJob
       rescue Redis::CannotConnectError => error
         Rails.logger.error "Import #{import.id}: Cannot queue AnalyzeChangeJob -- #{error.message}"
       end
+    else
+      Rails.logger.warn "Import #{import.id}: Auto-analysis requirements are not configured and AnalyzeChangeJobs were not scheduled for imported versions."
     end
   end
 

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -32,7 +32,7 @@ class ImportVersionsJob < ApplicationJob
         Rails.logger.error "Import #{import.id}: Cannot queue AnalyzeChangeJob -- #{error.message}"
       end
     else
-      Rails.logger.warn "Import #{import.id}: Auto-analysis requirements are not configured and AnalyzeChangeJobs were not scheduled for imported versions."
+      Rails.logger.warn "Import #{import.id}: Auto-analysis requirements are not configured; AnalyzeChangeJobs were not scheduled for imported versions."
     end
   end
 

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -102,7 +102,8 @@ class ImportVersionsJobTest < ActiveJob::TestCase
                    "[import=#{import.id}] Started Import #{import.id}",
                    "[import=#{import.id}][row=0] Found Page #{page.uuid}",
                    "[import=#{import.id}][row=0] Replaced Version #{versions(:page1_v5).uuid}",
-                   "[import=#{import.id}] Finished Import #{import.id}"
+                   "[import=#{import.id}] Finished Import #{import.id}",
+                   "Import #{import.id}: Auto-analysis requirements are not configured; AnalyzeChangeJobs were not scheduled for imported versions."
                  ], Rails.logger.logs, 'Logs are not as expected.')
   end
 


### PR DESCRIPTION
Closes #564.

Creates a CircleCI job, running in parallel to the `build` job that invokes the seeds script. Uses a few new CircleCI features of "executors" (reusable docker configuration block) and "commands" (reusable step blocks).