### PR TITLE
Turn on public viewing by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,10 +79,10 @@ TOKEN_PRIVATE_KEY='MIIEogIBAAKCAQEAufNrDQRl6Gj1yuga0DVHeJ4fi+lNWtn4S8XRU8/nBwm9v
 # https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/274
 ALLOW_VERSIONS_IN_PAGE_RESPONSES='false'
 
-# Allow anyone (including) non-logged-in users to have `view` permissions on
+# Allow anyone (including non-logged-in users) to have `view` permissions on
 # the API. Keeping this off means viewers will need to log in in order to see
-# anything except the docs/home page. (Defaults to false)
-ALLOW_PUBLIC_VIEW='true'
+# anything except the docs/home page. (Defaults to true)
+# ALLOW_PUBLIC_VIEW='false'
 
 # Set this in production to look up the user associated with automatic
 # annotations. Note a user with this e-mail must exist.

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,7 +64,7 @@ module WebpageVersionsDb
     end
 
     config.allow_public_view = ActiveModel::Type::Boolean.new.cast(
-      ENV.fetch('ALLOW_PUBLIC_VIEW', '')
+      ENV.fetch('ALLOW_PUBLIC_VIEW', 'true')
     ).present?
   end
 end


### PR DESCRIPTION
In #1071, we added support for public, unauthenticated users to have `view` permissions in the API and turned it on in staging. There haven’t been any major issues, so we are now switching the default from `false` to `true` (which will turn it on in production).