### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "10:00"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
This project is moving into maintenance mode; it does not make sense to continue making regular, non-security-related dependency updates. See edgi-govdata-archiving/web-monitoring#168 for more.