### PR TITLE
Add `PageUrl` model to describe pages with multiple URLs

### DIFF
--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -164,11 +164,12 @@ class Api::V0::PagesController < Api::V0::ApiController
 
     if params[:url]
       query = params[:url]
+      collection = collection.joins(:urls)
       if query.include? '*'
         query = query.gsub('%', '\%').gsub('_', '\_').tr('*', '%')
-        collection = collection.where('url LIKE ?', query)
+        collection = collection.where('page_urls.url LIKE ?', query)
       else
-        collection = collection.where(url: query)
+        collection = collection.where('page_urls.url = ?', query)
       end
     end
 

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -71,7 +71,16 @@ class Api::V0::PagesController < Api::V0::ApiController
   end
 
   def show
-    page = Page.find(params[:id])
+    begin
+      page = Page.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      merge = MergedPage.find(params[:id])
+      redirect_to(
+        api_v0_page_url(merge.target_uuid),
+        status: :permanent_redirect
+      ) and return
+    end
+
     data = page.as_json(include: [:maintainers, :tags])
     if should_allow_versions
       data['versions'] = page.versions.where(different: true).as_json

--- a/app/controllers/api/v0/urls_controller.rb
+++ b/app/controllers/api/v0/urls_controller.rb
@@ -1,0 +1,76 @@
+class Api::V0::UrlsController < Api::V0::ApiController
+  def index
+    urls = page.urls.order('page_urls.to_time DESC')
+
+    render json: {
+      links: { page: api_v0_page_url(page) },
+      data: urls
+    }
+  end
+
+  def show
+    @page_url ||= page.urls.find(params[:id])
+    render json: {
+      links: {
+        page: api_v0_page_url(page),
+        page_urls: api_v0_page_urls_url(page)
+      },
+      data: @page_url
+    }
+  end
+
+  def create
+    @page_url = page.urls.create!(url_params)
+    show
+  rescue ActiveRecord::RecordNotUnique
+    raise Api::ResourceExistsError, 'This page already has the given URL and timeframe'
+  end
+
+  def update
+    updates = url_params
+    if updates.key?(:url)
+      raise Api::UnprocessableError, 'You cannot change a URL\'s `url`'
+    end
+
+    @page_url ||= page.urls.find(params[:id])
+    @page_url.update(url_params)
+    show
+  end
+
+  def destroy
+    @page_url ||= page.urls.find(params[:id])
+    # You cannot delete the canonical URL.
+    if @page_url.url == page.url
+      raise Api::UnprocessableError, 'You cannot remove the page\'s canonical URL'
+    else
+      @page_url.destroy
+      redirect_to(api_v0_page_urls_url(page))
+    end
+  end
+
+  protected
+
+  def page
+    @page ||= Page.find(params[:page_id])
+  end
+
+  def url_params
+    result = params
+      .require(:page_url)
+      .permit(:url, :from_time, :to_time, :notes)
+
+    result.slice('from_time', 'to_time').each do |key, value|
+      result[key] = parse_time(key, value)
+    end
+
+    result
+  end
+
+  def parse_time(field, time_input)
+    return if time_input.nil?
+
+    Time.parse(time_input)
+  rescue ArgumentError
+    raise Api::UnprocessableError, "`#{field}` was not a valid time or `null`"
+  end
+end

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -191,6 +191,20 @@ class ImportVersionsJob < ApplicationJob
     (record['page_maintainers'] || []).each {|name| page.add_maintainer(name)}
     (record['page_tags'] || []).each {|name| page.add_tag(name)}
 
+    # If the page was not an *exact* URL match, add the URL to the page.
+    # (`page.find_by_url` used above will match by `url_key`, too.)
+    page.urls.find_or_create_by(url: url)
+    # TODO: Add URLs from redirects automatically. The main blocker for
+    # this at the moment is the following situation:
+    #
+    #   Two pages, A=https://example.com/about
+    #              B=https://example.com/about/locations
+    #   Page B is removed, but instead of returning a 404 or 403 status
+    #     code, it starts redirecting to Page A.
+    #
+    # This is unfortunately not uncommon, so we need some heuristics to
+    # account for it, e.g. URL does not already belong to another page.
+
     page
   end
 

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -173,10 +173,13 @@ class ImportVersionsJob < ApplicationJob
     validate_kind!([String], record, 'page_url')
     validate_kind!([Array, NilClass], record, 'page_maintainers')
     validate_kind!([Array, NilClass], record, 'page_tags')
+    validate_present!(record, 'capture_time')
+    validate_kind!([String], record, 'capture_time')
 
     url = record['page_url']
 
-    existing_page = Page.find_by_url(url)
+    capture_time = Time.parse(record['capture_time'])
+    existing_page = Page.find_by_url(url, at_time: capture_time)
     page = if existing_page
              log(object: existing_page, operation: :found, row: row)
              existing_page

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -2,8 +2,8 @@ module Taggable
   extend ActiveSupport::Concern
 
   included do
-    has_many :taggings, as: :taggable, foreign_key: 'taggable_uuid'
-    has_many :tags, through: :taggings
+    has_many :taggings, as: :taggable, foreign_key: 'taggable_uuid', dependent: :delete_all
+    has_many :tags, through: :taggings, dependent: nil
   end
 
   def add_tag(tag)

--- a/app/models/merged_page.rb
+++ b/app/models/merged_page.rb
@@ -1,0 +1,14 @@
+# MergedPage keeps track of pages that were merged into others so we can
+# support old links by redirecting to the page they were merged into.
+# - The primary key is the ID of the page that was merged and removed
+# - `target_uuid` is the ID of the page it was merged into
+# - `audit_data` is any useful JSON data about the page (usually a frozen
+#   copy of its attributes).
+class MergedPage < ApplicationRecord
+  include UuidPrimaryKey
+
+  belongs_to :target,
+             class_name: 'Page',
+             foreign_key: :target_uuid,
+             required: true
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -84,7 +84,7 @@ class Page < ApplicationRecord
 
     with_urls = Page.includes(:urls).order('page_urls.to_time DESC')
     found = with_urls.find_by(page_urls: { url: url }) ||
