### PR TITLE
Block public access to some expensive parameters

### DIFF
--- a/app/assets/data/swagger.yaml
+++ b/app/assets/data/swagger.yaml
@@ -229,7 +229,6 @@ paths:
           format: uuid4
         - $ref: '#/parameters/chunk'
         - $ref: '#/parameters/chunk_size'
-        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
         - name: capture_time
           in: query
@@ -241,7 +240,7 @@ paths:
         - name: source_metadata[:key]
           type: string
           in: query
-          description: >
+          description: >-
             Filter results by a given `key` in the `source_metadata` field. You
             can include this parameter multiple times to filter by more than
             one `key`. *Note that this field is not indexed, so these queries
@@ -250,6 +249,9 @@ paths:
             - `/api/v0/versions?source_metadata[version_id]=12345678`
 
             - `/api/v0/versions?source_metadata[account]=versionista1&source_metadata[has_content]=true`
+
+
+            🚫 You must be logged in to use this parameter!
         - name: different
           in: query
           description: >-
@@ -266,6 +268,8 @@ paths:
             If present, include a `change_from_previous` field in the result
             that represents a change object between this version and the
             previous version of this page.
+
+            🚫 You must be logged in to use this parameter!
         - name: include_change_from_earliest
           in: query
           type: boolean
@@ -285,6 +289,8 @@ paths:
             notation for intervals. For example, to get all 4XX status versions:
 
                 ?status=[400,500)
+
+            🚫 You must be logged in to use this parameter!
       responses:
         '200':
           description: successful operation
@@ -381,6 +387,8 @@ paths:
             If present, include a `change_from_previous` field in the result
             that represents a change object between this version and the
             previous version of this page.
+
+            🚫 You must be logged in to use this parameter!
         - name: include_change_from_earliest
           in: query
           type: boolean
@@ -390,6 +398,8 @@ paths:
             If present, include a `change_from_earliest` field in the result
             that represents a change object between this version and the
             earliest version of this page.
+
+            🚫 You must be logged in to use this parameter!
       responses:
         '200':
           description: successful operation
@@ -923,7 +933,6 @@ paths:
       parameters:
         - $ref: '#/parameters/chunk'
         - $ref: '#/parameters/chunk_size'
-        - $ref: '#/parameters/include_total'
         - $ref: '#/parameters/sort'
         - name: capture_time
           in: query
@@ -953,6 +962,9 @@ paths:
             - `/api/v0/versions?source_metadata[version_id]=12345678`
 
             - `/api/v0/versions?source_metadata[account]=versionista1&source_metadata[has_content]=true`
+
+
+            🚫 You must be logged in to use this parameter!
         - name: include_change_from_previous
           in: query
           type: boolean
@@ -962,6 +974,8 @@ paths:
             If present, include a `change_from_previous` field in the result
             that represents a change object between this version and the
             previous version of this page.
+
+            🚫 You must be logged in to use this parameter!
         - name: include_change_from_earliest
           in: query
           type: boolean
@@ -971,6 +985,8 @@ paths:
             If present, include a `change_from_earliest` field in the result
             that represents a change object between this version and the
             earliest version of this page.
+
+            🚫 You must be logged in to use this parameter!
         - name: status
           in: query
           type: string
@@ -981,6 +997,8 @@ paths:
             notation for intervals. For example, to get all 4XX status versions:
 
                 ?status=[400,500)
+
+            🚫 You must be logged in to use this parameter!
       responses:
         '200':
           description: successful operation
@@ -1012,6 +1030,8 @@ paths:
             If present, include a `change_from_previous` field in the result
             that represents a change object between this version and the
             previous version of this page.
+
+            🚫 You must be logged in to use this parameter!
         - name: include_change_from_earliest
           in: query
           type: boolean
@@ -1021,6 +1041,8 @@ paths:
             If present, include a `change_from_earliest` field in the result
             that represents a change object between this version and the
             earliest version of this page.
+
+            🚫 You must be logged in to use this parameter!
       responses:
         '200':
           description: successful operation

--- a/app/controllers/api/v0/annotations_controller.rb
+++ b/app/controllers/api/v0/annotations_controller.rb
@@ -1,5 +1,8 @@
 class Api::V0::AnnotationsController < Api::V0::ApiController
   include SortingConcern
+  include BlockedParamsConcern
+
+  block_params_for_public_users params: [:include_total]
   before_action(only: [:create]) { authorize :api, :annotate? }
   before_action :set_annotation, only: [:show]
 

