### PR TITLE
Remove hacky code to detect version media type

### DIFF
--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -40,7 +40,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
       upstream = Archiver.store.get_file(@version.uri)
 
       # Try to get the filetype, fall back on binary.
-      type = version_media_type(@version) || 'application/octet-stream'
+      type = version.media_type || 'application/octet-stream'
       # Set binary file disposition to attachment; anything else is inline.
       disposition = type == 'application/octet-stream' ? 'attachment' : 'inline'
 
@@ -48,20 +48,6 @@ class Api::V0::VersionsController < Api::V0::ApiController
     else
       raise Api::NotFoundError, "No raw content for #{@version.uuid}."
     end
-  end
-
-  def version_media_type(version)
-    # Media type logic mostly cribbed from
-    # web-monitoring-db/app/jobs/analyze_change_job.rb
-    # Lines 176 to 180 in 658ae8c
-    # TODO: this will eventually be a proper field on `version`:
-    # https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/199
-    meta = version.source_metadata || {}
-    media = meta['media_type'] || meta['content_type'] || meta['mime_type']
-    if !media && meta['headers'].is_a?(Hash)
-      media = meta['headers']['content-type'] || meta['headers']['Content-Type']
-    end
-    media
   end
 
   def create

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -40,7 +40,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
       upstream = Archiver.store.get_file(@version.uri)
 
       # Try to get the filetype, fall back on binary.
-      type = version.media_type || 'application/octet-stream'
+      type = @version.media_type || 'application/octet-stream'
       # Set binary file disposition to attachment; anything else is inline.
       disposition = type == 'application/octet-stream' ? 'attachment' : 'inline'
 

--- a/app/jobs/analyze_change_job.rb
+++ b/app/jobs/analyze_change_job.rb
@@ -185,16 +185,8 @@ class AnalyzeChangeJob < ApplicationJob
   end
 
   def diffable_media?(version)
-    # TODO: this will eventually be a proper field on `version`:
-    # https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/199
-    meta = version.source_metadata || {}
-    media = meta['media_type'] || meta['content_type'] || meta['mime_type']
-    if !media && meta['headers'].is_a?(Hash)
-      media = meta['headers']['content-type'] || meta['headers']['Content-Type']
-    end
-
+    media = version.media_type
     if media
-      media = media.split(';', 2)[0]
       ALLOWED_MEDIA.include?(media) || (
         media.start_with?('text/') && !DISALLOWED_MEDIA.include?(media)
       )


### PR DESCRIPTION
Now that versions actually have a real media type (see #669), we no longer need custom code to try and figure out a version’s media type. We can just ask for `version.media_type`.