-      with_urls.find_by(page_urls: { url_key: key })
+            with_urls.find_by(page_urls: { url_key: key })
     return found if found
 
     # TODO: remove this fallback when data is migrated over to Page.urls.

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -83,8 +83,12 @@ class Page < ApplicationRecord
     return found if found
 
     with_urls = Page.includes(:urls).order('page_urls.to_time DESC')
-    with_urls.find_by(page_urls: { url: url }) ||
+    found = with_urls.find_by(page_urls: { url: url }) ||
       with_urls.find_by(page_urls: { url_key: key })
+    return found if found
+
+    # TODO: remove this fallback when data is migrated over to Page.urls.
+    Page.find_by(url: url) || Page.find_by(url_key: key)
   end
 
   def self.normalize_url(url)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -224,13 +224,14 @@ class Page < ApplicationRecord
         # Delete the actual page record rather than keep it around so we don't
         # have to worry about messy partial indexes and querying around URLs.
         MergedPage.create!(uuid: other.uuid, target: self, audit_data: audit_data)
-        other.destroy!
-
         # If the page we're removing was previously a merge target, update
         # its references.
         MergedPage.where(target_uuid: other.uuid).update_all(target_uuid: self.uuid)
+        # And finally drop the merged page.
+        other.destroy!
 
-        Rails.logger.info("Merged page #{other.uuid} into #{uuid}. Old data: #{audit_data}")
+        audit_json = Oj.dump(audit_data, mode: :rails)
+        Rails.logger.info("Merged page #{other.uuid} into #{uuid}. Old data: #{audit_json}")
       end
 
       # Recalculate denormalized attributes

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -177,13 +177,13 @@ class Page < ApplicationRecord
   end
 
   def merge(*other_pages)
-    earliest_version_time = nil
+    first_version_time = nil
     other_pages.each do |other|
       # Move versions from other page.
       other.versions.each do |version|
         version.update(page_uuid: uuid)
-        if earliest_version_time.nil? || earliest_version_time > version.capture_time
-          earliest_version_time = version.capture_time
+        if first_version_time.nil? || first_version_time > version.capture_time
+          first_version_time = version.capture_time
         end
       end
 
@@ -191,34 +191,18 @@ class Page < ApplicationRecord
       other.tags.each {|tag| add_tag(tag)}
       other.maintainers.each {|maintainer| add_maintainer(maintainer)}
       other.urls.each do |page_url|
-        begin
-          page_url.update(page_uuid: self.uuid)
-        rescue ActiveRecord::RecordNotUnique
-          page_url.destroy
-        end
+        page_url.update(page_uuid: self.uuid)
+      rescue ActiveRecord::RecordNotUnique
+        page_url.destroy
       end
 
-      # TODO: flag `other` as merged into this one so we can support old links
+      # TODO: flag `other` as merged into this one so we can support old links.
       other.update(active: false)
     end
 
-    new_versions = self.versions.where('capture_time >= ?', earliest_version_time)
-
-    # Recalculate title
-    new_versions.reorder(capture_time: :desc).each do |version|
-      break if version.sync_page_title
-    end
-
-    # Recalculate page.versions.different
-    # TODO: figure out whether there's a reasonable way to merge this logic
-    # with `Version#update_different_attribute`.
-    previous_hash = nil
-    new_versions.reorder(capture_time: :asc).each do |version|
-      previous_hash = version.previous(different: false).try(:version_hash) if previous_hash.nil?
-      version.update(different: version.version_hash != previous_hash)
-      previous_hash = version.version_hash
-    end
-
+    # Recalculate denormalized attributes
+    update_page_title(first_version_time)
+    update_versions_different(first_version_time)
     # TODO: it might be neat to clean up overlapping URL timeframes
   end
 
@@ -285,5 +269,31 @@ class Page < ApplicationRecord
 
     success_rate = 1 - (error_time.to_f / total_time)
     success_rate < STATUS_SUCCESS_THRESHOLD ? latest_error : 200
+  end
+
+  def update_page_title(from_time = nil)
+    candidates = versions.reorder(capture_time: :desc)
+    candidates = candidates.where('capture_time >= ?', from_time) if from_time
+    candidates.each do |version|
+      break if version.sync_page_title
+    end
+  end
+
+  # TODO: figure out whether there's a reasonable way to merge this logic with
+  # `Version#update_different_attribute`.
+  def update_versions_different(from_time)
+    previous_hash = nil
+    candidates = versions
+      .where('capture_time >= ?', from_time)
+      .reorder(capture_time: :asc)
+
+    candidates.each do |version|
+      if previous_hash.nil?
+        previous_hash = version.previous(different: false).try(:version_hash)
+      end
+
+      version.update(different: version.version_hash != previous_hash)
+      previous_hash = version.version_hash
+    end
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -63,8 +63,9 @@ class Page < ApplicationRecord
   end)
 
   before_create :ensure_url_key
-  after_create :ensure_domain_and_news_tags, :ensure_page_urls
+  after_create :ensure_domain_and_news_tags
   before_save :normalize_url
+  after_save :ensure_page_urls
   validate :url_must_have_domain
   validates :status,
             allow_nil: true,
@@ -162,7 +163,7 @@ class Page < ApplicationRecord
   # canonical Url of the page, the true list of URLs associated with the page
   # should always be the list of PageUrls in Page#urls).
   def ensure_page_urls
-    urls.find_or_create_by(url: url)
+    urls.find_or_create_by(url: url) if saved_change_to_attribute?('url')
   end
 
   def update_status

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -341,9 +341,9 @@ class Page < ApplicationRecord
     end
 
     attributes.merge({
-      'tags' => tags.collect { |t| t.name },
-      'maintainers' => maintainers.collect { |m| m.name },
-      'versions' => versions.collect { |v| v.uuid },
+      'tags' => tags.collect(&:name),
+      'maintainers' => maintainers.collect(&:name),
+      'versions' => versions.collect(&:uuid),
       'urls' => urls_data
     })
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -17,6 +17,8 @@ class Page < ApplicationRecord
            foreign_key: 'page_uuid',
            inverse_of: :page,
            # You must explcitly dissociate or move versions before destroying.
