### PR TITLE
Switched maintainer to label directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 ### BASE ENVIRONMENT STAGE ###
 FROM ruby:2.6.3-slim as base
-MAINTAINER enviroDGI@gmail.com
+LABEL maintainer="enviroDGI@gmail.com"
 
 # Install apt based dependencies required to run Rails as
 # well as RubyGems. As the Ruby image itself is based on a
@@ -32,7 +32,7 @@ COPY . ./
 
 ### IMPORT WORKER TARGET ###
 FROM base as import-worker
-MAINTAINER enviroDGI@gmail.com
+LABEL maintainer="enviroDGI@gmail.com"
 WORKDIR /app
 
 ENV QUEUES=import,analysis
@@ -43,7 +43,7 @@ CMD ["bundle", "exec", "rake", "environment", "resque:work"]
 
 ### RAILS SERVER TARGET ###
 FROM base as rails-server
-MAINTAINER enviroDGI@gmail.com
+LABEL maintainer="enviroDGI@gmail.com"
 WORKDIR /app
 
 # Expose port 3000 to the Docker host, so we can access it

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ This project wouldn’t exist without a lot of amazing people’s help. Thanks t
 | [💻](# "Code") | [Kasper Holbek Jensen](https://github.com/kholbekj) |
 | [💻](# "Code") | [Shishir Joshi](https://github.com/shishir127) |
 | [💻](# "Code") [📖](# "Documentation") | [Krzysztof Madejski](https://github.com/KrzysztofMadejski) |
+| [📖](# "Documentation") | [Ansar Memon (Amoury)](https://github.com/amoury) |
 | [📖](# "Documentation") [📋](# "Organizer") [📢](# "Talks") | [Matt Price](https://github.com/titaniumbones) |
 | [📋](# "Organizer") [🔍](# "Funding/Grant Finder") | [Toly Rinberg](https://github.com/trinberg) |
 | [💻](# "Code") | [Ben Sheldon](https://github.com/bensheldon) |


### PR DESCRIPTION
closes #583 

Since `MAINTAINER` instruction is deprecated, the directive has been switched to `LABEL` which is a more flexible version and is recommended as per docs.