### PR TITLE
Ensure `url_key` stays in sync with `url`

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -253,6 +253,7 @@ class Page < ApplicationRecord
 
   def normalize_url
     self.url = self.class.normalize_url(self.url)
+    self.url_key = PageUrl.create_url_key(self.url) if self.changed_attributes.key?('url')
   end
 
   def domain

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -125,6 +125,12 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('com,example,sub)/somewhere', page.url_key)
   end
 
+  test 'pages update url_key when url is changed' do
+    page = Page.create(url: 'http://sub.EXAMPLE.com/somewhere')
+    page.update(url: 'http://sub.EXAMPLE.com/elsewhere')
+    assert_equal('com,example,sub)/elsewhere', page.url_key)
+  end
+
   test 'page status must be a valid status code or nil' do
     page = pages(:home_page)
     page.status = nil


### PR DESCRIPTION
I've been doing a bunch of cleanup lately, and the fact that `Page#url_key` does not automatically update to reflect `Page#url` is a huge pain. There's no reason this shouldn't be automatic, so this makes it so.