### PR TITLE
Format errors as JSON in dev mode

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -37,10 +37,12 @@ class Api::V0::ApiController < ApplicationController
 
     render status: status_code, json: {
       errors: errors.collect do |error|
-        {
+        formatted = {
           status: status_code,
           title: message_for(error)
         }
+        formatted[:stack] = error.try(:backtrace) || [] if Rails.env.development?
+        formatted
       end
     }
   end


### PR DESCRIPTION
In dev mode, we used to show most errors with Rails’s standard error page, which gives you some nice debugging tools. However, that’s really not useful if you are testing a client against a local server. This change makes sure we format errors as JSON even in dev mode if the requester asks for JSON (either via the `Accept: application/json` header or the `.json` extension on a request).

This also adds stack traces to the error data in dev mode.

Fixes #614.

