### PR TITLE
Add disabled notice to AnalyzeChangeJob

### DIFF
--- a/app/jobs/analyze_change_job.rb
+++ b/app/jobs/analyze_change_job.rb
@@ -1,3 +1,10 @@
+# NOTE: THIS JOB IS NOT IN ACTIVE USE.
+# The use cases it served were better solved by the task-sheets project
+# (https://github.com/edgi-govdata-archiving/web-monitoring-task-sheets).
+# That said, the outputs there were never integrated into the database here in
+# an automated way, which this job did.
+#
+# The job code here is preserved in case we need to turn it back on.
 class AnalyzeChangeJob < ApplicationJob
   queue_as :analysis
 

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -32,7 +32,7 @@ class ImportVersionsJob < ApplicationJob
         Rails.logger.error "Import #{import.id}: Cannot queue AnalyzeChangeJob -- #{error.message}"
       end
     else
-      Rails.logger.warn "Import #{import.id}: Auto-analysis requirements are not configured; AnalyzeChangeJobs were not scheduled for imported versions."
+      Rails.logger.warn "Import #{import.id}: Auto-analysis is not configured; AnalyzeChangeJobs were not scheduled for imported versions."
     end
   end
 

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -108,7 +108,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
                    "[import=#{import.id}][row=0] Found Page #{page.uuid}",
                    "[import=#{import.id}][row=0] Replaced Version #{versions(:page1_v5).uuid}",
                    "[import=#{import.id}] Finished Import #{import.id}",
-                   "Import #{import.id}: Auto-analysis requirements are not configured; AnalyzeChangeJobs were not scheduled for imported versions."
+                   "Import #{import.id}: Auto-analysis is not configured; AnalyzeChangeJobs were not scheduled for imported versions."
                  ], Rails.logger.logs, 'Logs are not as expected.')
   end
 


### PR DESCRIPTION
We've disabled `AnalyzeChangeJob` via configuration in production. Since we also expect to never make use of it again, I've added a note in the code (I opted not to delete it in case it needs to get turned on in the future -- someone could always go get it back from the git history, but since there is no technical maintainer to replace me, I'm worried that's too big of a barrier.)

Fixes #1090.