+           # It's OK for a version to be orphaned from all pages, but we want
+           # to make sure that's an intentional action and not accidental.
            dependent: :restrict_with_error
   has_one :earliest,
           (lambda do

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -167,7 +167,7 @@ class Page < ApplicationRecord
   # canonical Url of the page, the true list of URLs associated with the page
   # should always be the list of PageUrls in Page#urls).
   def ensure_page_urls
-    urls.find_or_create_by(url: url) if saved_change_to_attribute?('url')
+    urls.find_or_create_by!(url: url) if saved_change_to_attribute?('url')
   end
 
   def update_status

--- a/app/models/page_url.rb
+++ b/app/models/page_url.rb
@@ -1,0 +1,71 @@
+# PageUrl is a critical part of each Page model. Pages do not represent a
+# single URL -- pages are often reachable from multiple URLs (sometimes at
+# the same time; sometimes because a page moves over time) and different
+# pages are sometimes reached from the same URL at different points in time.
+#
+# Pages have many PageUrls, each representing a single URL associated with
+# the page. They can also store timeframe information and analyst-supplied
+# notes (both are human-managed, anecdocal information that should not be
+# treated as mechanistic, measured, objective values -- for example, we can
+# never measure the true valid timeframe for a (page, URL) combination
+# because we only sample the responses from a web server on a regular basis
+# and cannot know exactly when a web server stopped responding to a given
+# URL -- without external information gathered by had, the best we can
+# technically say is "sometime between version x and version y").
+class PageUrl < ApplicationRecord
+  include UuidPrimaryKey
+
+  belongs_to :page, foreign_key: :page_uuid, required: true, inverse_of: :urls
+
+  # NOTE: consider switching to a tsrange instead of two columns for the
+  # timeframe here if Rails decides on a plan for:
+  #   https://github.com/rails/rails/issues/39833
+  # Then this can just be: `where('timeframe @> ?::timestamp', Time.now)`
+  scope(:current, lambda do
+    now = Time.now
+    where('from_time <= ?', now).where('to_time > ?', now)
+  end)
+
+  validates :url,
+            allow_nil: false,
+            format: {
+              # We have some valid URLs that URI.parse doesn't like, so use
+              # this looser, but workable regex for now.
+              # (Example: "https://www.fws.gov/letsgooutside/docs/kids/RRNatureNotebook_JuneJuly_11[1].pdf")
+              with: /\A(https?|ftp):\/\/([^\/@]+@)?([^\/]+\.[^\/]{2,})/,
+              message: 'must be a valid HTTP(S) or FTP URL with a host'
+            }
+  before_save :ensure_url_key
+
+  def self.create_url_key(url)
+    Surt.surt(url)
+  end
+
+  def url=(value)
+    # Reset url_key to ensure it gets recalculated
+    self.url_key = nil if value != url
+    super(value)
+  end
+
+  # To simplify query logic, we want to make sure `from_time` and `to_time`
+  # always have a value. Unfortunately, Rails doesn't deal too well with
+  # Postgres's +/-infinity dates. You can only set them as a string (not a
+  # float) even though they read back as +/-Float::INFINITY!
+  # These custom setters let us set floats for sanity, and also converts
+  # `nil` to +/-infinity as appropriate, since they have the same meaning as
+  # far as we're concerned.
+  def from_time=(value)
+    value = '-infinity' if value.nil? || value == -Float::INFINITY
+    super(value)
+  end
+
+  # See note above on `from_time=()`.
+  def to_time=(value)
+    value = 'infinity' if value.nil? || value == Float::INFINITY
+    super(value)
+  end
+
+  def ensure_url_key
+    self.url_key ||= PageUrl.create_url_key(url)
+  end
+end

--- a/app/models/page_url.rb
+++ b/app/models/page_url.rb
@@ -55,20 +55,23 @@ class PageUrl < ApplicationRecord
   end
 
   # To simplify query logic, we want to make sure `from_time` and `to_time`
-  # always have a value. Unfortunately, Rails doesn't deal too well with
-  # Postgres's +/-infinity dates. You can only set them as a string (not a
-  # float) even though they read back as +/-Float::INFINITY!
-  # These custom setters let us set floats for sanity, and also converts
-  # `nil` to +/-infinity as appropriate, since they have the same meaning as
-  # far as we're concerned.
+  # always have a value. Convert `nil` to the appropriate +/-infinity value
+  # here as a convenience.
+  #
+  # NOTE: Rails has a bug with setting +/-Float::INFINITY for timestamp
+  # fields, even though that's the type of value it gives you when it reads
+  # +/-infinity dates out of the database. ¯\_(ツ)_/¯
+  # However, a hacky fix we've implemented to solve another bug also solves
+  # this, so we can safely use Float::INFINITY in this project.
+  # See `config/initializers/active_record_extras.rb` for more.
   def from_time=(value)
-    value = '-infinity' if value.nil? || value == -Float::INFINITY
+    value = -Float::INFINITY if value.nil?
     super(value)
   end
 
   # See note above on `from_time=()`.
   def to_time=(value)
-    value = 'infinity' if value.nil? || value == Float::INFINITY
+    value = Float::INFINITY if value.nil?
     super(value)
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -65,17 +65,15 @@ class Version < ApplicationRecord
   end
 
   def previous(different: true)
-    self.page.versions
-      .where('capture_time < ?', self.capture_time)
-      .where(different: different)
-      .first
+    query = self.page.versions.where('capture_time < ?', self.capture_time)
+    query = query.where(different: true) if different
+    query.first
   end
 
   def next(different: true)
-    self.page.versions
-      .where('capture_time > ?', self.capture_time)
-      .where(different: different)
-      .last
+    query = self.page.versions.where('capture_time > ?', self.capture_time)
+    query = query.where(different: true) if different
+    query.last
   end
 
   def change_from_previous(different: true)
@@ -105,21 +103,24 @@ class Version < ApplicationRecord
   def update_different_attribute(save: true)
     previous = self.previous
     self.different = previous.nil? || previous.version_hash != version_hash
-    self.save if save
+    self.save! if save
 
-    if self.different?
-      following = page.versions
-        .where('capture_time > ?', self.capture_time)
-        .reorder(capture_time: :asc)
+    # NOTE: it would be nice to stop early here if we didn't make any changes,
+    # but `different` defaults to `true` so if we just inserted this version
+    # and it was different, we won't have "changed" the attribute, even though
+    # we still need to update the next (because this was inserted before it).
+    last_hash = version_hash
+    following = page.versions
+      .where('capture_time > ?', self.capture_time)
+      .reorder(capture_time: :asc)
 
-      following.each do |next_version|
-        new_different = version_hash != next_version.version_hash
-        if next_version.different? == new_different
-          break
-        else
-          next_version.different = new_different
-          next_version.save!
-        end
+    following.each do |next_version|
+      new_different = last_hash != next_version.version_hash
+      if next_version.different? == new_different
+        break
+      else
+        next_version.update!(different: new_different)
+        last_hash = next_version.version_hash
       end
     end
   end
@@ -147,14 +148,19 @@ class Version < ApplicationRecord
     self.media_type = media if media
   end
 
-  private
-
   def sync_page_title
     if title.present?
       most_recent_capture_time = page.latest.capture_time
-      page.update(title: title) if most_recent_capture_time.nil? || most_recent_capture_time <= capture_time
+      if most_recent_capture_time.nil? || most_recent_capture_time <= capture_time
+        page.update(title: title)
+        return title
+      end
     end
+
+    nil
   end
+
+  private
 
   def normalize_media_type(text)
     normal = text.strip.downcase

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -37,7 +37,9 @@ class Version < ApplicationRecord
     'application/xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
   }.freeze
 
