### PR TITLE
Remove `media_type_parameters`

### DIFF
--- a/app/assets/data/swagger.yaml
+++ b/app/assets/data/swagger.yaml
@@ -1384,9 +1384,6 @@ definitions:
       media_type:
         type: string
         description: The media type of the version, e.g. `text/html`.
-      media_type_parameters:
-        type: string
-        description: Parameters to the media type, e.g. `encoding=utf-8`.
       source_type:
         type: string
       source_metadata:
@@ -1917,9 +1914,6 @@ definitions:
       media_type:
         type: string
         description: The media type of the version, e.g. `text/html`.
-      media_type_parameters:
-        type: string
-        description: Parameters to the media type, e.g. `encoding=utf-8`.
       source_type:
         type: string
         description: An identifier for the source of this version data, e.g. `versionista`, `internet_archive`, etc.

--- a/app/jobs/analyze_change_job.rb
+++ b/app/jobs/analyze_change_job.rb
@@ -4,13 +4,8 @@ class AnalyzeChangeJob < ApplicationJob
   # text/* media types are allowed, so only non-text types need be explicitly
   # allowed and only text types need be explicitly disallowed.
   ALLOWED_MEDIA = [
-    # HTML should be text/html, but these are also common.
-    'appliction/html',
-    'application/xhtml',
-    'application/xhtml+xml',
-    'application/xml',
-    'application/xml+html',
-    'application/xml+xhtml'
+    'text/html',
+    'application/xhtml+xml'
   ].freeze
 
   DISALLOWED_MEDIA = [

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -139,7 +139,6 @@ class ImportVersionsJob < ApplicationJob
     if record.key?('source_metadata')
       meta = record['source_metadata']
       record['media_type'] = meta['mime_type'] if meta.key?('mime_type')
-      record['media_type_parameters'] = "charset=#{meta['encoding']}" if meta.key?('encoding')
       unless record.key?('content_length')
         length = meta.dig('headers', 'Content-Length')
         record['content_length'] = length if length.present?

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -2,7 +2,7 @@ class Version < ApplicationRecord
   include UuidPrimaryKey
   include SimpleTitle
 
-  MEDIA_TYPE_PATTERN = /\A\w[\w!\#$&^_+\-.]+\/\w[\w!\#$&^_+\-.]+\z/
+  MEDIA_TYPE_PATTERN = /\A\w[\w!\#$&^_+\-.]+\/\w[\w!\#$&^_+\-.]+\z/.freeze
 
   belongs_to :page, foreign_key: :page_uuid, required: true, inverse_of: :versions, touch: true
   has_many :tracked_changes, class_name: 'Change', foreign_key: 'uuid_to'

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -4,6 +4,39 @@ class Version < ApplicationRecord
 
   MEDIA_TYPE_PATTERN = /\A\w[\w!\#$&^_+\-.]+\/\w[\w!\#$&^_+\-.]+\z/.freeze
 
+  # Commonly used, but not quite correct media types.
+  MEDIA_TYPE_SYNONYMS = {
+    # HTML
+    'application/html' => 'text/html',
+    # XHTML (it would be nice to combine this with HTML most of the time, but alas, not always)
+    'application/xhtml' => 'application/xhtml+xml',
+    'application/xml+html' => 'application/xhtml+xml',
+    'application/xml+xhtml' => 'application/xhtml+xml',
+    'text/xhtml' => 'application/xhtml+xml',
+    'text/xhtml+xml' => 'application/xhtml+xml',
+    'text/xml+html' => 'application/xhtml+xml',
+    'text/xml+xhtml' => 'application/xhtml+xml',
+    # PDF
+    'application/x-pdf' => 'application/pdf',
+    # JS
+    'application/javascript' => 'text/javascript',
+    'application/x-javascript' => 'text/javascript',
+    'text/x-javascript' => 'text/javascript',
+    # JSON
+    'text/x-json' => 'application/json',
+    'text/json' => 'application/json',
+    # WOFF
+    'application/font-woff' => 'font/woff', # Used to be standard, now deprecated
+    'application/x-font-woff' => 'font/woff', # Used by Chrome pre-standardization
+    # JPEG
+    'image/jpg' => 'image/jpeg',
+    # MS Office
+    # https://docs.microsoft.com/en-us/previous-versions/office/office-2007-resource-kit/ee309278(v=office.12)
+    # This is the only mis-named one we've seen, and I'm wary of setting
+    # similar ones because they might override future legitimate types.
+    'application/xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  }.freeze
+
   belongs_to :page, foreign_key: :page_uuid, required: true, inverse_of: :versions, touch: true
   has_many :tracked_changes, class_name: 'Change', foreign_key: 'uuid_to'
   has_many :invalid_changes,
@@ -124,7 +157,8 @@ class Version < ApplicationRecord
   end
 
   def normalize_media_type(text)
-    text.strip.downcase
+    normal = text.strip.downcase
+    MEDIA_TYPE_SYNONYMS[normal] || normal
   end
 
   def parse_media_type(text)

--- a/db/migrate/20201112194523_remove_media_type_parameters_from_version.rb
+++ b/db/migrate/20201112194523_remove_media_type_parameters_from_version.rb
@@ -1,0 +1,5 @@
+class RemoveMediaTypeParametersFromVersion < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :versions, :media_type_parameters, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_11_182822) do
+ActiveRecord::Schema.define(version: 2020_11_12_194523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -150,7 +150,6 @@ ActiveRecord::Schema.define(version: 2020_11_11_182822) do
     t.integer "status"
     t.integer "content_length"
     t.string "media_type"
-    t.string "media_type_parameters"
     t.index ["capture_time"], name: "index_different_versions_on_capture_time", where: "(different = true)"
     t.index ["capture_time"], name: "index_versions_on_capture_time"
     t.index ["created_at"], name: "index_different_versions_on_created_at", where: "(different = true)"

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -296,7 +296,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
     assert_equal(10, version_b.content_length, 'the `content_length` property should match the body byte length when loaded from storage')
   end
 
-  test 'normalizes media_type and media_type_parameters' do
+  test 'normalizes media_type' do
     now = Time.now
     import = Import.create_with_data(
       {
@@ -308,8 +308,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
           capture_time: now - 1.second,
           uri: 'https://test-bucket.s3.amazonaws.com/whatever',
           version_hash: 'abc',
-          media_type: 'text/HTML',
-          media_type_parameters: 'cHarSet=UTf-8;    param2=OK; Param3=ok'
+          media_type: 'text/HTML'
         }
       ].map(&:to_json).join("\n")
     )
@@ -318,6 +317,5 @@ class ImportVersionsJobTest < ActiveJob::TestCase
 
     version = pages(:home_page).latest
     assert_equal('text/html', version.media_type)
-    assert_equal('charset=utf-8; param2=OK; param3=ok', version.media_type_parameters)
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -78,18 +78,15 @@ class VersionTest < ActiveSupport::TestCase
     assert_equal('text/html', version.media_type)
   end
 
-  test 'media_type_parameters is set to a normalized form' do
-    version = Version.new
-    version.media_type_parameters = 'cHarSet=UTf-8;    param2=OK; Param3=ok'
-    assert_equal('charset=utf-8; param2=OK; param3=ok', version.media_type_parameters)
-  end
-
-  test 'content_type getter/setter handles parameters' do
-    version = Version.new(page: Page.new)
-    version.content_type = 'text/plain; charset=utf-8'
+  test 'media_type is extracted from headers if not set' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      source_metadata: {
+        'headers' => { 'Content-Type' => 'text/plain; charset=utf-8' }
+      }
+    )
     assert_equal('text/plain', version.media_type)
-    assert_equal('charset=utf-8', version.media_type_parameters)
-    assert_equal('text/plain; charset=utf-8', version.content_type)
   end
 
   test 'content_length cannot be negative' do

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -78,6 +78,14 @@ class VersionTest < ActiveSupport::TestCase
     assert_equal('text/html', version.media_type)
   end
 
+  test 'media_type changes known synonyms to their canonical version' do
+    version = Version.new(media_type: 'application/html')
+    assert_equal('text/html', version.media_type)
+
+    version.media_type = 'application/xhtml'
+    assert_equal('application/xhtml+xml', version.media_type)
+  end
+
   test 'media_type is extracted from headers if not set' do
     version = Version.create(
       page: pages(:home_page),


### PR DESCRIPTION
This removes the `Version#media_type_parameters` field (it wasn’t useful) and changes the `Versions#media_type` field to a cleaned-up, normalized, canonicalized field (instead of just reflecting whatever the HTTP response’s `Content-Type` header had). This makes it dramatically more useful without removing canonical information stored elsewhere.

Fixes #752.