### PR TITLE
Use range-based pagination for versions

### DIFF
--- a/app/controllers/concerns/paging_concern.rb
+++ b/app/controllers/concerns/paging_concern.rb
@@ -19,6 +19,7 @@ module PagingConcern
   # assembled your relation with all the relevant conditions.
   def pagination(collection, path_resolver: :paging_path_for, include_total: nil)
     collection ||= @collection
+    path_resolver = method(path_resolver) if path_resolver.is_a? Symbol
     include_total = boolean_param(:include_total) if include_total.nil?
 
     chunk_size = (params[:chunk_size] || DEFAULT_PAGE_SIZE).to_i.clamp(1, MAX_PAGE_SIZE)
@@ -29,11 +30,6 @@ module PagingConcern
     query = collection.limit(chunk_size).offset(item_offset)
     # Use `length` instead of `count` or `size` to ensure we don't issue an expensive `count(x)` SQL query.
     is_last = query.length < chunk_size
-
-    if path_resolver.is_a? Symbol
-      resolver_symbol = path_resolver
-      path_resolver = lambda {|*args| self.send resolver_symbol, *args}
-    end
 
     collection_type = collection.new.class.name.underscore.to_sym
     format_type = self.paging_url_format

--- a/db/migrate/20230124184531_remove_simple_time_indexes_on_versions.rb
+++ b/db/migrate/20230124184531_remove_simple_time_indexes_on_versions.rb
@@ -1,0 +1,17 @@
+class RemoveSimpleTimeIndexesOnVersions < ActiveRecord::Migration[7.0]
+  def change
+    # Drop indexes on Version time fields. These are now redundant since we
+    # have compound indexes (with UUID) that can be used in the cases these
+    # were designed for.
+    remove_index(:versions, :created_at)
+    remove_index(:versions, :capture_time)
+
+    # Similarly, these partial indexes are no longer heavily used
+    remove_index(:versions, :capture_time,
+                 where: 'different = true',
+                 name: 'index_different_versions_on_capture_time')
+    remove_index(:versions, :created_at,
+                 where: 'different = true',
+                 name: 'index_different_versions_on_created_at')
+  end
+end

--- a/db/migrate/20230124184531_remove_simple_time_indexes_on_versions.rb
+++ b/db/migrate/20230124184531_remove_simple_time_indexes_on_versions.rb
@@ -3,15 +3,11 @@ class RemoveSimpleTimeIndexesOnVersions < ActiveRecord::Migration[7.0]
     # Drop indexes on Version time fields. These are now redundant since we
     # have compound indexes (with UUID) that can be used in the cases these
     # were designed for.
-    remove_index(:versions, :created_at)
-    remove_index(:versions, :capture_time)
+    remove_index(:versions, name: 'index_versions_on_created_at')
+    remove_index(:versions, name: 'index_versions_on_capture_time')
 
     # Similarly, these partial indexes are no longer heavily used
-    remove_index(:versions, :capture_time,
-                 where: 'different = true',
-                 name: 'index_different_versions_on_capture_time')
-    remove_index(:versions, :created_at,
-                 where: 'different = true',
-                 name: 'index_different_versions_on_created_at')
+    remove_index(:versions, name: 'index_different_versions_on_created_at')
+    remove_index(:versions, name: 'index_different_versions_on_capture_time')
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_24_182815) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_24_184531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -172,11 +172,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_182815) do
     t.jsonb "headers"
     t.index ["body_hash"], name: "index_versions_on_body_hash"
     t.index ["capture_time", "uuid"], name: "index_versions_on_capture_time_and_uuid"
-    t.index ["capture_time"], name: "index_different_versions_on_capture_time", where: "(different = true)"
-    t.index ["capture_time"], name: "index_versions_on_capture_time"
     t.index ["created_at", "uuid"], name: "index_versions_on_created_at_and_uuid"
