### PR TITLE
Add new indexes for range-based pagination

### DIFF
--- a/db/migrate/20230124182815_add_compound_time_uuid_indexes_on_versions.rb
+++ b/db/migrate/20230124182815_add_compound_time_uuid_indexes_on_versions.rb
@@ -1,0 +1,17 @@
+class AddCompoundTimeUuidIndexesOnVersions < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    # The versions table has gotten so big that offset-based queries are a real
+    # problem, so we need to paginate by the actual sort critera
+    # (created/captured time), which requires a compound index with UUID to make
+    # sure we never skip versions with identical timestamps.
+    add_index(:versions, [:created_at, :uuid], algorithm: :concurrently)
+    add_index(:versions, [:page_uuid, :created_at, :uuid], algorithm: :concurrently)
+    add_index(:versions, [:capture_time, :uuid], algorithm: :concurrently)
+    add_index(:versions, [:page_uuid, :capture_time, :uuid], algorithm: :concurrently)
+
+    # NOTE: this leaves simpler indexes like just created_at, just capture_time
+    # in place for now. We can remove them once the above indexes are validated.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_01_211031) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_24_182815) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -171,10 +171,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_01_211031) do
     t.string "media_type"
     t.jsonb "headers"
     t.index ["body_hash"], name: "index_versions_on_body_hash"
+    t.index ["capture_time", "uuid"], name: "index_versions_on_capture_time_and_uuid"
     t.index ["capture_time"], name: "index_different_versions_on_capture_time", where: "(different = true)"
     t.index ["capture_time"], name: "index_versions_on_capture_time"
+    t.index ["created_at", "uuid"], name: "index_versions_on_created_at_and_uuid"
     t.index ["created_at"], name: "index_different_versions_on_created_at", where: "(different = true)"
     t.index ["created_at"], name: "index_versions_on_created_at"
+    t.index ["page_uuid", "capture_time", "uuid"], name: "index_versions_on_page_uuid_and_capture_time_and_uuid"
+    t.index ["page_uuid", "created_at", "uuid"], name: "index_versions_on_page_uuid_and_created_at_and_uuid"
     t.index ["page_uuid"], name: "index_versions_on_page_uuid"
     t.index ["source_type"], name: "index_versions_on_source_type"
   end


### PR DESCRIPTION
Before we can actually do range-based pagination in any usefully workable way, we need to have indexes in place that support it (partially because the primary key for versions is a UUID, which is unordered -- this wouldn't be such a big deal with bigint). These indexes will take a while to build, so it's good to get these in place ahead of time.

A future change will remove the old, non-compound indexes that will be redundant after these new ones finish building.

Addresses part of #571, and required before deploying #1066.