### PR TITLE
Don't rewrite lines in progress logs on non-TTYs

### DIFF
--- a/app/lib/data_helpers.rb
+++ b/app/lib/data_helpers.rb
@@ -2,7 +2,11 @@
 module DataHelpers
   # Log and rewrite a progress indicator like "  x/y completed"
   def self.log_progress(completed, total, description: 'completed', end_line: false)
-    ending = end_line ? "\n" : ''
+    ending = if $stdout.isatty
+               end_line ? "\n" : ''
+             else
+               " (#{Time.now})\n"
+             end
     $stdout.write("\r   #{completed}/#{total} #{description}#{ending}")
   end
 

--- a/lib/tasks/data/20200218_add_version_length_media_type.rake
+++ b/lib/tasks/data/20200218_add_version_length_media_type.rake
@@ -10,6 +10,7 @@ namespace :data do
 
   def update_version_length_media_type(start_date, end_date = nil, force: false)
     end_date ||= start_date + 1.month
+    progress_interval = $stdout.isatty ? 2 : 10
 
     ActiveRecord::Migration.say_with_time('Updating content_length and media_type on versions...') do
       DataHelpers.with_activerecord_log_level(:error) do
@@ -26,7 +27,7 @@ namespace :data do
           changed = update_version_media_length(version, force: force)
           fixed += 1 if changed
           completed += 1
-          if Time.now - last_update > 2
+          if Time.now - last_update > progress_interval
             message = "#{fixed} updated, #{completed}"
             DataHelpers.log_progress(message, total, description: 'versions processed')
             last_update = Time.now


### PR DESCRIPTION
Without line endings, it's tough to stream logs (for example, we can't see the logs if we don't write line endings when running as a Kubernetes job). If running on a TTY, keep the friendly output that updates the line. On non-TTY interfaces, however, just write out the log as a line, and include a timestamp.