### PR TITLE
Update CircleCI and Rubocop config files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: circleci/ruby:2.6.3-node
         environment:
+          BUNDLE_PATH: 'vendor/bundle'
           RAILS_ENV: test
           RACK_ENV: test
           PGHOST: 127.0.0.1
@@ -18,14 +19,16 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: web-monitoring-db-{{ arch }}-{{ checksum "Gemfile.lock" }}
+          keys:
+            - web-monitoring-db-{{ arch }}-{{ checksum "Gemfile.lock" }}
+            - web-monitoring-db-{{ arch }}-
 
       # Bundle install dependencies
       - run:
           name: Install Dependencies
           command: |
             gem install bundler
-            bundle install --path vendor/bundle
+            bundle install
 
       # Store bundle cache
       - save_cache:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,7 +34,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 95
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
-Metrics/LineLength:
+Layout/LineLength:
   Max: 335
 
 # Offense count: 28
@@ -83,8 +83,8 @@ Style/HashSyntax:
 # Cop supports --auto-correct.
 # Configuration parameters: MaxLineLength.
 Style/IfUnlessModifier:
-  # TURNING THIS OFF UNTIL WE GET Metrics/LineLength under control
-  Enabled: false
+  # TURNING THIS OFF UNTIL WE GET Layout/LineLength under control
+  Enabled: true
   Exclude:
     - 'app/controllers/concerns/paging_concern.rb'
     - 'app/controllers/pages_controller.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -84,7 +84,7 @@ Style/HashSyntax:
 # Configuration parameters: MaxLineLength.
 Style/IfUnlessModifier:
   # TURNING THIS OFF UNTIL WE GET Layout/LineLength under control
-  Enabled: true
+  Enabled: false
   Exclude:
     - 'app/controllers/concerns/paging_concern.rb'
     - 'app/controllers/pages_controller.rb'


### PR DESCRIPTION
Update config files for CircleCI and Rubocop:

- The Rubocop `Metrics/LineLength` cop was renamed to `Layout/LineLength`.
- The `--path` option for `bundle install` was deprecated. Use an environment variable instead.
- Add a fallback cache key for dependencies to speed things up.