### PR TITLE
Upgrade Sentry to v5.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,8 @@ gem 'redis', '~> 5.0'
 gem 'hiredis'
 
 # Monitoring & Telemetry
-gem 'sentry-ruby', '~> 5.4.2'
-gem 'sentry-rails', '~> 5.4.2'
+gem 'sentry-ruby', '~> 5.5.0'
+gem 'sentry-rails', '~> 5.5.0'
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,10 +316,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.4.2)
+    sentry-rails (5.5.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.4.2)
-    sentry-ruby (5.4.2)
+      sentry-ruby (~> 5.5.0)
+    sentry-ruby (5.5.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     signet (0.17.0)
       addressable (~> 2.8)
@@ -407,8 +407,8 @@ DEPENDENCIES
   rubocop-rails (~> 2.17.2)
   sassc-rails (~> 2.1.2)
   selenium-webdriver
-  sentry-rails (~> 5.4.2)
-  sentry-ruby (~> 5.4.2)
+  sentry-rails (~> 5.5.0)
+  sentry-ruby (~> 5.5.0)
   spring
   spring-watcher-listen (~> 2.1)
   tzinfo-data


### PR DESCRIPTION
Dependabot opened a PR for this (#1028) but then promptly closed it. Not sure what went wrong there, so I’m redoing it manually.