### PR TITLE
Add config for public read access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,11 @@ TOKEN_PRIVATE_KEY='MIIEogIBAAKCAQEAufNrDQRl6Gj1yuga0DVHeJ4fi+lNWtn4S8XRU8/nBwm9v
 # https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
 ALLOW_VERSIONS_IN_PAGE_RESPONSES='false'
 
+# Allow anyone (including) non-logged-in users to have `view` permissions on
+# the API. Keeping this off means viewers will need to log in in order to see
+# anything except the docs/home page. (Defaults to false)
+ALLOW_PUBLIC_VIEW='true'
+
 # Set this in production to look up the user associated with automatic
 # annotations. Note a user with this e-mail must exist.
 # AUTO_ANNOTATION_USER='someone@example.com'

--- a/app/policies/api_policy.rb
+++ b/app/policies/api_policy.rb
@@ -1,6 +1,6 @@
 class ApiPolicy < ApplicationPolicy
   def view?
-    user.present? && user.can_view?
+    Rails.configuration.allow_public_view || (user.present? && user.can_view?)
   end
 
   def annotate?

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,5 +62,9 @@ module WebpageVersionsDb
         }
       }
     end
+
+    config.allow_public_view = ActiveModel::Type::Boolean.new.cast(
+      ENV.fetch('ALLOW_PUBLIC_VIEW', '')
+    ).present?
   end
 end


### PR DESCRIPTION
This starts the path toward #1069 by adding an environment variable `ALLOW_PUBLIC_VIEW` that determines whether you need to be logged in to have `view` permissions on API routes. For now, it defaults to false, but once we are comfortable that it's safe, we'll switch the default to true.