### PR TITLE
Ensure media type & parameters are lower-case

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,7 @@ Metrics/ModuleLength:
   Enabled: false
 
 Metrics/ParameterLists:
+  CountKeywordArgs: false
   Exclude:
     - 'lib/versionista_service/*'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,6 @@ AllCops:
     - config/**/*
     - scratch*.rb
     - Gemfile
-    - lib/versionista_service/scraper.rb # This is likely going away anyhow
     # Don't attempt to lint third-party code
     - vendor/**/*
 
@@ -33,8 +32,6 @@ Metrics/ModuleLength:
 
 Metrics/ParameterLists:
   CountKeywordArgs: false
-  Exclude:
-    - 'lib/versionista_service/*'
 
 Metrics/CyclomaticComplexity:
   Max: 12

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,16 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-Lint/NestedMethodDefinition:
-  Exclude:
-    - 'lib/tasks/versionista.rake'
-
-# Offense count: 1
-Lint/ParenthesesAsGroupedExpression:
-  Exclude:
-    - 'lib/tasks/versionista.rake'
-
 # Offense count: 16
 Metrics/AbcSize:
   Max: 77
@@ -74,7 +64,6 @@ Style/HashSyntax:
   Exclude:
     - 'Gemfile'
     - 'app/models/invitation.rb'
-    - 'lib/tasks/versionista.rake'
 
 # Offense count: 18
 # Cop supports --auto-correct.
@@ -91,7 +80,6 @@ Style/IfUnlessModifier:
     - 'app/models/invitation.rb'
     - 'app/models/page.rb'
     - 'app/models/user.rb'
-    - 'lib/tasks/versionista.rake'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -101,19 +89,6 @@ Style/Lambda:
   Exclude:
     - 'app/controllers/concerns/paging_concern.rb'
     - 'app/controllers/pages_controller.rb'
-
-# Offense count: 1
-Style/MultilineBlockChain:
-  Exclude:
-    - 'lib/tasks/versionista.rake'
-
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: symmetrical, new_line, same_line
-Layout/MultilineMethodCallBraceLayout:
-  Exclude:
-    - 'lib/tasks/versionista.rake'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -138,13 +113,6 @@ Style/NegatedIf:
 Style/Next:
   Exclude:
     - 'db/migrate/20170314195641_populate_generic_models_from_versionista_models.rb'
-    - 'lib/tasks/versionista.rake'
-
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/RedundantBegin:
-  Exclude:
-    - 'lib/tasks/versionista.rake'
 
 # Offense count: 33
 # Cop supports --auto-correct.

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -61,8 +61,8 @@ class ImportVersionsJob < ApplicationJob
 
       # Jobs can be *long*, so make sure updates are persisted periodically.
       if Time.now - last_update > 5
-        @import.save
-        last_update = Time.now
+        @import.updated_at = last_update = Time.now
+        @import.save!
       end
     end
     log(object: @import, operation: :finished)

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -60,10 +60,13 @@ class ImportVersionsJob < ApplicationJob
       end
 
       # Jobs can be *long*, so make sure updates are persisted periodically.
-      if Time.now - last_update > 5
-        @import.updated_at = last_update = Time.now
-        @import.save!
-      end
+      next unless Time.now - last_update > 5
+
+      # save! will set updated_at, but only if something else has changed.
+      # Explicitly change updated_at so it always gets set, even if we don't
+      # have any other messages to persist.
+      @import.updated_at = last_update = Time.now
+      @import.save!
     end
     log(object: @import, operation: :finished)
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -103,7 +103,7 @@ class Version < ApplicationRecord
   end
 
   def media_type=(value)
-    value = value.downcase if value.present?
+    value = normalize_media_type(value) if value.present?
     super(value)
   end
 
@@ -121,14 +121,19 @@ class Version < ApplicationRecord
     end
   end
 
+  def normalize_media_type(text)
+    text.strip.downcase
+  end
+
   def parse_media_parameters(text)
     text
       .strip
       .split(/\s*;\s*/)
       .collect do |param|
         name, value = param.split('=', 2)
-        # Parameter names are case-insensitive, so always surface them as
-        # lower-case. Same for the value of `charset`.
+        # Parameter names are not case-sensitive, so always surface them as
+        # lower-case. Values *may be* case-sensitive, so don't touch them.
+        # (The value of `charset` is special and is always insensitive.)
         name = name.strip.downcase
         value = value.downcase if name == 'charset' && value.present?
         [name, value]

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -102,6 +102,16 @@ class Version < ApplicationRecord
     self.media_type_parameters = type_parameters.strip if type_parameters
   end
 
+  def media_type=(value)
+    value = value.downcase if value.present?
+    super(value)
+  end
+
+  def media_type_parameters=(value)
+    value = normalize_media_parameters(value) if value.present?
+    super(value)
+  end
+
   private
 
   def sync_page_title
@@ -109,5 +119,25 @@ class Version < ApplicationRecord
       most_recent_capture_time = page.latest.capture_time
       page.update(title: title) if most_recent_capture_time.nil? || most_recent_capture_time <= capture_time
     end
+  end
+
+  def parse_media_parameters(text)
+    text
+      .strip
+      .split(/\s*;\s*/)
+      .collect do |param|
+        name, value = param.split('=', 2)
+        # Parameter names are case-insensitive, so always surface them as
+        # lower-case. Same for the value of `charset`.
+        name = name.strip.downcase
+        value = value.downcase if name == 'charset' && value.present?
+        [name, value]
+      end
+  end
+
+  def normalize_media_parameters(text)
+    parse_media_parameters(text)
+      .collect {|name, value| "#{name}=#{value}"}
+      .join('; ')
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -72,6 +72,18 @@ class VersionTest < ActiveSupport::TestCase
     assert_includes(version.errors, :media_type)
   end
 
+  test 'media_type is always lower-case' do
+    version = Version.new
+    version.media_type = 'text/HTML'
+    assert_equal('text/html', version.media_type)
+  end
+
+  test 'media_type_parameters is set to a normalized form' do
+    version = Version.new
+    version.media_type_parameters = 'cHarSet=UTf-8;    param2=OK; Param3=ok'
+    assert_equal('charset=utf-8; param2=OK; param3=ok', version.media_type_parameters)
+  end
+
   test 'content_type getter/setter handles parameters' do
     version = Version.new(page: Page.new)
     version.content_type = 'text/plain; charset=utf-8'


### PR DESCRIPTION
Version media types and media type parameter names (and the `charset` parameter value) are always normalized as lower-case when set because they are not actually case-sensitive. This makes any code that needs to use them much simpler, since it doesn't have to handle variations in case or spacing.

Fixes #689.