### PR TITLE
Fix e-mail invitation expiration and confirmation issues

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -68,7 +68,7 @@ class Invitation < ApplicationRecord
 
   def ensure_expiration
     unless self.expires_on
-      self.expires_on = Time.now + EXPIRATION_DAYS
+      self.expires_on = Time.now + EXPIRATION_DAYS.days
     end
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :postmark
   config.action_mailer.postmark_settings = {
-    api_key: ENV.fetch('POSTMARK_API_TOKEN')
+    api_token: ENV.fetch('POSTMARK_API_TOKEN')
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
This fixes a few issues with user invitations/registration. The expiration date on an invitation somehow wound up being calculated based on N *seconds* instead of *days* from the current time!

~This also disables user e-mail confirmation for now. We’ve got some issues with Postmark that I *think* are on their end (I have a support ticket open with them), so it’s better not to require any e-mail to get an account set up for now. (Confirmation was always a weird step since invitations are currently required here; it was originally intended for a future vision where we wouldn’t require invitations, but that future will probably never exist for this codebase.)~