--- a/app/controllers/api/v0/changes_controller.rb
+++ b/app/controllers/api/v0/changes_controller.rb
@@ -1,5 +1,8 @@
 class Api::V0::ChangesController < Api::V0::ApiController
   include SortingConcern
+  include BlockedParamsConcern
+
+  block_params_for_public_users params: [:include_total]
 
   def index
     query = changes_collection

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -1,5 +1,8 @@
 class Api::V0::PagesController < Api::V0::ApiController
   include SortingConcern
+  include BlockedParamsConcern
+
+  block_params_for_public_users [:include_earliest, :include_latest, :source_type]
 
   def index
     query = page_collection

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -2,7 +2,12 @@ class Api::V0::PagesController < Api::V0::ApiController
   include SortingConcern
   include BlockedParamsConcern
 
-  block_params_for_public_users [:include_earliest, :include_latest, :source_type]
+  # Params that can cause expensive performance overhead require logging in.
+  block_params_for_public_users actions: [:index],
+                                params: [
+                                  :include_change_from_previous,
+                                  :include_change_from_earliest
+                                ]
 
   def index
     query = page_collection

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -5,8 +5,8 @@ class Api::V0::PagesController < Api::V0::ApiController
   # Params that can cause expensive performance overhead require logging in.
   block_params_for_public_users actions: [:index],
                                 params: [
-                                  :include_change_from_previous,
-                                  :include_change_from_earliest
+                                  :include_earliest,
+                                  :include_latest
                                 ]
 
   def index

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -1,8 +1,19 @@
 class Api::V0::VersionsController < Api::V0::ApiController
   include SortingConcern
+  include BlockedParamsConcern
 
   SAMPLE_DAYS_DEFAULT = 183
   SAMPLE_DAYS_MAX = 365
+
+  # Params that can cause expensive performance overhead require logging in.
+  block_params_for_public_users [
+    # Serialization
+    :include_change_from_previous,
+    :include_change_from_earliest,
+    # Querying
+    :source_metadata,
+    :status
+  ]
 
   def index
     query = version_collection

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -6,14 +6,13 @@ class Api::V0::VersionsController < Api::V0::ApiController
   SAMPLE_DAYS_MAX = 365
 
   # Params that can cause expensive performance overhead require logging in.
-  block_params_for_public_users [
-    # Serialization
-    :include_change_from_previous,
-    :include_change_from_earliest,
-    # Querying
-    :source_metadata,
-    :status
-  ]
+  block_params_for_public_users actions: :all,
+                                params: [:source_metadata, :status]
+  block_params_for_public_users actions: [:index, :sampled],
+                                params: [
+                                  :include_change_from_previous,
+                                  :include_change_from_earliest
+                                ]
 
   def index
     query = version_collection

--- a/app/controllers/concerns/blocked_params_concern.rb
+++ b/app/controllers/concerns/blocked_params_concern.rb
@@ -1,0 +1,29 @@
+# Block unauthenticated requests that use certain params with a 403 (Forbidden)
+# error. This can be used to prevent abuse of options that may cause expensive
+# operations.
+module BlockedParamsConcern
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    attr_reader :blocked_public_params
+
+    private
+
+    def block_params_for_public_users(blocked_params)
+      @blocked_public_params = Set.new(blocked_params.collect &:to_s)
+    end
+  end
+
+  included do
+    before_action :raise_for_non_public_params!
+  end
+
+  protected
+
+  def raise_for_non_public_params!
+    if !current_user && self.class.blocked_public_params&.intersect?(params.keys)
+      names = self.class.blocked_public_params.collect {|p| "`#{p}`"}.join(', ')
+      raise Api::ForbiddenError, "You must be logged in to use the params: #{names}"
+    end
+  end
+end

--- a/app/controllers/concerns/blocked_params_concern.rb
+++ b/app/controllers/concerns/blocked_params_concern.rb
@@ -9,20 +9,48 @@ module BlockedParamsConcern
 
     private
 
-    def block_params_for_public_users(blocked_params)
-      @blocked_public_params = Set.new(blocked_params.collect(&:to_s))
+    # Raise an exception on any non-logged-in request that uses the specified
+    # params.
+    #
+    # @param actions [:all, Array<Symbol>] Only block the params on these
+    #        actions. If `:all` or not set, blocking is applied to all actions.
+    # @param params [Array<Symbol, String>] Param names to block.
+    #
+    # @example
+    #   class MyController
+    #     include BlockedParamsConcern
+    #     block_params_for_public_users actions: [:index, :show]
+    #                                   params: [:bad, :params, :here]
+    #   end
+    def block_params_for_public_users(actions: nil, params:)
+      actions = nil if actions == :all
+      actions = [actions] unless actions.nil? || actions.is_a?(Array)
+      actions = actions&.collect(&:to_s)
+
+      @blocked_public_params ||= {}
+      @blocked_public_params[actions] = params.collect(&:to_s)
     end
   end
 
   included do
