### PR TITLE
Remove bad old Versionista titles

### DIFF
--- a/lib/tasks/data/20230119_remove_bad_versionista_titles.rake
+++ b/lib/tasks/data/20230119_remove_bad_versionista_titles.rake
@@ -1,0 +1,24 @@
+namespace :data do
+  desc 'Remove bad version titles from Versionista.'
+  task :'20230119_remove_bad_versionista_titles', [] => [:environment] do |_t, args|
+    progress_interval = $stdout.isatty ? 2 : 10
+
+    ActiveRecord::Migration.say_with_time('Removing bad titles from Versionista versions...') do
+      DataHelpers.with_activerecord_log_level(:error) do
+        Version.
+          where(source_type: 'versionista').
+          where(title: [
+            # These titles are or appear to have been text strings from the
+            # Versionista UI to represent documents without titles, or where
+            # the title could not be ascertained, rather than the document's
+            # actual title.
+            'None',
+            'No title available',
+            'No title yet',
+            'Your page is missing!'
+          ]).
+          update_all(title: '')
+      end
+    end
+  end
+end

--- a/lib/tasks/data/20230119_remove_bad_versionista_titles.rake
+++ b/lib/tasks/data/20230119_remove_bad_versionista_titles.rake
@@ -1,23 +1,21 @@
 namespace :data do
   desc 'Remove bad version titles from Versionista.'
-  task :'20230119_remove_bad_versionista_titles', [] => [:environment] do |_t, args|
-    progress_interval = $stdout.isatty ? 2 : 10
-
+  task :'20230119_remove_bad_versionista_titles', [] => [:environment] do |_t, _args|
     ActiveRecord::Migration.say_with_time('Removing bad titles from Versionista versions...') do
       DataHelpers.with_activerecord_log_level(:error) do
-        Version.
-          where(source_type: 'versionista').
-          where(title: [
-            # These titles are or appear to have been text strings from the
-            # Versionista UI to represent documents without titles, or where
-            # the title could not be ascertained, rather than the document's
-            # actual title.
-            'None',
-            'No title available',
-            'No title yet',
-            'Your page is missing!'
-          ]).
-          update_all(title: '')
+        Version
+          .where(source_type: 'versionista')
+          .where(title: [
+                   # These titles are or appear to have been text strings from the
+                   # Versionista UI to represent documents without titles, or where
+                   # the title could not be ascertained, rather than the document's
+                   # actual title.
+                   'None',
+                   'No title available',
+                   'No title yet',
+                   'Your page is missing!'
+                 ])
+          .update_all(title: '')
       end
     end
   end


### PR DESCRIPTION
It turns out we have some bad page titles from back when we got data from Versionista (discovered while working on #1061). When a page was missing a title, Versionista showed human-friendly text like "None", "No title available", etc. We incorrectly read these in as titles. This updates old version records from Versionista by replaces those titles with an empty string.

There may be additional strings we're missing here, but this is a big improvement (covers almost 32,000 records). Verified by looking for titles used across many versions, then sampling a few of the stored response bodies to make sure they didn't actually have these strings as literal titles.