-  belongs_to :page, foreign_key: :page_uuid, required: true, inverse_of: :versions, touch: true
+  # NOTE: Versions *may* be orphaned from pages. This is pretty rare, but is a
+  # legitimate scenario.
+  belongs_to :page, foreign_key: :page_uuid, optional: true, inverse_of: :versions, touch: true
   has_many :tracked_changes, class_name: 'Change', foreign_key: 'uuid_to'
   has_many :invalid_changes,
            ->(version) { where.not(uuid_from: version.previous.uuid) },

--- a/config/initializers/active_record_extras.rb
+++ b/config/initializers/active_record_extras.rb
@@ -1,0 +1,22 @@
+# DateTime types do not serialize the values for +/-infinity
+# correctly for `schema.rb`. This hack gives us a functional
+# schema.rb file.
+# See also:
+#   https://github.com/rails/rails/issues/40751
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class DateTime < Type::DateTime
+          def type_cast_for_schema(value)
+            case value
+              when ::Float::INFINITY then '::Float::INFINITY'
+              when -::Float::INFINITY then '-::Float::INFINITY'
+              else super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/active_record_extras.rb
+++ b/config/initializers/active_record_extras.rb
@@ -15,6 +15,15 @@ module ActiveRecord
               else super
             end
           end
+
+          # Convert from input to Ruby value
+          def serialize(value)
+            case value
+              when ::Float::INFINITY then "'infinity'::timestamp"
+              when -::Float::INFINITY then "'-infinity'::timestamp"
+              else super
+            end
+          end
         end
       end
     end

--- a/config/initializers/active_record_extras.rb
+++ b/config/initializers/active_record_extras.rb
@@ -1,13 +1,14 @@
-# DateTime types do not serialize the values for +/-infinity
-# correctly for `schema.rb`. This hack gives us a functional
-# schema.rb file.
-# See also:
-#   https://github.com/rails/rails/issues/40751
+# Hacks to fix ActiveRecord bugs.
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID
         class DateTime < Type::DateTime
+          # DateTime types do not serialize the values for +/-infinity
+          # correctly for `schema.rb`. This hack gives us a functional
+          # schema.rb file.
+          # See also:
+          #   https://github.com/rails/rails/issues/40751
           def type_cast_for_schema(value)
             case value
               when ::Float::INFINITY then '::Float::INFINITY'
@@ -15,14 +16,80 @@ module ActiveRecord
               else super
             end
           end
+        end
+      end
+    end
+  end
 
-          # Convert from input to Ruby value
-          def serialize(value)
-            case value
-              when ::Float::INFINITY then "'infinity'::timestamp"
-              when -::Float::INFINITY then "'-infinity'::timestamp"
-              else super
-            end
+  module AttributeMethods
+    module TimeZoneConversion
+      class TimeZoneConverter
+        # This fixes an issue where ActiveRecord screws up and incorrectly
+        # dirties a model with +/-Float::INFINITY when trying to mediate
+        # between an in-memory copy of the data and fresh info from the
+        # database. There are a variety of situations where this happens,
+        # but one simple one is calling `collection.to_a`, e.g:
+        #
+        #     # page.urls is a :has_many collection of records where
+        #     # :from_time defaults to -infinity.
+        #     some_url = page.urls.create(url: 'https://example.gov/')
+        #     some_url.from_time
+        #     => -Infinity  # GOOD
+        #     page.urls.to_a
+        #     some_url.from_time
+        #     => nil   # WTF
+        #     some_url.changed?
+        #     => true  # WTF
+        #
+        # What is happening here, you ask? WELL. `page.urls.to_a` is one of a
+        # variety of things that might cause ActiveRecord to go fetch some
+        # info from the database (in this case, I think because it can't be
+        # sure its in-memory version of page.urls has all the data). It also
+        # knows it has some cached in-memory data in the collection, too
+        # (that's `some_url` in the example above). So it tries to merge the
+        # data from the DB into any matching in-memory records (very cool!).
+        #   See: `ActiveRecord::Associations::CollectionAssociation#merge_target_lists`
+        #   https://github.com/rails/rails/blob/v6.0.3.4/activerecord/lib/active_record/associations/collection_association.rb#L305-L333)
+        #
+        # Ultimately, the values have to go through `Type#cast` in
+        # ActiveRecord/ActiveModel before they can be compared.
+        #   See: `ActiveModel::Attribute::FromUser`
+        #   https://github.com/rails/rails/blob/v6.0.3.4/activemodel/lib/active_model/attribute.rb#L173-L181
+        #
+        # The rest of the ActiveRecord/Postgres machinery happily deserializes
+        # `'-infinity'` from the database to `-Float::INFINITY`, and so we are
+        # at this point calling `DateTime.cast(-Float::INFINITY)`. That method
+        # is overridden by:
+        #   `ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter#cast`
+        # here, which pessimistically returns `nil` if you hand it anything
+        # other than a Hash or something that responds to :in_time_zone (e.g.
+        # a Time or a String). We override it here to handle Float::INFINITY.
+        #
+        # NOTE: this is really just another effect of this issue:
+        #   https://github.com/rails/rails/issues/40595
+        # which covers the inability to set `Float::INFINITY` as a value.
+        # The same logic that is breaking there is the cause of this issue.
+        #
+        # It's worth noting that normal Time casting logic in
+        #   ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime#cast_value
+        # will return values it it doesn't know how to handle (like
+        # `Float::INFINITY`) unchanged, while the decorated version you get
+        # with `TimeZoneConversion` does the opposite -- if it gets something
+        # it doesn't recognize, it will convert the value to `nil`.
+        #
+        # This problematic behavior is turned on by setting:
+        #   config.active_record.time_zone_aware_attributes = true
+        # which we don't explicitly do, but it gets turned on anyway. I'm a
+        # little leery of causing some new bugs by modifying that setting
+        # right now, so this hack feels like a better solution (it's still a
+        # bug that the setting breaks things) than the easy workaround of
+        # changing that setting to false, at least for now.
+        alias :_cast :cast
+        def cast(value)
+          case value
+            when ::Float::INFINITY then ::Float::INFINITY
+            when -::Float::INFINITY then -::Float::INFINITY
+            else _cast(value)
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
         end
         resources :maintainers, except: [:new, :edit], format: :json
         resources :tags, except: [:new, :edit], format: :json
