### PR TITLE
Add caching headers for production assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,7 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.headers = { 'Cache-Control' => "public, max-age=#{1.day.to_i}" }
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
It turns out we weren't sending any caching headers for assets in production, so they weren't generally getting cached. This adds a 1-day cache for them (most assets are compiled and have hashes in the name, so could be cached forever, but some don't, e.g. `robots.txt`).