### PR TITLE
Add `content_length` & `media_type` to Version

### DIFF
--- a/app/assets/data/swagger.yaml
+++ b/app/assets/data/swagger.yaml
@@ -1388,6 +1388,15 @@ definitions:
       version_hash:
         type: string
         description: A SHA-256 hash of the version’s raw content.
+      content_length:
+        type: integer
+        description: Number of bytes in the version's HTTP response body.
+      media_type:
+        type: string
+        description: The media type of the version, e.g. `text/html`.
+      media_type_parameters:
+        type: string
+        description: Parameters to the media type, e.g. `encoding=utf-8`.
       source_type:
         type: string
       source_metadata:
@@ -1916,6 +1925,15 @@ definitions:
       version_hash:
         type: string
         description: A hex-encoded SHA-256 hash of the response body of the version.
+      content_length:
+        type: integer
+        description: Number of bytes in the version's HTTP response body.
+      media_type:
+        type: string
+        description: The media type of the version, e.g. `text/html`.
+      media_type_parameters:
+        type: string
+        description: Parameters to the media type, e.g. `encoding=utf-8`.
       source_type:
         type: string
         description: An identifier for the source of this version data, e.g. `versionista`, `internet_archive`, etc.

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -100,7 +100,7 @@ class ImportVersionsJob < ApplicationJob
     elsif !Archiver.already_archived?(version.uri) || !version.version_hash
       result = Archiver.archive(version.uri, expected_hash: version.version_hash)
       version.version_hash = result[:hash]
-      version.length = result[:length]
+      version.content_length = result[:length]
       if result[:url] != version.uri
         version.source_metadata ||= {}
         version.source_metadata['original_url'] = version.uri
@@ -137,9 +137,9 @@ class ImportVersionsJob < ApplicationJob
       meta = record['source_metadata']
       record['media_type'] = meta['mime_type'] if meta.key?('mime_type')
       record['media_type_parameters'] = "charset=#{meta['encoding']}" if meta.key?('encoding')
-      unless record.key?('length')
+      unless record.key?('content_length')
         length = meta.dig('headers', 'Content-Length')
-        record['length'] = length if length.present?
+        record['content_length'] = length if length.present?
       end
     end
     disallowed = ['id', 'uuid', 'created_at', 'updated_at']

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -102,7 +102,7 @@ class ImportVersionsJob < ApplicationJob
       version.version_hash = result[:hash]
       version.length = result[:length]
       if result[:url] != version.uri
-        version.source_metadata = {} if version.source_metadata.nil?
+        version.source_metadata ||= {}
         version.source_metadata['original_url'] = version.uri
         version.uri = result[:url]
       end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -13,6 +13,16 @@ class Version < ApplicationRecord
   validates :status,
             allow_nil: true,
             inclusion: { in: 100...600, message: 'is not between 100 and 599' }
+  validates :media_type,
+            allow_nil: true,
+            format: {
+              with: /\A\w[\w!\#$&^_+\-.]+\/\w[\w!\#$&^_+\-.]+\z/,
+              message: 'must be a media type, like `text/plain`, and *not* ' \
+                       'include parameters, like `; charset=utf-8`'
+            }
+  validates :length,
+            allow_nil: true,
+            numericality: { greater_than_or_equal_to: 0 }
 
   def earliest
     self.page.versions.reorder(capture_time: :asc).first
@@ -76,6 +86,20 @@ class Version < ApplicationRecord
         end
       end
     end
+  end
+
+  def content_type
+    return nil unless self.media_type
+
+    value = self.media_type
+    value += "; #{self.media_type_parameters}" if self.media_type_parameters
+    value
+  end
+
+  def content_type=(value)
+    type_only, type_parameters = value.split(';', 2)
+    self.media_type = type_only
+    self.media_type_parameters = type_parameters.strip if type_parameters
   end
 
   private

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -20,7 +20,7 @@ class Version < ApplicationRecord
               message: 'must be a media type, like `text/plain`, and *not* ' \
                        'include parameters, like `; charset=utf-8`'
             }
-  validates :length,
+  validates :content_length,
             allow_nil: true,
             numericality: { greater_than_or_equal_to: 0 }
 

--- a/config/initializers/archiver.rb
+++ b/config/initializers/archiver.rb
@@ -19,7 +19,8 @@ if ENV['AWS_ARCHIVE_BUCKET']
     bucket: aws_bucket
   )
 elsif !Rails.env.production?
