### PR TITLE
Remove deprecated buckets from tests/examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
           PGHOST: 127.0.0.1
           PGUSER: root
           HOST_URL: 'web-monitoring-db.test'
-          ALLOWED_ARCHIVE_HOSTS: 'https://edgi-wm-versionista.s3.amazonaws.com/ https://test-bucket.s3.amazonaws.com/'
+          ALLOWED_ARCHIVE_HOSTS: 'https://edgi-wm-archive.s3.amazonaws.com/ https://edgi-wm-versionista.s3.amazonaws.com/ https://test-bucket.s3.amazonaws.com/'
       - image: circleci/postgres:9.5-alpine-ram
         environment:
           POSTGRES_USER: root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
           PGHOST: 127.0.0.1
           PGUSER: root
           HOST_URL: 'web-monitoring-db.test'
-          ALLOWED_ARCHIVE_HOSTS: 'https://edgi-wm-versionista.s3.amazonaws.com/ https://edgi-versionista-archive.s3.amazonaws.com/ https://test-bucket.s3.amazonaws.com/'
+          ALLOWED_ARCHIVE_HOSTS: 'https://edgi-wm-versionista.s3.amazonaws.com/ https://test-bucket.s3.amazonaws.com/'
       - image: circleci/postgres:9.5-alpine-ram
         environment:
           POSTGRES_USER: root

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ MAIL_SENDER='some-email-account@example.com'
 # `ALLOWED_ARCHIVE_HOSTS`, the application downloads the data from `body_url`
 # and stores it (see `lib/archiver` for more). That way, we can ensure data is
 # always available to API users from a reliable public location.
-ALLOWED_ARCHIVE_HOSTS='https://edgi-wm-versionista.s3.amazonaws.com/ https://edgi-wm-versionista.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-wm-versionista/'
+ALLOWED_ARCHIVE_HOSTS='https://edgi-wm-archive.s3.amazonaws.com/ https://edgi-wm-versionista.s3.amazonaws.com/ https://edgi-wm-versionista.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-wm-versionista/'
 
 # OPTIONAL: Uncomment & fill in to use S3 for storage instead of your local
 # file system

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ MAIL_SENDER='some-email-account@example.com'
 # `ALLOWED_ARCHIVE_HOSTS`, the application downloads the data from `body_url`
 # and stores it (see `lib/archiver` for more). That way, we can ensure data is
 # always available to API users from a reliable public location.
-ALLOWED_ARCHIVE_HOSTS='https://edgi-web-monitoring-db.s3.amazonaws.com/ https://edgi-wm-versionista.s3.amazonaws.com/ https://edgi-wm-versionista.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-wm-versionista/ https://edgi-versionista-archive.s3.amazonaws.com/ https://edgi-versionista-archive.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-versionista-archive/'
+ALLOWED_ARCHIVE_HOSTS='https://edgi-wm-versionista.s3.amazonaws.com/ https://edgi-wm-versionista.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-wm-versionista/'
 
 # OPTIONAL: Uncomment & fill in to use S3 for storage instead of your local
 # file system

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -87,7 +87,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     # post(api_v0_page_versions_url(page), params: {
     #   {
     #     'capture_time': '2017-04-23T17:25:43.000Z',
-    #     'body_url': 'https://edgi-versionista-archive.s3.amazonaws.com/versionista1/74304-6222353/version-10997815.html',
+    #     'body_url': 'https://edgi-wm-versionista.s3.amazonaws.com/versionista1/74304-6222353/version-10997815.html',
     #     'body_hash': 'f366e89639758cd7f75d21e5026c04fb1022853844ff471865004b3274059686',
     #     'source_type': 'versionista',
     #     'source_metadata': {


### PR DESCRIPTION
Something somewhere is still accessing these old buckets. Maybe related to these old examples? These should be cleaned up regardless, though.