### PR TITLE
Paginate samples by date range

### DIFF
--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -54,7 +54,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
         raise Api::InputError, 'time range must be no more than 365 days'
       end
     elsif time_range[1]
-      to_time = now.to_date + 1.day
+      to_time = time_range[1] + 1.day
       time_range = [to_time - SAMPLE_DAYS_DEFAULT.days, to_time]
     elsif time_range[0]
       from_time = time_range[0]

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -27,26 +27,6 @@ class Api::V0::VersionsController < Api::V0::ApiController
     query = page.versions
 
     now = Time.now
-    # time_range = nil
-    # if params[:from] && params[:to]
-    #   # time_range = parse_unbounded_range!(params[:capture_time], "capture_time") { |d| parse_date!(d) }
-    #   from_time = parse_date!(params[:from]).to_date
-    #   to_time = parse_date!(params[:to]).to_date + 1.day
-    #   if to_time - from_time > SAMPLE_DAYS_MAX.days
-    #     raise Api::InputError, "`from` and `to` parameters must be no more than 365 days apart"
-    #   end
-    #   time_range = [from_time, to_time]
-    # elsif params[:from]
-    #   from_time = parse_date!(params[:from]).to_date
-    #   time_range = [from_time, from_time + SAMPLE_DAYS_DEFAULT.days]
-    # elsif params[:to]
-    #   to_time = parse_date!(params[:to]).to_date + 1.day
-    #   time_range = [to_time - SAMPLE_DAYS_DEFAULT.days, to_time]
-    # else
-    #   to_time = now.to_date + 1.day
-    #   time_range = [to_time - SAMPLE_DAYS_DEFAULT.days, to_time]
-    # end
-
     time_range = parse_unbounded_range!(params[:capture_time], 'capture_time') { |d| parse_date!(d).to_date } || []
     if time_range[0] && time_range[1]
       time_range[1] = time_range[1] + 1.day
@@ -100,20 +80,12 @@ class Api::V0::VersionsController < Api::V0::ApiController
     # Optimize forward pagination by skipping to a time range with data.
     if next_version
       next_to = next_version.capture_time.to_date + 1.day
-      # links[:next] = api_v0_page_versions_sampled_url(
-      #   page,
-      #   params: {from: (next_to - SAMPLE_DAYS_DEFAULT.days).iso8601, to: next_to.iso8601}
-      # )
       links[:next] = api_v0_page_versions_sampled_url(
         page,
         params: { capture_time: "#{(next_to - SAMPLE_DAYS_DEFAULT.days).iso8601}..#{next_to.iso8601}" }
       )
     end
     if time_range[1] < Time.now
