### PR TITLE
Ensure permissions are correctly enforced

### DIFF
--- a/app/controllers/api/v0/maintainers_controller.rb
+++ b/app/controllers/api/v0/maintainers_controller.rb
@@ -1,6 +1,8 @@
 class Api::V0::MaintainersController < Api::V0::ApiController
   include SortingConcern
 
+  before_action(except: [:index, :show]) { authorize(:api, :annotate?) }
+
   def index
     query = maintainer_collection
     paging = pagination(query)

--- a/app/controllers/api/v0/tags_controller.rb
+++ b/app/controllers/api/v0/tags_controller.rb
@@ -1,6 +1,8 @@
 class Api::V0::TagsController < Api::V0::ApiController
   include SortingConcern
 
+  before_action(except: [:index, :show]) { authorize(:api, :annotate?) }
+
   def index
     query = tag_collection
     paging = pagination(query)

--- a/app/controllers/api/v0/urls_controller.rb
+++ b/app/controllers/api/v0/urls_controller.rb
@@ -1,4 +1,6 @@
 class Api::V0::UrlsController < Api::V0::ApiController
+  before_action(except: [:index, :show]) { authorize(:api, :import?) }
+
   def index
     urls = page.urls.order('page_urls.to_time DESC')
 

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -122,6 +122,8 @@ class Api::V0::VersionsController < Api::V0::ApiController
   end
 
   def create
+    authorize(:api, :import?)
+
     # TODO: unify this with import code in ImportVersionsJob#import_record
     @version = page.versions.new(version_params)
 

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -3,9 +3,16 @@ require 'test_helper'
 class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test 'cannot list pages without auth' do
-    get '/api/v0/pages/'
-    assert_response :unauthorized
+  test 'can only list pages without auth if configured' do
+    with_rails_configuration(:allow_public_view, true) do
+      get api_v0_pages_path
+      assert_response :success
+    end
+
+    with_rails_configuration(:allow_public_view, false) do
+      get api_v0_pages_path
+      assert_response :unauthorized
+    end
   end
 
   test 'can list pages' do

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -15,3 +15,9 @@ admin_user:
   encrypted_password: <%= Devise::Encryptor.digest(User, 'testpassword') %>
   confirmed_at: <%= Time.now %>
   permissions: <%= [User::VIEW_PERMISSION, User::ANNOTATE_PERMISSION, User::IMPORT_PERMISSION, User::MANAGE_USERS_PERMISSION] %>
+
+view_only_user:
+  email: test3@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'testpassword') %>
+  confirmed_at: <%= Time.now %>
+  permissions: <%= [User::VIEW_PERMISSION] %>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,4 +44,12 @@ class ActiveSupport::TestCase
     message ||= "Expected #{list} to have an item that includes '#{value}'"
     assert_any(list, ->(item) { item.include?(value) }, message)
   end
+
+  def with_rails_configuration(key, value, &block)
+    original =  Rails.configuration.send(key)
+    Rails.configuration.send("#{key}=", value)
+    block.call
+  ensure
+    Rails.configuration.send("#{key}=", original)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,10 +45,10 @@ class ActiveSupport::TestCase
     assert_any(list, ->(item) { item.include?(value) }, message)
   end
 
-  def with_rails_configuration(key, value, &block)
-    original =  Rails.configuration.send(key)
+  def with_rails_configuration(key, value)
+    original = Rails.configuration.send(key)
     Rails.configuration.send("#{key}=", value)
-    block.call
+    yield
   ensure
     Rails.configuration.send("#{key}=", original)
   end


### PR DESCRIPTION
It turns out we were lazy about a lot of permissions in the API since we had a small set of users and nobody with `view` permissions didn't also have `annotate`. Now that we are enabling public access, that's a problem! This makes sure we're checking appropriate permissions in all the API controllers and actions.

This also does a little work to differentiate requests with no credentials and invalid credentials, which is important now that we are enabling public view access (no credentials is OK, invalid credentials is obviously an error, but needs an API-style response rather than the default authentication error handling). Devise doesn't provide anything that differentiates those, so we have to drop down to check some Warden data.

Found as part of auditing API access and options in https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/1070.