### PR TITLE
Add missing dependency on net-imap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ ruby '3.1.2'
 # (Probably with an upgrade to Rails 7)
 gem 'net-smtp'
 gem 'net-pop'
+gem 'net-imap'
 
 gem 'aws-sdk-s3', '~> 1.114'
 gem 'concurrent-ruby', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,10 @@ GEM
     multi_xml (0.6.0)
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
     net-pop (0.1.1)
       digest
       net-protocol
@@ -337,6 +341,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.4)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.2.0)
@@ -385,6 +390,7 @@ DEPENDENCIES
   httparty
   jwt (~> 2.5)
   listen (~> 3.7)
+  net-imap
   net-pop
   net-smtp
   oj (~> 3.13)


### PR DESCRIPTION
OK, this time I ran the server in production mode locally to make sure nothing *else* was missing. Argh.