### PR TITLE
Update CircleCI to v2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     working_directory: ~/web-monitoring-db
@@ -69,7 +69,7 @@ jobs:
           docker push envirodgi/db-status-update-job:latest
 
 workflows:
-  version: 2
+  version: 2.1
   build:
     jobs:
       - build:


### PR DESCRIPTION
We actually already have all the v2.1 features turned on; this just updates our config file to declare v2.1.