### PR TITLE
Upgrade from Raven to Sentry SDK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,11 +23,14 @@ gem 'sassc-rails', '~> 2.1.2'
 gem 'uglifier', '>= 1.3.0'
 gem 'oj', '~> 3.13'
 gem 'pundit', '~> 2.2.0'
-gem 'sentry-raven'
 gem 'redis'
 gem 'hiredis'
 gem 'google-apis-sheets_v4'
 gem 'addressable', '~> 2.8'
+
+# Monitoring & Telemetry
+gem 'sentry-ruby', '~> 5.4.1'
+gem 'sentry-rails', '~> 5.4.1'
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,8 +299,11 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (5.4.1)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.4.1)
+    sentry-ruby (5.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -385,7 +388,8 @@ DEPENDENCIES
   rubocop-rails (~> 2.15.2)
   sassc-rails (~> 2.1.2)
   selenium-webdriver
-  sentry-raven
+  sentry-rails (~> 5.4.1)
+  sentry-ruby (~> 5.4.1)
   spring
   spring-watcher-listen (~> 2.0)
   tzinfo-data

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,7 +55,7 @@ module WebpageVersionsDb
         error_handler: -> (method:, returning:, exception:) {
           # Rails cache fails silently without raising exceptions (which is
           # generally good), but we still want to know if it can't connect.
-          Raven.capture_exception(exception, level: 'warning', tags: {
+          Sentry.capture_exception(exception, level: 'warning', tags: {
             method: method,
             returning: returning
           })

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,4 @@
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  config.traces_sample_rate = 0.2
+end


### PR DESCRIPTION
Sentry's "Raven" library has been deprecated and in maintentance mode for a long time. The newwer, full-featured, updated gem is "sentry_sdk". Fixes #837.