+        resources :urls
       end
 
       resources :versions, only: [:index, :show], format: :json do
@@ -47,6 +48,6 @@ Rails.application.routes.draw do
   post 'admin/cancel_invitation'
   delete 'admin/destroy_user'
   post 'admin/destroy_user'
-  
+
   get 'healthcheck', to: 'healthcheck#index'
 end

--- a/db/migrate/20201116224426_add_page_url_model.rb
+++ b/db/migrate/20201116224426_add_page_url_model.rb
@@ -1,0 +1,47 @@
+class AddPageUrlModel < ActiveRecord::Migration[6.0]
+  def change
+    create_table :page_urls, id: false do |t|
+      t.primary_key :uuid, :uuid
+      # No way to use `belongs_to/references` to make a column named `*_uuid`
+      t.uuid :page_uuid, null: false
+      t.string :url, null: false
+      t.string :url_key, null: false
+
+      # NOTE: The `tsrange` type would be much more suitable here, BUT Rails
+      # handles it poorly, especially when it comes to ranges where there are
+      # no bounds or the bounds are +/-infinity (which is our most common
+      # case). For details, see:
+      #   - https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/492#issuecomment-738523165
+      #   - https://github.com/rails/rails/issues/39833
+      #   ex: `t.tsrange :timeframe, null: false, default: '[-infinity,infinity]'`
+      #
+      # We don't allow these to be null and instead use +/-infinity to keep
+      # queries straightforward. Note this also impacts indexing: Postgres
+      # index ignore NULL values, so using +/-infinity here helps make sure
+      # all rows are indexed and *ensured to be unique*.
+      t.datetime :from_time, null: false, default: '-infinity'
+      t.datetime :to_time, null: false, default: 'infinity'
+
+      t.string :notes
+      t.timestamps
+
+      t.foreign_key :pages, column: :page_uuid, primary_key: 'uuid'
+      t.index :url
+      t.index :url_key
+      # NOTE: this index depends on from_time/to_time not being nullable.
+      # If we ever make them nullable, the index will need to use:
+      #   `coalesce(from_time, '-infinity'::timestamp)`
+      # Because otherwise Postgres will ignore NULLs in the index.
+      # NOTE: the unique index helps make sure we don't make really
+      # bone-headed mistakes, but it does not prevent us from creating
+      # problematic, overlapping timeframes.
+      #   - Constraining this at the DB level is hard without using tsrange,
+      #     and tsrange has issues in Rails (see above).
+      #   - The timeframe values are really more of a guess, and could change
+      #     if/when we pull in versions that were missed, or new data from
+      #     another archival source, so making serious guarantees about
+      #     overlapping timeframes may not be reasonable or feasible anyway.
+      t.index [:page_uuid, :url, :from_time, :to_time], unique: true
+    end
+  end
+end

--- a/db/migrate/20201116224426_add_page_url_model.rb
+++ b/db/migrate/20201116224426_add_page_url_model.rb
@@ -45,6 +45,18 @@ class AddPageUrlModel < ActiveRecord::Migration[6.0]
       t.index [:page_uuid, :url, :from_time, :to_time], unique: true
     end
 
+    # Stores information about pages that have been merged into others so we
+    # can support old links by redirecting the new page.
+    create_table :merged_pages, id: false do |t|
+      t.primary_key :uuid, :uuid
+      t.uuid :target_uuid, null: false
+      t.jsonb :audit_data
+
+      # Needed for reverse lookups to update references if a page that was
+      # previously merged into is itself later merged into another page.
+      t.index :target_uuid
+    end
+
     # As part of this, we anticipate orphaning some version records. That's
     # OK -- we've been slowly loosening the conceptual model from Pages-with-
     # -Versions-of-those-pages to Versions-are-records-of-urls-at-a-point-in-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,6 +84,12 @@ ActiveRecord::Schema.define(version: 2020_11_16_224426) do
     t.index ["page_uuid"], name: "index_maintainerships_on_page_uuid"
   end
 
+  create_table "merged_pages", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "target_uuid", null: false
+    t.jsonb "audit_data"
+    t.index ["target_uuid"], name: "index_merged_pages_on_target_uuid"
+  end
+
   create_table "page_urls", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "page_uuid", null: false
     t.string "url", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -150,7 +150,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_224426) do
   end
 
   create_table "versions", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "page_uuid", null: false
+    t.uuid "page_uuid"
     t.datetime "capture_time", null: false
     t.string "uri"
     t.string "version_hash"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_194523) do
