### PR TITLE
Link `data` directory in Sprockets manifest

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
+//= link_tree ../data
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css


### PR DESCRIPTION
The last release seems to be running into some issues with Sprockets failing to recognize the `swagger.yml` file (even though it successfully precompiles). In Sprockets 4 there were changes to how config options are handled vs. what's in the `manifest.js` file, so I'm adding it to `manifest.js` to see if that solves it.