### PR TITLE
Add API route for sampled list of versions

### DIFF
--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -14,6 +14,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
   end
 
   def sampled
+    @sampling = true
     raise API::NotFoundError('You must provide a page to sample versions of.') unless page
 
     # TODO: support variable sample periods. Need to figure out a reference
@@ -125,7 +126,9 @@ class Api::V0::VersionsController < Api::V0::ApiController
   protected
 
   def paging_path_for_version(*args)
-    if page
+    if @sampling
+      api_v0_page_versions_sampled_url(*args)
+    elsif page
       api_v0_page_versions_url(*args)
     else
       api_v0_versions_url(*args)

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -13,6 +13,46 @@ class Api::V0::VersionsController < Api::V0::ApiController
     }
   end
 
+  def sampled
+    raise API::NotFoundError('You must provide a page to sample versions of.') if !self.page
+
+    # TODO: support variable sample periods. Need to figure out a reference
+    # point for when those periods start.
+    # We don't support the complex filters and options #index does; we want to
+    # keep this as simple and fast as possible.
+    query = page.versions
+    # FIXME: this should probably have special pagination by date, since we
+    # don't want a sample group split across two responses.
+    paging = pagination(query)
+
+    samples = paging[:query].inject({}) do |samples, version|
+      key = version.capture_time.to_date.iso8601
+      if !samples.key?(key)
+        samples[key] = {
+          time: key,
+          version_count: 1,
+          version: version
+        }
+      else
+        samples[key][:version_count] += 1
+        if version.different && !samples[key][:version].different
+          samples[key][:version] = version
+        end
+      end
+      samples
+    end
+
+    samples.each_value do |sample|
+      sample[:version] = serialize_version(sample[:version])
+    end
+
+    render json: {
+      links: paging[:links],
+      meta: paging[:meta],
+      data: samples.values
+    }
+  end
+
   def show
     @version ||= version_collection.find(params[:id])
     render json: {

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -48,7 +48,10 @@ class Api::V0::VersionsController < Api::V0::ApiController
 
     render json: {
       links: paging[:links],
-      meta: paging[:meta],
+      meta: {
+        **paging[:meta],
+        sample_period: 'day'
+      },
       data: samples.values
     }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v0 do
       resources :pages, only: [:index, :show], format: :json do
+        get 'versions/sampled', to: 'versions#sampled'
         resources :versions, only: [:index, :show, :create]
         resources :changes,
           # Allow :id to be ":from_uuid..:to_uuid" or just ":change_id"


### PR DESCRIPTION
This adds a new API route at `/api/v0/pages/:page_id/versions/sampled` that gets a "sampled" list of versions — that is, one version per sampling period. Right now, the sampling period is hard-coded to one day, but we might change that in the future. The main idea here is to give people a list of versions to look at, but reduce the amount of data in a useful way for pages that we capture extremely often (e.g. `https://epa.gov`/ gets many captures every day). For most use cases, we don't want to look more granularly than each day.

Basically, instead of getting a list of versions, this gets a list of objects like:

```js
{
  time: "2022-01-01",
  version_count: 3,
  // A version object like we would get from /versions.
  // This is the latest `different` version in the sample period
  version: { ... }
}
```

The order of sample periods is always latest first.

This is part of https://github.com/edgi-govdata-archiving/web-monitoring/issues/161