+ActiveRecord::Schema.define(version: 2020_11_16_224426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -82,6 +82,20 @@ ActiveRecord::Schema.define(version: 2020_11_12_194523) do
     t.index ["maintainer_uuid", "page_uuid"], name: "index_maintainerships_on_maintainer_uuid_and_page_uuid", unique: true
     t.index ["maintainer_uuid"], name: "index_maintainerships_on_maintainer_uuid"
     t.index ["page_uuid"], name: "index_maintainerships_on_page_uuid"
+  end
+
+  create_table "page_urls", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "page_uuid", null: false
+    t.string "url", null: false
+    t.string "url_key", null: false
+    t.datetime "from_time", default: -::Float::INFINITY, null: false
+    t.datetime "to_time", default: ::Float::INFINITY, null: false
+    t.string "notes"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["page_uuid", "url", "from_time", "to_time"], name: "index_page_urls_on_page_uuid_and_url_and_from_time_and_to_time", unique: true
+    t.index ["url"], name: "index_page_urls_on_url"
+    t.index ["url_key"], name: "index_page_urls_on_url_key"
   end
 
   create_table "pages", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -167,6 +181,7 @@ ActiveRecord::Schema.define(version: 2020_11_12_194523) do
   add_foreign_key "invitations", "users", column: "redeemer_id"
   add_foreign_key "maintainerships", "maintainers", column: "maintainer_uuid", primary_key: "uuid"
   add_foreign_key "maintainerships", "pages", column: "page_uuid", primary_key: "uuid"
+  add_foreign_key "page_urls", "pages", column: "page_uuid", primary_key: "uuid"
   add_foreign_key "taggings", "tags", column: "tag_uuid", primary_key: "uuid"
   add_foreign_key "versions", "pages", column: "page_uuid", primary_key: "uuid"
 end

--- a/lib/tasks/data/20201116_add_page_urls.rake
+++ b/lib/tasks/data/20201116_add_page_urls.rake
@@ -1,0 +1,25 @@
+namespace :data do
+  desc 'Add default PageUrls to all pages.'
+  task :'20201116_add_page_urls', [] => [:environment] do
+    ActiveRecord::Migration.say_with_time('Adding page.urls records for existing pages...') do
+      DataHelpers.with_activerecord_log_level(:error) do
+        last_update = Time.now - 1.minute
+        expected = Page.all.count
+        total = 0
+
+        DataHelpers.iterate_each(Page.all.order(created_at: :asc)) do |page|
+          page.urls.find_or_create_by(url: page.url)
+          total += 1
+
+          if Time.now - last_update >= 2
+            DataHelpers.log_progress(total, expected)
+            last_update = Time.now
+          end
+        end
+
+        DataHelpers.log_progress(total, expected)
+        total
+      end
+    end
+  end
+end

--- a/lib/tasks/merge_pages.rake
+++ b/lib/tasks/merge_pages.rake
@@ -1,0 +1,10 @@
+desc 'Merge multiple pages together. Pages will be merged *into* the first listed.'
+task :merge_pages, [] => :environment do |_t, args|
+  DataHelpers.with_activerecord_log_level(:error) do
+    pages = Page.where(uuid: args.extras)
+    base, *removals = pages
+
+    puts "Merging #{removals.length} other pages into #{base.uuid}..."
+    base.merge(*removals)
+  end
+end

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -744,4 +744,15 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(@response.body)
     assert(body['data'].all? {|page| page['status'] >= 400 && page['status'] < 500})
   end
+
+  test 'redirects to new page if requested page was merged away' do
+    page1 = Page.create(title: 'First Page', url: 'https://example.gov/')
+    page2 = Page.create(title: 'Second Page', url: 'https://example.gov/subpage')
+    page1.merge(page2)
+
+    sign_in users(:alice)
+    get(api_v0_page_url(page2))
+    assert_response(:permanent_redirect)
+    assert_redirected_to(api_v0_page_url(page1.uuid))
+  end
 end

--- a/test/controllers/api/v0/urls_controller_test.rb
+++ b/test/controllers/api/v0/urls_controller_test.rb
@@ -1,0 +1,157 @@
+require 'test_helper'
+
+class Api::V0::UrlsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'cannot list urls without auth' do
+    get api_v0_page_urls_path(pages(:home_page))
+    assert_response :unauthorized
+  end
+
+  test 'can list urls' do
+    sign_in users(:alice)
+    get api_v0_page_urls_path(pages(:home_page))
+    assert_response :success
+    assert_equal 'application/json', @response.media_type
+    body = JSON.parse @response.body
+
+    assert body.key?('links'), 'Response should have a "links" property'
+    assert body.key?('data'), 'Response should have a "data" property'
+    assert_kind_of(Array, body['data'])
+
+    page_urls = pages(:home_page).urls.pluck(:url)
+    body['data'].each do |page_url|
+      assert_includes(page_url, 'uuid')
+      assert_includes(page_url, 'url')
+      assert_includes(page_urls, page_url['url'])
+    end
+  end
+
+  test 'can create new urls' do
+    sign_in users(:alice)
+    post(
+      api_v0_page_urls_path(pages(:home_page)),
+      as: :json,
+      params: { page_url: { url: 'https://example.gov/new_url' } }
+    )
+    assert_response :success
+    assert_equal 'application/json', @response.media_type
+    body = JSON.parse @response.body
+    assert_equal('https://example.gov/new_url', body.dig('data', 'url'))
+  end
+
+  test 'cannot specify url_key when creating' do
+    sign_in users(:alice)
+    post(
+      api_v0_page_urls_path(pages(:home_page)),
+      as: :json,
+      params: {
+        page_url: {
+          url: 'https://example.gov/new_url',
+          url_key: 'gov.example)/old_url'
+        }
+      }
+    )
+    assert_response :success
+    assert_equal 'application/json', @response.media_type
+    body = JSON.parse @response.body
+    assert_not_equal('gov.example)/old_url', body.dig('data', 'url_key'))
+  end
+
+  test 'cannot create duplicate urls' do
+    page_url = pages(:home_page).urls.first
+
+    sign_in users(:alice)
+    post(
+      api_v0_page_urls_path(pages(:home_page)),
+      as: :json,
+      params: {
+        page_url: {
+          url: page_url.url,
+          from_time: page_url.from_time,
+          to_time: page_url.to_time
+        }
+      }
+    )
+    assert_response :conflict
+    assert_equal 'application/json', @response.media_type
+  end
+
+  test 'can update urls' do
+    page_url = pages(:home_page).urls.first
+    new_from_time = Time.now.utc - 1.day
+
+    sign_in users(:alice)
+    put(
+      api_v0_page_url_path(pages(:home_page), page_url),
+      as: :json,
+      params: { page_url: { from_time: new_from_time } }
+    )
+    assert_response :success
+    assert_equal 'application/json', @response.media_type
+    body = JSON.parse @response.body
+    assert_equal(new_from_time.round, Time.parse(body.dig('data', 'from_time')).round)
+  end
+
+  test 'cannot update url.url' do
+    page_url = pages(:home_page).urls.first
+
+    sign_in users(:alice)
+    put(
+      api_v0_page_url_path(pages(:home_page), page_url),
+      as: :json,
+      params: { page_url: { url: 'https://example.gov/some_new_url' } }
+    )
+    assert_response :unprocessable_entity
+    assert_equal 'application/json', @response.media_type
+  end
+
+  test 'cannot update url.url_key' do
+    page_url = pages(:home_page).urls.first
+
+    sign_in users(:alice)
+    put(
+      api_v0_page_url_path(pages(:home_page), page_url),
+      as: :json,
+      params: { page_url: { url_key: 'gov.example)/old_url' } }
+    )
+    # It just gets ignored, so this is "successful".
+    assert_response :success
+    assert_equal 'application/json', @response.media_type
+    body = JSON.parse @response.body
+    assert_not_equal('gov.example)/old_url', body.dig('data', 'url_key'))
+  end
+
+  test 'updating with a malformed url.from_time returns an error' do
+    page_url = pages(:home_page).urls.first
+
+    sign_in users(:alice)
+    put(
+      api_v0_page_url_path(pages(:home_page), page_url),
+      as: :json,
+      params: { page_url: { from_time: 'This is not a time' } }
+    )
+    assert_response :unprocessable_entity
+    assert_equal 'application/json', @response.media_type
+  end
+
+  test 'can delete urls' do
+    page_url = pages(:home_page).urls.create(url: 'https://example.gov/whatever')
+
+    sign_in users(:alice)
+    delete(api_v0_page_url_path(pages(:home_page), page_url))
+    assert_redirected_to(api_v0_page_urls_path(pages(:home_page)))
+
+    remaining_urls = pages(:home_page).urls.pluck(:url)
+    assert_not_includes(remaining_urls, page_url.url)
+  end
+
+  test 'cannot delete the canonical url for a page' do
+    page_url = pages(:home_page).urls.first
+
+    sign_in users(:alice)
+    delete(api_v0_page_url_path(pages(:home_page), page_url))
+    assert_response :unprocessable_entity
+    assert_equal 'application/json', @response.media_type
+  end
+end

--- a/test/fixtures/page_urls.yml
+++ b/test/fixtures/page_urls.yml
@@ -1,0 +1,40 @@
+# NOTE: do not specify maintainers and tags here; set up the appropriate
+# models in `maintainerships.yml` and `taggings.yml`. (We get DB errors about)
+# the `created_at` field in the many-to-many models if we try and set
+# `maintainers` or `tags` here, which *shouldn't* be the case. Not sure what's
+# broken in Rails.
+
+home_page_url:
+  page: home_page
+  url: 'http://example1.com/'
+  url_key: 'com,example1)/'
+
+sub_page_url:
+  page: sub_page
+  url: 'http://example1.com/page2.html'
+  url_key: 'com,example1)/page2.html'
+
+home_page_site2_url:
+  page: home_page_site2
+  url: 'http://example2.com/index.html'
+  url_key: 'com,example2)/index.html'
+
+dot_home_page_url:
+  page: dot_home_page
+  url: 'http://depart-of-testing.com/index.html'
+  url_key: 'com,depart-of-testing)/index.html'
+
+other_page_one_url:
+  page: other_page_one
+  url: 'http://example3.com/'
+  url_key: 'com,example3)/'
+
+home_page_site3_url:
+  page: home_page_site3
+  url: 'http://example3.com/'
+  url_key: 'com,example3)/'
+
+inactive_page_url:
+  page: inactive_page
+  url: 'http://example-inactive.com/'
+  url_key: 'com,example-inactive)/'

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -270,14 +270,17 @@ class PageTest < ActiveSupport::TestCase
     assert_equal(['maintainer1', 'maintainer2', 'maintainer3'], page1.maintainers.pluck(:name))
     assert_equal(3, page1.urls.count, 'Page1 has all the unique URLs from the pages')
     assert_equal(0, page2.urls.count, 'Page2 has no more URLs')
-    assert_equal([
-      [now - 2.5.days, 'https://example.gov/', false],
-      [now - 3.0.days, 'https://example.gov/index.html', true],
-      [now - 3.5.days, 'https://example.gov/subpage', false],
-      [now - 4.0.days, 'https://example.gov/', true],
-      [now - 4.5.days, 'https://example.gov/subpage', true],
-      [now - 5.0.days, 'https://example.gov/', true]
-    ], page1.versions.pluck(:capture_time, :capture_url, :different))
+    assert_equal(
+      [
+        [now - 2.5.days, 'https://example.gov/', false],
+        [now - 3.0.days, 'https://example.gov/index.html', true],
+        [now - 3.5.days, 'https://example.gov/subpage', false],
+        [now - 4.0.days, 'https://example.gov/', true],
+        [now - 4.5.days, 'https://example.gov/subpage', true],
+        [now - 5.0.days, 'https://example.gov/', true]
+      ],
+      page1.versions.pluck(:capture_time, :capture_url, :different)
+    )
     assert_not_predicate(page2, :active?)
   end
 end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -243,7 +243,7 @@ class PageTest < ActiveSupport::TestCase
   end
 
   test 'merge adds attributes and versions from another page' do
-    now = Time.zone.now.utc
+    now = Time.zone.now
     page1 = Page.create(title: 'First Page', url: 'https://example.gov/')
     page1.urls.create(url: 'https://example.gov/index.html')
     page1.add_tag('tag1')

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -263,7 +263,7 @@ class PageTest < ActiveSupport::TestCase
     page2.versions.create(capture_time: now - 4.5.days, capture_url: 'https://example.gov/subpage', version_hash: 'def')
     page2.versions.create(capture_time: now - 3.5.days, capture_url: 'https://example.gov/subpage', version_hash: 'abc')
     page2.versions.create(capture_time: now - 2.5.days, capture_url: 'https://example.gov/', version_hash: 'def', title: 'Title from p2 v3')
-    page2_version_ids = page2.versions.collect { |v| v.uuid }
+    page2_version_ids = page2.versions.collect(&:uuid)
 
     page1.merge(page2)
     assert_equal('Title from p2 v3', page1.title)
@@ -305,8 +305,8 @@ class PageTest < ActiveSupport::TestCase
         'url' => 'https://example.gov/subpage',
         'url_key' => 'gov,example)/subpage',
         'urls' => [
-          {'url' => 'https://example.gov/subpage', 'from_time' => nil, 'to_time' => nil, 'notes' => nil},
-          {'url' => 'https://example.gov/', 'notes' => nil, 'to_time' => nil, 'from_time' => nil}
+          { 'url' => 'https://example.gov/subpage', 'from_time' => nil, 'to_time' => nil, 'notes' => nil },
+          { 'url' => 'https://example.gov/', 'notes' => nil, 'to_time' => nil, 'from_time' => nil }
         ],
         'tags' => ['domain:example.gov', '2l-domain:example.gov', 'tag1', 'tag3'],
         'maintainers' => ['maintainer1', 'maintainer3'],

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -270,16 +270,19 @@ class PageTest < ActiveSupport::TestCase
     assert_equal(['maintainer1', 'maintainer2', 'maintainer3'], page1.maintainers.pluck(:name))
     assert_equal(3, page1.urls.count, 'Page1 has all the unique URLs from the pages')
     assert_equal(0, page2.urls.count, 'Page2 has no more URLs')
+    # NOTE: depending on the system and on PG, there may be precision issues
+    # data, so round before checking them.
     assert_equal(
       [
-        [now - 2.5.days, 'https://example.gov/', false],
-        [now - 3.0.days, 'https://example.gov/index.html', true],
-        [now - 3.5.days, 'https://example.gov/subpage', false],
-        [now - 4.0.days, 'https://example.gov/', true],
-        [now - 4.5.days, 'https://example.gov/subpage', true],
-        [now - 5.0.days, 'https://example.gov/', true]
+        [(now - 2.5.days).round, 'https://example.gov/', false],
+        [(now - 3.0.days).round, 'https://example.gov/index.html', true],
+        [(now - 3.5.days).round, 'https://example.gov/subpage', false],
+        [(now - 4.0.days).round, 'https://example.gov/', true],
+        [(now - 4.5.days).round, 'https://example.gov/subpage', true],
+        [(now - 5.0.days).round, 'https://example.gov/', true]
       ],
       page1.versions.pluck(:capture_time, :capture_url, :different)
+        .map { |row| [row[0].round, row[1], row[2]] }
     )
     assert_not_predicate(page2, :active?)
   end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -195,6 +195,19 @@ class PageTest < ActiveSupport::TestCase
     assert_equal(page.uuid, PageUrl.current.find_by_url(page.url).page_uuid, 'find_by_url() should return the page')
   end
 
+  test 'pages populate urls when page.url is updated' do
+    page = Page.create(url: 'https://example.gov/')
+    assert_equal(page.urls.count, 1, 'There should only be one URL for the page')
+    assert_equal(page.urls.first.url, page.url)
+
+    page.update(url: 'https://www.example.gov/')
+    assert_equal(page.urls.count, 2, 'There should be two URLs for the page after updating page.url')
+    assert_includes(page.urls.pluck(:url), 'https://www.example.gov/', 'New URL should be in the page\'s list of URLs')
+
+    page.update(url: 'https://example.gov/')
+    assert_equal(page.urls.count, 2, 'Changing page.url back to a previous value should not add a new PageUrl')
+  end
+
   test 'find_by_url matches by url_key if there is no URL match' do
     page = Page.create(title: 'Test Page', url: 'https://example.gov/some_page')
     found = Page.find_by_url('http://example.gov/some_page/')

--- a/test/models/page_url_test.rb
+++ b/test/models/page_url_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class PageUrlTest < ActiveSupport::TestCase
+  test 'PageUrls should always have a url_key' do
+    page = Page.create(url: 'https://example.gov/')
+    assert_not_empty(page.urls.first.url_key)
+
+    new_url = page.urls.create(url: 'https://example.gov/some_page.html')
+    assert_not_empty(new_url.url_key)
+  end
+
+  test 'PageUrls cannot change their url after saving' do
+    page = Page.create(url: 'https://example.gov/')
+    assert_raises(Exception) do
+      page.urls.first.update(url: 'https://example2.gov/')
+    end
+  end
+
+  test 'PageUrls are unique by page, url, from_time, to_time' do
+    page = Page.create(url: 'https://example.gov/')
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      page.urls.create(url: 'https://example.gov/')
+    end
+  end
+
+  test 'PageUrls.current returns only records with matching from_time and to_time' do
+    page = Page.create(url: 'https://example.gov/')
+    page.urls.first.update(to_time: Time.now - 1.day)
+    page.urls.create(url: 'https://example.gov/2', from_time: Time.now - 1.day)
+    current = page.urls.current
+    assert_equal(1, current.count)
+    assert_equal('https://example.gov/2', current.first.url)
+  end
+
+  test 'PageUrls.current works with specified times instead of the current time' do
+    page = Page.create(url: 'https://example.gov/')
+    page.urls.first.update(to_time: Time.now - 1.day)
+    page.urls.create(url: 'https://example.gov/2', from_time: Time.now - 1.day)
+    current = page.urls.current(Time.now - 1.month)
+    assert_equal(1, current.count)
+    assert_equal('https://example.gov/', current.first.url)
+  end
+end


### PR DESCRIPTION
This adds support for multiple URLs per page. The `url` field directly on a `Page` should now be treated as the current canonical URL, but pages may also have any number of additional URLs associated with them. Page + URL combinations may have a timeframe (`>= PageUrl.start_time` and `< PageUrl.end_time`) describing when they are valid and a notes field that are meant to mostly carry anecdotal information. The timeframe does have one technical purpose: if two pages occupied the same URL, we prefer the most current when adding new versions.

Things that still need to happen here:

- [x] Basic Migration
- [x] New class and associations
- [x] Tests for `PageUrl`
- [x] Data migration to populate new `PageUrl` records for existing pages
- [x] Tooling to merge pages
- [x] Update import logic to account for this (I *think* the only change we need is to add a `PageUrl` record if we found a non-exact page match [i.e. we matched against `url_key` and not `url`])
- [x] Add to the API (We may need to update the `?url=` query param on `PagesController`; not sure if we should return the URLs with page records or add a new controller for `/api/v0/pages/{id}/urls`).
- [x] Redirect merged pages to page they got merged into

Fixes #492.