### PR TITLE
HOTFIX: respect hashes in import records

### DIFF
--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -121,6 +121,7 @@ class ImportVersionsJob < ApplicationJob
     # is complete
     record['title'] = record['page_title'] if record.key?('page_title')
     record['capture_url'] = record['page_url'] if record.key?('page_url')
+    record['version_hash'] = record['hash'] if record.key?('hash')
     disallowed = ['id', 'uuid', 'created_at', 'updated_at']
     allowed = Version.attribute_names - disallowed
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,15 +30,14 @@ class ActiveSupport::TestCase
     assert_equal(sorted, list, "#{name} were not in ordered by: #{orderings}")
   end
 
-  def assert_any(list, operation, message = nil, description: nil)
-    message ||= "Expected #{list} to have an item that #{description}" if description.present?
+  def assert_any(list, predicate, message = nil)
+    message ||= "Expected #{list} to have a matching item"
     assert_respond_to(list, :any?)
-    assert(list.any? {|item| operation.call(item)}, message)
+    assert(list.any? {|item| predicate.call(item)}, message)
   end
 
   def assert_any_includes(list, value, message = nil)
-    description = message.nil? ? "includes '#{value}'" : nil
-    any_predicate = lambda { |item| item.include?(value) }
-    assert_any(list, any_predicate, message, description: description)
+    message ||= "Expected #{list} to have an item that includes '#{value}'"
+    assert_any(list, ->(item) { item.include?(value) }, message)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,4 +29,16 @@ class ActiveSupport::TestCase
 
     assert_equal(sorted, list, "#{name} were not in ordered by: #{orderings}")
   end
+
+  def assert_any(list, operation, message = nil, description: nil)
+    message ||= "Expected #{list} to have an item that #{description}" if description.present?
+    assert_respond_to(list, :any?)
+    assert(list.any? {|item| operation.call(item)}, message)
+  end
+
+  def assert_any_includes(list, value, message = nil)
+    description = message.nil? ? "includes '#{value}'" : nil
+    any_predicate = lambda { |item| item.include?(value) }
+    assert_any(list, any_predicate, message, description: description)
+  end
 end


### PR DESCRIPTION
The Internet Archive importer has been sending `hash` instead of `version_hash`, which means its hashes haven't been respected! Instead, we've been ignoring them and setting the hash to whatever we got when archiving the content at `uri`. :(