-    t.index ["created_at"], name: "index_different_versions_on_created_at", where: "(different = true)"
-    t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["page_uuid", "capture_time", "uuid"], name: "index_versions_on_page_uuid_and_capture_time_and_uuid"
     t.index ["page_uuid", "created_at", "uuid"], name: "index_versions_on_page_uuid_and_created_at_and_uuid"
     t.index ["page_uuid"], name: "index_versions_on_page_uuid"

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -304,6 +304,11 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'meta.total_results should be the total results across all chunks' do
+    # For now, there no reasonable way to count versions in a reasonable amount
+    # of time, so this functionality is disabled. This test is kept in case
+    # the feature comes back (e.g. with clever caching of counts).
+    skip
+
     sign_in users(:alice)
     page = pages(:home_page)
 
@@ -318,18 +323,27 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test 'can order versions with `?sort=field:direction,field:direction`' do
+  test 'the ?include_total=true parameter is not supported' do
+    sign_in users(:alice)
+    page = pages(:home_page)
+
+    get(api_v0_page_versions_url(page, params: { include_total: true }))
+    assert_response(400)
+    assert_equal('application/json', @response.media_type)
+  end
+
+  test 'can order versions with `?sort=field:direction`' do
     sign_in users(:alice)
     get(
       api_v0_versions_url(
-        params: { sort: 'source_type:asc, capture_time:asc' }
+        params: { sort: 'capture_time:asc' }
       )
     )
     assert_response(:success)
     body = JSON.parse(@response.body)
     assert_ordered_by(
       body['data'],
-      [['source_type'], ['capture_time']],
+      [['capture_time']],
       name: 'Versions'
     )
   end


### PR DESCRIPTION
This is a *super rough* first cut at the logic for range-based pagination for versions (see #579). It’s ugly, problematic, and absolutely not mergeable as-is, but lets us test things out. Still needs:

- [x] Cleanup and encapsulation. (Maybe pull this stuff out into a concern so it can be used on other models.)
- [x] Migration to add the appropriate indexes (`(capture_time, uuid)`, `(created_at, uuid)` maybe also `(page_uuid, capture_time, uuid)`, `(page_uuid, created_at, uuid)`).
- [x] Tests.
- [ ] Maybe extend to pages? (Not sure it’s worthwhile, there aren’t critical problems there like there are for versions)

*Update 2023-01-25: I’m not going to extend this to other endpoints. While it would be nice, the real priority right now is doing the minimum required for https://github.com/edgi-govdata-archiving/web-monitoring/issues/168*

## Overall Summary

The slow performance of offset-based pagination (when you get a batch of results with a query like `SELECT xyz FROM table OFFSET = n LIMIT = m`) is a serious problem on the the `versions` table (really any large table, but in practice it’s just `versions` for this app). This solves the problem by using range-based pagination (skipping to the place you want in the result set using a `WHERE` clause that filters to a range of values from at the same field(s) you are sorting by).

For the versions table, that means doing queries based on a different minimum/maximum `(capture_time, uuid)` or `(created_at, uuid)` for each page/batch/chunk of results rather than using SQL's `OFFSET` clause to get to the chunk we want. This is more-or-less compatible with with any existing client, since the `next` link still works and the `chunk_size` parameter also works the same.

On the other hand, this introduces some new restrictions:

- You can only sort by one field, and it must be either `capture_time` or `created_at` instead of any field(s) you want. We need an index for the fields we want to sort by, and these two are the ones we chose.

- Clients shouldn’t usually be setting the `chunk` parameter on their own, and will run into problems if they do, since that field is no longer an integer (now it is either a version UUID or a combined `"<timestamp>,<uuid>"` string).

- The `?include_total=true` parameter is no longer supported for versions. There’s just no performant way to do it without additional caching of that field somewhere (`count()` in Postgres always requires a full table scan; the entire point of this change is to prevent us from doing large scans in order to paginate results).

There’s also plenty in here that’s not perfectly clean, and not totally generalized. If we wanted to utilize this kind of pagination for other models/controllers, it would need some work to make more abstract.