### PR TITLE
Perf: avoid unnecessary joins in pagination

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -179,19 +179,15 @@ class Api::V0::PagesController < Api::V0::ApiController
   # we want actual output to include *all* the maintainers/tags on the pages
   # that were matched, not just the ones asked for.
   def filter_maintainers_and_tags(collection)
-    # NOTE: You *can't* use left_outer_joins here because ActiveRecord screws
-    # up and tries to join the tables *twice* in the query. I think this is
-    # probably because it is a has_and_belongs_to_many, but have not had time
-    # to break down exactly what is going wrong. `eager_load` works, though.
     if params[:maintainers].is_a?(Array)
       collection = collection
-        .eager_load(maintainerships: [:maintainer])
+        .left_outer_joins(maintainerships: [:maintainer])
         .where(maintainers: { name: params[:maintainers] })
     end
 
     if params[:tags].is_a?(Array)
       collection = collection
-        .eager_load(taggings: [:tag])
+        .left_outer_joins(taggings: [:tag])
         .where(tags: { name: params[:tags] })
     end
 

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -131,14 +131,6 @@ class Api::V0::PagesController < Api::V0::ApiController
 
     # TODO: remove agency and site here
     collection = Page.where(params.permit(:agency, :site, :title))
-    # NOTE: You *can't* use left_outer_joins here because ActiveRecord screws
-    # up and tries to join the tables *twice* in the query. I think this is
-    # probably because it is a has_and_belongs_to_many, but have not had time
-    # to break down exactly what is going wrong. In any case, `includes` works.
-    collection = collection.eager_load(
-      maintainerships: [:maintainer],
-      taggings: [:tag]
-    )
 
     if params.key?(:capture_time)
       collection = where_in_range_param(
@@ -187,12 +179,20 @@ class Api::V0::PagesController < Api::V0::ApiController
   # we want actual output to include *all* the maintainers/tags on the pages
   # that were matched, not just the ones asked for.
   def filter_maintainers_and_tags(collection)
+    # NOTE: You *can't* use left_outer_joins here because ActiveRecord screws
+    # up and tries to join the tables *twice* in the query. I think this is
+    # probably because it is a has_and_belongs_to_many, but have not had time
+    # to break down exactly what is going wrong. `eager_load` works, though.
     if params[:maintainers].is_a?(Array)
-      collection = collection.where(maintainers: { name: params[:maintainers] })
+      collection = collection
+        .eager_load(maintainerships: [:maintainer])
+        .where(maintainers: { name: params[:maintainers] })
     end
 
     if params[:tags].is_a?(Array)
-      collection = collection.where(tags: { name: params[:tags] })
+      collection = collection
+        .eager_load(taggings: [:tag])
+        .where(tags: { name: params[:tags] })
     end
 
     collection


### PR DESCRIPTION
It turns out we were issuing a really overcomplicated query when calculating pagination information for `Page` objects -- we'd join to maintainers and tags even if we didn't need to do any filtering on them, causing a two-step query for the relevant page IDs, rather than one. This two-step query has been KILLING our database in production.

This only joins to those tables if we are actually filtering on them. It should drastically increase performance in our most common cases and not affect others.

This also flips from `eager_load` to `left_outer_joins` for this case. The `left_outer_joins` call used to be problematic, but no longer is. I think that’s because of how we split up the logic when we finally fetch the actual results, but may also be due to improvements in ActiveRecord between versions 5 and 6. Either way, hooray! 🎉 