-    before_action :raise_for_non_public_params!
+    before_action :check_non_public_params!
   end
 
   protected
 
-  def raise_for_non_public_params!
-    if !current_user && self.class.blocked_public_params&.intersect?(params.keys)
-      names = self.class.blocked_public_params.collect {|p| "`#{p}`"}.join(', ')
+  def check_non_public_params!
+    return unless self.class.blocked_public_params
+
+    blocked = self.class.blocked_public_params.flat_map do |actions, params|
+      (actions.nil? || actions.include?(self.action_name)) ? params : nil
+    end
+
+    raise_for_non_public_params!(blocked)
+  end
+
+  def raise_for_non_public_params!(blocked_params)
+    if !current_user && blocked_params.intersect?(params.keys)
+      names = blocked_params.collect {|p| "`#{p}`"}.join(', ')
       raise Api::ForbiddenError, "You must be logged in to use the params: #{names}"
     end
   end

--- a/app/controllers/concerns/blocked_params_concern.rb
+++ b/app/controllers/concerns/blocked_params_concern.rb
@@ -42,7 +42,7 @@ module BlockedParamsConcern
     return unless self.class.blocked_public_params
 
     blocked = self.class.blocked_public_params.flat_map do |actions, params|
-      (actions.nil? || actions.include?(self.action_name)) ? params : nil
+      actions.nil? || actions.include?(action_name) ? params : nil
     end
 
     raise_for_non_public_params!(blocked)

--- a/app/controllers/concerns/blocked_params_concern.rb
+++ b/app/controllers/concerns/blocked_params_concern.rb
@@ -10,7 +10,7 @@ module BlockedParamsConcern
     private
 
     def block_params_for_public_users(blocked_params)
-      @blocked_public_params = Set.new(blocked_params.collect &:to_s)
+      @blocked_public_params = Set.new(blocked_params.collect(&:to_s))
     end
   end
 

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -184,6 +184,13 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_kind_of Hash, results[0]['earliest'], '"earliest" property was not a hash'
   end
 
+  test 'should not include earliest version if not logged in' do
+    with_rails_configuration(:allow_public_view, true) do
+      get api_v0_pages_path(include_earliest: true)
+      assert_response :forbidden
+    end
+  end
+
   test 'includes latest version if include_latest = true' do
     sign_in users(:alice)
     get api_v0_pages_path(include_latest: true)
@@ -191,6 +198,13 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     results = body['data']
 
     assert_kind_of Hash, results[0]['latest'], '"latest" property was not a hash'
+  end
+
+  test 'should not include lastest version if not logged in' do
+    with_rails_configuration(:allow_public_view, true) do
+      get api_v0_pages_path(include_latest: true)
+      assert_response :forbidden
+    end
   end
 
   test 'includes versions if include_versions = true' do

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -306,12 +306,14 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'cannot query by source_metadata fields if not logged in' do
-    version = versions(:page1_v1)
-    get api_v0_versions_path(params: {
-      source_metadata: { version_id: version.source_metadata['version_id'] }
-    })
+    with_rails_configuration(:allow_public_view, true) do
+      version = versions(:page1_v1)
+      get api_v0_versions_path(params: {
+        source_metadata: { version_id: version.source_metadata['version_id'] }
+      })
 
-    assert_response(:forbidden)
+      assert_response(:forbidden)
+    end
   end
 
   test 'meta.total_results should be the total results across all chunks' do

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -305,6 +305,15 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test 'cannot query by source_metadata fields if not logged in' do
+    version = versions(:page1_v1)
+    get api_v0_versions_path(params: {
+      source_metadata: { version_id: version.source_metadata['version_id'] }
+    })
+
+    assert_response(:forbidden)
+  end
+
   test 'meta.total_results should be the total results across all chunks' do
     # For now, there no reasonable way to count versions in a reasonable amount
     # of time, so this functionality is disabled. This test is kept in case


### PR DESCRIPTION
Some parameters for the various `/versions` collections cause expensive queries, so they are disallowed for public, non-logged-in usage.

Solves part of #1070.