### PR TITLE
Revert Redis upgrade from #1004

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,16 +17,20 @@ gem 'pg', '~> 1.4'
 gem 'puma', '~> 5.6'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'rack-brotli'
-gem 'resque'
-gem 'resque-heroku-signals'
 gem 'sassc-rails', '~> 2.1.2'
 gem 'uglifier', '>= 1.3.0'
 gem 'oj', '~> 3.13'
 gem 'pundit', '~> 2.2.0'
-gem 'redis'
-gem 'hiredis'
 gem 'google-apis-sheets_v4'
 gem 'addressable', '~> 2.8'
+
+# Workers/Queuing
+# Resque 2.3.0 is not compatible with Redis v5; if updated, see about updating
+# the redis gem as well. See: https://github.com/resque/resque/pull/1828
+gem 'resque', '~> 2.3.0'
+# gem 'resque-heroku-signals'
+gem 'redis', '~> 4.8'
+gem 'hiredis'
 
 # Monitoring & Telemetry
 gem 'sentry-ruby', '~> 5.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,6 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.10)
-    connection_pool (2.2.5)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -246,10 +245,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (5.0.2)
-      redis-client (~> 0.7)
-    redis-client (0.7.1)
-      connection_pool
+    redis (4.8.0)
     redis-namespace (1.9.0)
       redis (>= 4)
     regexp_parser (2.5.0)
@@ -265,8 +261,6 @@ GEM
       multi_json (~> 1.0)
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
-    resque-heroku-signals (2.3.0)
-      resque (= 2.3.0)
     retriable (3.1.2)
     rexml (3.2.5)
     rubocop (1.36.0)
@@ -386,9 +380,8 @@ DEPENDENCIES
   rack-brotli
   rack-cors
   rails (~> 6.1.6.1)
-  redis
-  resque
-  resque-heroku-signals
+  redis (~> 4.8)
+  resque (~> 2.3.0)
   rubocop (~> 1.36.0)
   rubocop-performance (~> 1.14.3)
   rubocop-rails (~> 2.15.2)


### PR DESCRIPTION
This reverts the Redis upgrade to v5 in #1004, since Resque is not yet compatible with it.