-      # links[:prev] = api_v0_page_versions_sampled_url(
-      #   page,
-      #   params: {from: time_range[1].iso8601, to: (time_range[1] + SAMPLE_DAYS_DEFAULT.days).iso8601}
-      # )
       links[:prev] = api_v0_page_versions_sampled_url(
         page,
         params: { capture_time: "#{time_range[1].iso8601}..#{(time_range[1] + SAMPLE_DAYS_DEFAULT.days).iso8601}" }

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -1,6 +1,9 @@
 class Api::V0::VersionsController < Api::V0::ApiController
   include SortingConcern
 
+  SAMPLE_DAYS_DEFAULT = 183
+  SAMPLE_DAYS_MAX = 365
+
   def index
     query = version_collection
     paging = pagination(query)
@@ -22,11 +25,48 @@ class Api::V0::VersionsController < Api::V0::ApiController
     # We don't support the complex filters and options #index does; we want to
     # keep this as simple and fast as possible.
     query = page.versions
-    # FIXME: this should probably have special pagination by date, since we
-    # don't want a sample group split across two responses.
-    paging = pagination(query)
 
-    samples = paging[:query].each_with_object({}) do |version, result|
+    now = Time.now
+    # time_range = nil
+    # if params[:from] && params[:to]
+    #   # time_range = parse_unbounded_range!(params[:capture_time], "capture_time") { |d| parse_date!(d) }
+    #   from_time = parse_date!(params[:from]).to_date
+    #   to_time = parse_date!(params[:to]).to_date + 1.day
+    #   if to_time - from_time > SAMPLE_DAYS_MAX.days
+    #     raise Api::InputError, "`from` and `to` parameters must be no more than 365 days apart"
+    #   end
+    #   time_range = [from_time, to_time]
+    # elsif params[:from]
+    #   from_time = parse_date!(params[:from]).to_date
+    #   time_range = [from_time, from_time + SAMPLE_DAYS_DEFAULT.days]
+    # elsif params[:to]
+    #   to_time = parse_date!(params[:to]).to_date + 1.day
+    #   time_range = [to_time - SAMPLE_DAYS_DEFAULT.days, to_time]
+    # else
+    #   to_time = now.to_date + 1.day
+    #   time_range = [to_time - SAMPLE_DAYS_DEFAULT.days, to_time]
+    # end
+
+    time_range = parse_unbounded_range!(params[:capture_time], "capture_time") { |d| parse_date!(d).to_date } || []
+    if time_range[0] && time_range[1]
+      time_range[1] = time_range[1] + 1.day
+      if time_range[1] - time_range[0] > SAMPLE_DAYS_MAX.days
+        raise Api::InputError, "time range must be no more than 365 days"
+      end
+    elsif time_range[1]
+      to_time = now.to_date + 1.day
+      time_range = [to_time - SAMPLE_DAYS_DEFAULT.days, to_time]
+    elsif time_range[0]
+      from_time = time_range[0]
+      time_range = [from_time, from_time + SAMPLE_DAYS_DEFAULT.days]
+    else
+      to_time = now.to_date + 1.day
+      time_range = [to_time - SAMPLE_DAYS_DEFAULT.days, to_time]
+    end
+
+    query = query.where_in_unbounded_range(:capture_time, time_range)
+
+    samples = query.each_with_object({}) do |version, result|
       key = version.capture_time.to_date.iso8601
       if result.key?(key)
         result[key][:version_count] += 1
@@ -46,11 +86,45 @@ class Api::V0::VersionsController < Api::V0::ApiController
       sample[:version] = serialize_version(sample[:version])
     end
 
+    next_version = page.versions.where('capture_time < ?', time_range[0]).select(:uuid, :capture_time).first
+    if samples.length.zero? && next_version.nil?
+      raise Api::NotFoundError, "`to` time is older than the oldest version"
+    end
+
+    links = {
+      first: api_v0_page_versions_sampled_url(page),
+      last: nil,
+      next: nil,
+      prev: nil
+    }
+    # Optimize forward pagination by skipping to a time range with data.
+    if next_version
+      next_to = next_version.capture_time.to_date + 1.day
+      # links[:next] = api_v0_page_versions_sampled_url(
+      #   page,
+      #   params: {from: (next_to - SAMPLE_DAYS_DEFAULT.days).iso8601, to: next_to.iso8601}
+      # )
+      links[:next] = api_v0_page_versions_sampled_url(
+        page,
+        params: {capture_time: "#{(next_to - SAMPLE_DAYS_DEFAULT.days).iso8601}..#{next_to.iso8601}"}
+      )
+    end
+    if time_range[1] < Time.now
+      # links[:prev] = api_v0_page_versions_sampled_url(
+      #   page,
+      #   params: {from: time_range[1].iso8601, to: (time_range[1] + SAMPLE_DAYS_DEFAULT.days).iso8601}
+      # )
+      links[:prev] = api_v0_page_versions_sampled_url(
+        page,
+        params: {capture_time: "#{time_range[1].iso8601}..#{(time_range[1] + SAMPLE_DAYS_DEFAULT.days).iso8601}"}
+      )
+    end
+
     render json: {
-      links: paging[:links],
+      links: links,
       meta: {
-        **paging[:meta],
-        sample_period: 'day'
+        sample_period: 'day',
+        warning: 'This API endpoint is experimental and may change'
       },
       data: samples.values
     }

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -47,11 +47,11 @@ class Api::V0::VersionsController < Api::V0::ApiController
     #   time_range = [to_time - SAMPLE_DAYS_DEFAULT.days, to_time]
     # end
 
-    time_range = parse_unbounded_range!(params[:capture_time], "capture_time") { |d| parse_date!(d).to_date } || []
+    time_range = parse_unbounded_range!(params[:capture_time], 'capture_time') { |d| parse_date!(d).to_date } || []
     if time_range[0] && time_range[1]
       time_range[1] = time_range[1] + 1.day
       if time_range[1] - time_range[0] > SAMPLE_DAYS_MAX.days
-        raise Api::InputError, "time range must be no more than 365 days"
+        raise Api::InputError, 'time range must be no more than 365 days'
       end
     elsif time_range[1]
       to_time = now.to_date + 1.day
@@ -88,7 +88,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
 
     next_version = page.versions.where('capture_time < ?', time_range[0]).select(:uuid, :capture_time).first
     if samples.length.zero? && next_version.nil?
-      raise Api::NotFoundError, "`to` time is older than the oldest version"
+      raise Api::NotFoundError, '`to` time is older than the oldest version'
     end
 
     links = {
@@ -106,7 +106,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
       # )
       links[:next] = api_v0_page_versions_sampled_url(
         page,
-        params: {capture_time: "#{(next_to - SAMPLE_DAYS_DEFAULT.days).iso8601}..#{next_to.iso8601}"}
+        params: { capture_time: "#{(next_to - SAMPLE_DAYS_DEFAULT.days).iso8601}..#{next_to.iso8601}" }
       )
     end
     if time_range[1] < Time.now
@@ -116,7 +116,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
       # )
       links[:prev] = api_v0_page_versions_sampled_url(
         page,
-        params: {capture_time: "#{time_range[1].iso8601}..#{(time_range[1] + SAMPLE_DAYS_DEFAULT.days).iso8601}"}
+        params: { capture_time: "#{time_range[1].iso8601}..#{(time_range[1] + SAMPLE_DAYS_DEFAULT.days).iso8601}" }
       )
     end
 

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -64,7 +64,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     page.versions.each(&:update_different_attribute)
 
     sign_in users(:alice)
-    get(api_v0_page_versions_sampled_url(page))
+    get(api_v0_page_versions_sampled_url(page, capture_time: '2021-12-01...2022-02-01'))
     assert_response(:success)
     assert_equal('application/json', @response.media_type)
     body_json = JSON.parse(@response.body)


### PR DESCRIPTION
In #946, I added a `/pages/:id/versions/sampled` endpoint that returns no more than one page per date. The goal was to reduce the number of queries and the amount of data transferred to load some pages that have a *lot* of snapshots. It turns out this didn't work well because it still paginated by the number of versions it was querying, which means it still required the exact same number of requests (d'oh!). (It *did* reduce the amount of data sent, but not by much after gzipping responses. It was still many megabytes for some pages.)

This changes the approach to paginate by date range instead, which should make a big difference. The code is pretty rough, but as long as it works, I plan to deploy so we can try it out with the bigger production data set.

Some remaining concerns:
- Times are treated as dates only, since we summarize by day.
- ~There is some commented out code using `from` and `to` params instead of `capture_time` with a range for a value. I originally wrote it with those, but realized the parsing code for `capture_time` works just as well and is probably more consistent, although I definitely find myself questioning this possibly-too-fancily-formatted param now.~
- It might be worth considering having specific time ranges (i.e. arbitrary date ranges are not allowed, instead only things like quarter N of year Y or something) in order to make it easier to cache and reduce the cost of the queries. Not sure it’s really necessary, though.
- Versions (and pagination) are in reverse order by date (as with `/pages/:id/versions`). It’s probably correct to do this so different APIs work similarly, but I definitely found myself thinking more than I expected about this. Then again, I haven’t really touched this whole codebase in a while, and there are probably a *lot* of things I’d do differently now. ¯\\\_(ツ)\_/¯