-  storage_path = Rails.root.join 'tmp/storage/archive'
+  directory = Rails.env.test? ? 'archive-test' : 'archive'
+  storage_path = Rails.root.join("tmp/storage/#{directory}")
   Archiver.store = FileStorage::LocalFile.new(path: storage_path)
 end
 

--- a/db/migrate/20200216215324_add_length_and_media_type_to_versions.rb
+++ b/db/migrate/20200216215324_add_length_and_media_type_to_versions.rb
@@ -1,0 +1,7 @@
+class AddLengthAndMediaTypeToVersions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :versions, :length, :integer, null: true
+    add_column :versions, :media_type, :string, null: true
+    add_column :versions, :media_type_parameters, :string, null: true
+  end
+end

--- a/db/migrate/20200216215324_add_length_and_media_type_to_versions.rb
+++ b/db/migrate/20200216215324_add_length_and_media_type_to_versions.rb
@@ -1,6 +1,6 @@
 class AddLengthAndMediaTypeToVersions < ActiveRecord::Migration[6.0]
   def change
-    add_column :versions, :length, :integer, null: true
+    add_column :versions, :content_length, :integer, null: true
     add_column :versions, :media_type, :string, null: true
     add_column :versions, :media_type_parameters, :string, null: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -151,7 +151,7 @@ ActiveRecord::Schema.define(version: 2020_02_16_215324) do
     t.string "capture_url"
     t.boolean "different", default: true
     t.integer "status"
-    t.integer "length"
+    t.integer "content_length"
     t.string "media_type"
     t.string "media_type_parameters"
     t.index ["capture_time"], name: "index_different_versions_on_capture_time", where: "(different = true)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_01_194241) do
