### PR TITLE
Ensure we get ALL versions in `copy_page` rake task

### DIFF
--- a/lib/tasks/copy_data.rake
+++ b/lib/tasks/copy_data.rake
@@ -4,6 +4,7 @@ task :copy_page, [:url, :username, :password, :page_uuid] => [:environment] do |
 
   page_count = 0
   version_count = 0
+  skipped_version_count = 0
 
   data = api_request("/api/v0/pages/#{args[:page_uuid]}", args)['data']
   page_data = data.clone
@@ -14,7 +15,7 @@ task :copy_page, [:url, :username, :password, :page_uuid] => [:environment] do |
     maintainers = page_data.delete('maintainers') || []
     tags = page_data.delete('tags') || []
 
-    page = Page.create(page_data)
+    page = Page.create!(page_data)
     maintainers.each {|maintainer| page.add_maintainer(maintainer['name'])}
     tags.each {|tag| page.add_tag(tag['name'])}
 
@@ -22,20 +23,34 @@ task :copy_page, [:url, :username, :password, :page_uuid] => [:environment] do |
     puts "Copied page #{page.uuid}" if verbose
   end
 
-  versions = api_request("/api/v0/pages/#{args[:page_uuid]}/versions", args)['data']
-  versions.each do |version_data|
-    next if Version.find_by(uuid: version_data['uuid'])
+  version_errors = []
+  api_paginated_request("/api/v0/pages/#{args[:page_uuid]}/versions?chunk_size=1000", args) do |version_data|
+    if Version.find_by(uuid: version_data['uuid'])
+      skipped_version_count += 1
+      next
+    end
 
-    page.versions.create(version_data)
-    version_count += 1
-    puts "  Copied version #{version_data['uuid']}" if verbose
+    version = page.versions.create(version_data)
+    if version.valid?
+      version_count += 1
+      puts "  Copied version #{version_data['uuid']}" if verbose
+    else
+      version_errors << version.uuid
+      puts "  Failed to copy version #{version_data['uuid']}:"
+      version.errors.full_messages.each { |error| puts "    #{error}" }
+    end
   end
 
   puts "Copied #{page_count} pages and #{version_count} versions from #{args[:url]}"
+  puts "Skipped #{skipped_version_count} pre-existing versions" unless skipped_version_count.zero?
+  unless version_errors.empty?
+    puts "Failed on #{version_errors.length} versions:"
+    version_errors.each { |uuid| puts "  #{uuid}" }
+  end
 end
 
 def api_request(path, options)
-  complete_url = "#{options[:url]}#{path}"
+  complete_url = /^https?:\/\//.match?(path) ? path : "#{options[:url]}#{path}"
   response = HTTParty.get(complete_url, basic_auth: {
     username: options[:username],
     password: options[:password]
@@ -49,5 +64,14 @@ def api_request(path, options)
     parsed
   rescue JSON::ParserError
     raise "Error parsing data: #{response.body}"
+  end
+end
+
+def api_paginated_request(path, options, &block)
+  next_url = path
+  while next_url.present?
+    chunk = api_request(next_url, options)
+    chunk['data'].each { |item| block.call(item) }
+    next_url = chunk['links']['next']
   end
 end


### PR DESCRIPTION
The important change here is that we now make sure to iterate through *all* the versions of a page and copy them in the `copy_page` rake task, instead of only copying the first 100 pages (i.e. the first “chunk”).

While I was at it, I added a few helpful features:

- Stop early if there was a validation failure adding the page.
- Log all failed versions and the validation errors that failed them (but don’t stop in the middle for these).
- Log how many versions were skipped because you already had them.
- Allow specifying login credentials for the remote API as environment variables instead of command-line arguments. The names are the same as the ones you’d use with the [Python API wrapper in the -processing project](https://github.com/edgi-govdata-archiving/web-monitoring-processing/blob/c469866253a40dd5ae11485d8d1c77905fa5eaba/web_monitoring/db.py#L139-L164):
    - `WEB_MONITORING_DB_URL`
    - `WEB_MONITORING_DB_EMAIL`
    - `WEB_MONITORING_DB_PASSWORD`

    This also works if you put these in the `.env` file. You can still specify them as arguments, but now they come *after* the page ID to copy.

Fixes #600.