### PR TITLE
Improve the logging for `data:clean_media_types`

### DIFF
--- a/lib/tasks/data/clean_media_types.rake
+++ b/lib/tasks/data/clean_media_types.rake
@@ -2,18 +2,17 @@ namespace :data do
   desc 'Clean up the media_type field on Versions, remap non-canonical to canonical types.'
   task :clean_media_types, [] => [:environment] do
     ActiveRecord::Migration.say_with_time('Cleaning up media_type on versions...') do
-      total = 0
+      DataHelpers.with_activerecord_log_level(:error) do
+        total = 0
 
-      Version::MEDIA_TYPE_SYNONYMS.each do |bad_type, canonical_type|
-        fixed = Version.where(media_type: bad_type).update_all(media_type: canonical_type)
-
-        if fixed > 0
+        Version::MEDIA_TYPE_SYNONYMS.each do |bad_type, canonical_type|
+          fixed = Version.where(media_type: bad_type).update_all(media_type: canonical_type)
           puts "   #{fixed} versions changed media_type '#{bad_type}' to '#{canonical_type}'"
           total += fixed
         end
-      end
 
-      total
+        total
+      end
     end
   end
 end


### PR DESCRIPTION
Silence DB-level debug messages, and log each attempted change so you can see progress being made, regardless of whether any records wound up being changed.