+ActiveRecord::Schema.define(version: 2020_02_16_215324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -151,6 +151,9 @@ ActiveRecord::Schema.define(version: 2019_11_01_194241) do
     t.string "capture_url"
     t.boolean "different", default: true
     t.integer "status"
+    t.integer "length"
+    t.string "media_type"
+    t.string "media_type_parameters"
     t.index ["capture_time"], name: "index_different_versions_on_capture_time", where: "(different = true)"
     t.index ["capture_time"], name: "index_versions_on_capture_time"
     t.index ["created_at"], name: "index_different_versions_on_created_at", where: "(different = true)"

--- a/lib/archiver/archiver.rb
+++ b/lib/archiver/archiver.rb
@@ -37,7 +37,8 @@ module Archiver
     # If the hash is already in the store, there's no reason to load & verify.
     if expected_hash && !force
       hash_url = store.url_for_file(expected_hash)
-      return { url: hash_url, hash: expected_hash } if store.contains_url?(hash_url)
+      meta = store.get_metadata(hash_url)
+      return { url: hash_url, hash: expected_hash, length: meta[:size] } if meta
     end
 
     response = retry_request do
@@ -61,7 +62,7 @@ module Archiver
         store.url_for_file(hash)
       end
 
-    { url: url, hash: hash }
+    { url: url, hash: hash, length: response.body.bytes.length }
   end
 
   def self.already_archived?(url)

--- a/lib/file_storage/local_file.rb
+++ b/lib/file_storage/local_file.rb
@@ -17,7 +17,7 @@ module FileStorage
     end
 
     def get_metadata(path)
-      return get_metadata!(path)
+      get_metadata!(path)
     rescue Errno::ENOENT
       nil
     # FIXME: should have a more specific error class here; we could

--- a/lib/file_storage/local_file.rb
+++ b/lib/file_storage/local_file.rb
@@ -16,6 +16,25 @@ module FileStorage
       @directory ||= Dir.mktmpdir "web-monitoring-db--#{@tag}"
     end
 
+    def get_metadata(path)
+      return get_metadata!(path)
+    rescue Errno::ENOENT
+      nil
+    # FIXME: should have a more specific error class here; we could
+    # catch errors we don't want to.
+    rescue ArgumentError
+      nil
+    end
+
+    def get_metadata!(path)
+      data = File.stat(normalize_full_path(path))
+      {
+        last_modified: data.mtime,
+        size: data.size,
+        content_type: nil
+      }
+    end
+
     def get_file(path)
       File.read(normalize_full_path(path))
     end
@@ -33,12 +52,7 @@ module FileStorage
     end
 
     def contains_url?(url_string)
-      if url_string.starts_with? 'file://'
-        path = url_string[7..-1]
-        File.exist? path
-      else
-        false
-      end
+      get_metadata(url_string).present?
     end
 
     private

--- a/lib/file_storage/s3.rb
+++ b/lib/file_storage/s3.rb
@@ -18,7 +18,7 @@ module FileStorage
     end
 
     def get_metadata(path)
-      return get_metadata!(path)
+      get_metadata!(path)
     rescue Aws::S3::Errors::NotFound
       nil
     # FIXME: should have a more specific error class here; we could

--- a/lib/file_storage/s3.rb
+++ b/lib/file_storage/s3.rb
@@ -14,17 +14,27 @@ module FileStorage
     end
 
     def contains_url?(url_string)
-      # details = parse_s3_url(url_string)
-      # return false if details.nil? || details[:bucket] != @bucket
-      bucket_path = normalize_full_path(url_string)
+      get_metadata(url_string).present?
+    end
 
-      @client.head_object(bucket: @bucket, key: bucket_path).present?
+    def get_metadata(path)
+      return get_metadata!(path)
     rescue Aws::S3::Errors::NotFound
-      false
+      nil
     # FIXME: should have a more specific error class here; we could
     # catch errors we don't want to.
     rescue ArgumentError
-      false
+      nil
+    end
+
+    def get_metadata!(path)
+      bucket_path = normalize_full_path(path)
+      data = @client.head_object(bucket: @bucket, key: bucket_path)
+      {
+        last_modified: data.last_modified,
+        size: data.content_length,
+        content_type: data.content_type
+      }
     end
 
     def get_file(path)

--- a/lib/tasks/data/20200218_add_version_length_media_type.rake
+++ b/lib/tasks/data/20200218_add_version_length_media_type.rake
@@ -1,0 +1,59 @@
+namespace :data do
+  desc 'Set `length`, `media_type`, and `media_type_parameters` on all versions.'
+  task :'20200218_add_version_length_media_type', [:force] => [:environment] do |_t, args|
+    force = ['t', 'true', '1'].include? args.fetch(:force, '').downcase
+
+    ActiveRecord::Migration.say_with_time('Updating length and media_type on versions...') do
+      DataHelpers.with_activerecord_log_level(:error) do
+        last_update = Time.now
+        completed = 0
+        total = Version.all.count
+
+        DataHelpers.iterate_each(Version.all.order(created_at: :asc), batch_size: 500) do |version|
+          update_version_media_length(version, force: force)
+          completed += 1
+          if Time.now - last_update > 2
+            DataHelpers.log_progress(completed, total, description: 'versions updated')
+            last_update = Time.now
+          end
+        end
+
+        DataHelpers.log_progress(completed, total, end_line: true, description: 'versions updated')
+        completed
+      end
+    end
+  end
+
+  def update_version_media_length(version, force: false)
+    meta = version.source_metadata || {}
+    set_version_media(version, meta, force)
+    set_version_length(version, meta, force)
+    version.save if version.changed?
+  end
+
+  def set_version_media(version, meta, force)
+    return if version.media_type && !force
+
+    media = meta['media_type'] || meta['content_type'] || meta['mime_type']
+    encoding = meta['encoding']
+    if media
+      version.media_type = media
+      version.media_type_parameters = "charset=#{encoding}" if encoding
+    elsif meta['headers'].is_a?(Hash)
+      media = meta['headers']['content-type'] || meta['headers']['Content-Type']
+      version.content_type = media if media
+    end
+  end
+
+  def set_version_length(version, meta, force)
+    return if !version.uri || (version.length && !force)
+
+    stored_meta = Archiver.store.get_metadata(version.uri)
+    if stored_meta
+      version.length = stored_meta[:size]
+    elsif meta && meta['headers'].is_a?(Hash)
+      header_length = meta['headers']['content-length'] || meta['headers']['Content-Length']
+      version.length = header_length if header_length
+    end
+  end
+end

--- a/lib/tasks/data/20200218_add_version_length_media_type.rake
+++ b/lib/tasks/data/20200218_add_version_length_media_type.rake
@@ -1,9 +1,9 @@
 namespace :data do
-  desc 'Set `length`, `media_type`, and `media_type_parameters` on all versions.'
+  desc 'Set `content_length`, `media_type`, and `media_type_parameters` on all versions.'
   task :'20200218_add_version_length_media_type', [:force] => [:environment] do |_t, args|
     force = ['t', 'true', '1'].include? args.fetch(:force, '').downcase
 
-    ActiveRecord::Migration.say_with_time('Updating length and media_type on versions...') do
+    ActiveRecord::Migration.say_with_time('Updating content_length and media_type on versions...') do
       DataHelpers.with_activerecord_log_level(:error) do
         last_update = Time.now
         completed = 0
@@ -46,14 +46,14 @@ namespace :data do
   end
 
   def set_version_length(version, meta, force)
-    return if !version.uri || (version.length && !force)
+    return if !version.uri || (version.content_length && !force)
 
     stored_meta = Archiver.store.get_metadata(version.uri)
     if stored_meta
-      version.length = stored_meta[:size]
+      version.content_length = stored_meta[:size]
     elsif meta && meta['headers'].is_a?(Hash)
       header_length = meta['headers']['content-length'] || meta['headers']['Content-Length']
-      version.length = header_length if header_length
+      version.content_length = header_length if header_length
     end
   end
 end

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -258,7 +258,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
     assert_any_includes(import.processing_errors, 'hash')
   end
 
-  test 'gets length from archiver' do
+  test 'gets content_length from archiver' do
     page_versions_count = pages(:home_page).versions.count
     now = Time.now
     hash = 'fd9b8b0e5e12450cae7c43aba3209ffc54bf5cbcb4bcaf70287d9201c6845d1d'
@@ -292,7 +292,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
     assert_equal(page_versions_count + 2, pages(:home_page).versions.count)
 
     version_b, version_a = pages(:home_page).versions.order(created_at: :desc).limit(2)
-    assert_equal(10, version_a.length, 'the `length` property should match the body byte length')
-    assert_equal(10, version_b.length, 'the `length` property should match the body byte length when loaded from storage')
+    assert_equal(10, version_a.content_length, 'the `content_length` property should match the body byte length')
+    assert_equal(10, version_b.content_length, 'the `content_length` property should match the body byte length when loaded from storage')
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -80,12 +80,12 @@ class VersionTest < ActiveSupport::TestCase
     assert_equal('text/plain; charset=utf-8', version.content_type)
   end
 
-  test 'length cannot be negative' do
-    version = Version.new(page: Page.new, length: 10)
-    assert(version.valid?, 'A positive length should be valid')
+  test 'content_length cannot be negative' do
+    version = Version.new(page: Page.new, content_length: 10)
+    assert(version.valid?, 'A positive content_length should be valid')
 
-    version = Version.new(page: Page.new, length: -10)
-    assert_not(version.valid?, 'A negative length should not be valid')
-    assert_includes(version.errors, :length)
+    version = Version.new(page: Page.new, content_length: -10)
+    assert_not(version.valid?, 'A negative content_length should not be valid')
+    assert_includes(version.errors, :content_length)
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -60,4 +60,32 @@ class VersionTest < ActiveSupport::TestCase
     version.status = 'whats this now'
     assert_not(version.valid?, 'A text status was valid')
   end
+
+  test 'basic media types are valid' do
+    version = Version.new(page: Page.new, media_type: 'text/plain')
+    assert(version.valid?, 'A common media type should be valid')
+  end
+
+  test 'media_type cannot include parameters' do
+    version = Version.new(page: Page.new, media_type: 'text/plain; charset=utf-8')
+    assert_not(version.valid?, 'A media type with parameters should not be valid')
+    assert_includes(version.errors, :media_type)
+  end
+
+  test 'content_type getter/setter handles parameters' do
+    version = Version.new(page: Page.new)
+    version.content_type = 'text/plain; charset=utf-8'
+    assert_equal('text/plain', version.media_type)
+    assert_equal('charset=utf-8', version.media_type_parameters)
+    assert_equal('text/plain; charset=utf-8', version.content_type)
+  end
+
+  test 'length cannot be negative' do
+    version = Version.new(page: Page.new, length: 10)
+    assert(version.valid?, 'A positive length should be valid')
+
+    version = Version.new(page: Page.new, length: -10)
+    assert_not(version.valid?, 'A negative length should not be valid')
+    assert_includes(version.errors, :length)
+  end
 end


### PR DESCRIPTION
This also includes a third field, `media_type_parameters`, which holds things like `charset=utf-8` that get tacked onto the end of the media type.

There is also a `content_type` getter/setter that includes the parameters, and sets `media_type` and `media_type_parameters` appropriately.

Fixes #199.

To do:

- [x] Add fields to Version model
- [x] Set `length` and `media_type` during import
- [x] Add data migration to update all existing versions