### PR TITLE
Add manually triggered workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+on:
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'Message'
+        type: string
+        required: true
+
+name: Trigger New Release
+
+jobs:
+  # CircleCI currently builds the release; all this does is push a merge commit
+  # to the `release` branch (which triggers Circle to build and publish).
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update release branch
+        run: |
+          git checkout release
+          git pull
+          git merge main -m '${{ inputs.message }}'
+          git push


### PR DESCRIPTION
To make releases a little simpler, you can now trigger them via a button in the GitHub Actions UI.

![actions-workflow-dispatch](https://user-images.githubusercontent.com/74178/225678887-981eda66-f424-4ff6-a6dd-c97fa55170b8.jpeg)
