### PR TITLE
Only update the page title for non-error versions

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -254,7 +254,7 @@ class Page < ApplicationRecord
     # Fall back to the filename from the page's URL.
     if new_title.blank?
       filename = /\/([^\/]+)\/?$/.match(url).try(:[], 1)
-      clean_name = CGI::unescape(filename || '')
+      clean_name = CGI.unescape(filename || '')
       self.update(title: clean_name)
     end
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -241,6 +241,24 @@ class Page < ApplicationRecord
     end
   end
 
+  def update_page_title(from_time = nil)
+    candidates = versions.reorder(capture_time: :desc)
+    candidates = candidates.where('capture_time >= ?', from_time) if from_time
+
+    new_title = nil
+    candidates.each do |version|
+      new_title = version.sync_page_title
+      break if new_title
+    end
+
+    # Fall back to the filename from the page's URL.
+    if new_title.blank?
+      filename = /\/([^\/]+)\/?$/.match(url).try(:[], 1)
+      clean_name = CGI::unescape(filename || '')
+      self.update(title: clean_name)
+    end
+  end
+
   protected
 
   def news?
@@ -305,14 +323,6 @@ class Page < ApplicationRecord
 
     success_rate = 1 - (error_time.to_f / total_time)
     success_rate < STATUS_SUCCESS_THRESHOLD ? latest_error : 200
-  end
-
-  def update_page_title(from_time = nil)
-    candidates = versions.reorder(capture_time: :desc)
-    candidates = candidates.where('capture_time >= ?', from_time) if from_time
-    candidates.each do |version|
-      break if version.sync_page_title
-    end
   end
 
   # TODO: figure out whether there's a reasonable way to merge this logic with

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -164,24 +164,24 @@ class Version < ApplicationRecord
 
     # Special case for the EPA "signpost" page, where they redirected hundreds
     # of climate-related pages to instead of giving them 4xx status codes.
-    return 404 if (
+    return 404 if
       source_metadata &&
       source_metadata['redirected_url']&.end_with?('epa.gov/sites/production/files/signpost/cc.html')
-    )
+
 
     status || 200
   end
 
-  def is_error?(strict: false)
+  def status_ok?(strict: false)
     if strict
-      status >= 400
+      status < 400
     else
-      effective_status >= 400
+      effective_status < 400
     end
   end
 
   def sync_page_title
-    if title.present? && !is_error?
+    if title.present? && status_ok?
       most_recent_capture_time = page.latest.capture_time
       if most_recent_capture_time.nil? || most_recent_capture_time <= capture_time
         page.update(title:)

--- a/lib/tasks/data/20230119_reset_page_titles.rake
+++ b/lib/tasks/data/20230119_reset_page_titles.rake
@@ -1,0 +1,25 @@
+namespace :data do
+  desc 'Reset the titles for all pages based on new logic.'
+  task :'20230119_reset_page_titles', [] => [:environment] do
+    ActiveRecord::Migration.say_with_time('Resetting titles for existing pages...') do
+      DataHelpers.with_activerecord_log_level(:error) do
+        last_update = Time.now - 1.minute
+        expected = Page.all.count
+        total = 0
+
+        DataHelpers.iterate_each(Page.all.order(created_at: :asc)) do |page|
+          page.update_page_title
+          total += 1
+
+          if Time.now - last_update >= 2
+            DataHelpers.log_progress(total, expected)
+            last_update = Time.now
+          end
+        end
+
+        DataHelpers.log_progress(total, expected)
+        total
+      end
+    end
+  end
+end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -52,6 +52,21 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it is an error status')
   end
 
+  test "page title should should use URL if there's no valid version" do
+    page = Page.create(url: 'http://no-title.com/my/special+page.html', status: 404)
+    page.versions.create(capture_time: '2017-03-05T00:00:00Z', status: 404, title: '')
+    page.update_page_title
+
+    assert_equal('special page.html', page.title)
+
+    # Also works with no path in the URL?
+    page2 = Page.create(url: 'http://no-title.com/', status: 404)
+    page2.versions.create(capture_time: '2017-03-05T00:00:00Z', status: 404, title: '')
+    page2.update_page_title
+
+    assert_equal('no-title.com', page2.title)
+  end
+
   test 'can add many maintainer models to a page' do
     pages(:home_page).add_maintainer(maintainers(:epa))
     pages(:home_page).add_maintainer(maintainers(:doi))

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -43,6 +43,15 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has an empty title')
   end
 
+  test "page title should not sync with a version's title if the version was an error page" do
+    page = pages(:home_page)
+    assert_equal('Page One', page.title)
+
+    page.versions.create(capture_time: '2017-03-05T00:00:00Z', status: 500, title: 'Page One v2')
+    refute(page.changed?, 'The page was left with unsaved changes')
+    assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it is an error status')
+  end
+
   test 'can add many maintainer models to a page' do
     pages(:home_page).add_maintainer(maintainers(:epa))
     pages(:home_page).add_maintainer(maintainers(:doi))


### PR DESCRIPTION
If a new version is an error (e.g. a 404 status code because the page was removed), don't update the page record's title with the title from the error response. This also uses the filename component of the URL as a fallback title in case no versions with a parsed title can be found.

Fixes #751.
Fixes #468.

To-Do:

- [x] Check for error statuses before updating
- [x] Fall back to URL-based title
- [x] Add data migration to reset all page titles