### PR TITLE
Filter non-different captures in page queries

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -140,12 +140,19 @@ class Api::V0::PagesController < Api::V0::ApiController
       taggings: [:tag]
     )
 
-    collection = where_in_range_param(
-      collection,
-      :capture_time,
-      'versions.capture_time',
-      &method(:parse_date!)
-    )
+    if params.key?(:capture_time)
+      collection = where_in_range_param(
+        collection,
+        :capture_time,
+        'versions.capture_time',
+        &method(:parse_date!)
+      )
+
+      if boolean_param(:different, default: true)
+        collection = collection.where(versions: { different: true })
+      end
+    end
+
     collection = where_in_interval_param(collection, :status)
 
     version_params = params.permit(:hash, :source_type)

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -164,15 +164,34 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   test 'can filter pages by version capture_time' do
     sign_in users(:alice)
     get api_v0_pages_url(
-      capture_time: '2017-03-01T00:00:00Z..2017-03-01T12:00:00Z'
+      capture_time: '2017-03-04T00:00:00Z..'
     )
     body_json = JSON.parse @response.body
     ids = body_json['data'].pluck 'uuid'
 
     assert_includes ids, pages(:home_page).uuid,
-                    'Results did not include pages with versions captured in the filtered date range'
+                    'Results should include pages with versions captured in the filtered date range'
     assert_not_includes ids, pages(:home_page_site2).uuid,
-                        'Results included pages with versions not captured in the filtered date range'
+                        'Results should not include pages with no versions in the filtered date range'
+    assert_not_includes ids, pages(:sub_page).uuid,
+                        'Results should not include pages with non-different versions in the filtered date range'
+  end
+
+  test 'includes pages with non-different captures when using capture_time AND different=false' do
+    sign_in users(:alice)
+    get api_v0_pages_url(
+      capture_time: '2017-03-04T00:00:00Z..',
+      different: false
+    )
+    body_json = JSON.parse @response.body
+    ids = body_json['data'].pluck 'uuid'
+
+    assert_includes ids, pages(:home_page).uuid,
+                    'Results should include pages with versions captured in the filtered date range'
+    assert_not_includes ids, pages(:home_page_site2).uuid,
+                        'Results should not include pages with no versions in the filtered date range'
+    assert_includes ids, pages(:sub_page).uuid,
+                    'Results should include pages with non-different versions in the filtered date range'
   end
 
   test 'includes earliest version if include_earliest = true' do

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -128,6 +128,25 @@ page1_v4:
     version_id: 114
   }
 
+page2_v4:
+  page: sub_page
+  capture_time: '2017-03-04T00:00:00Z'
+  version_hash: 'vwx'
+  different: false
+  status: 200
+  source_type: 'versionista'
+  source_metadata: {
+    account: 'test@example.com',
+    site_id: 1,
+    page_id: 12,
+    version_id: 124,
+    page_url: 'http://versionista.com/1/12/',
+    diff_with_previous_url: 'http://versionista.com/1/12/124/',
+    diff_with_first_url: nil,
+    diff_length: 1234678,
+    diff_hash: 'vwx'
+  }
+
 page1_v5:
   page: home_page
   uri: https://test-bucket.s3.amazonaws.com/page1_v5.html


### PR DESCRIPTION
When querying pages by `capture_time`, we whould be disregarding versions a page might have that are non-different (they don't actually represent a different version from the previous because they have the same hash). You can opt back into the old behavior (including pages with non-different captures) by passing `?different=false` when querying. This matches how queries on the versions collection work.

Fixes #565.