### PR TITLE
Re-enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "10:00"
+    open-pull-requests-limit: 10
+    groups:
+      linters:
+        patterns:
+          - "rubocop*"
+      selenium:
+        patterns:
+          - "selenium*"
+      # Group other patch-only updates by prod/dev (bigger updates stay
+      # separate, so they are easier to review and check release notes).
+      development:
+        dependency-type: "development"
+        update-types:
+          - patch
+      production:
+        update-types:
+          - patch
+        exclude-patterns:
+          - rails


### PR DESCRIPTION
In preparation for spinning things back up in Trump 2.0 world, re-enable Dependabot. There’s going to be a lot to catch up on.