### PR TITLE
Add `network_error` field to Version model

### DIFF
--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -111,7 +111,9 @@ class Api::V0::VersionsController < Api::V0::ApiController
 
     expires_in 1.year, public: true
 
-    if @version.body_url.nil?
+    if @version.network_error.present?
+      render :network_error, layout: nil
+    elsif @version.body_url.nil?
       raise Api::NotFoundError, "No raw content for #{@version.uuid}."
     elsif Archiver.external_archive_url?(@version.body_url)
       redirect_to @version.body_url, status: 301, allow_other_host: true

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -250,6 +250,10 @@ class Version < ApplicationRecord
     end
   end
 
+  def domain
+    url.present? ? Addressable::URI.parse(url).host : '<unknown>'
+  end
+
   def sync_page_title
     page.update_page_title(capture_time)
   end

--- a/app/views/api/v0/versions/network_error.html.erb
+++ b/app/views/api/v0/versions/network_error.html.erb
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Network error <%= @version.network_error %></title>
+    <style type="text/css">
+      body {
+        font-size: 1.25rem;
+        margin: 0;
+        padding: 1rem;
+        margin: 2rem auto;
+      }
+
+      body > * {
+        margin: 1rem auto;
+        max-width: 35rem;
+        text-align: center;
+      }
+
+      h1 { font-size: 1em; }
+      #error-code {
+        font-size: 0.75em;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>There was a network error when capturing this page.</h1>
+    <p id="description">
+      <% if @version.network_error.include? 'ERR_NAME_NOT_RESOLVED' %>
+        No server could be found for “<%= @version.domain %>” in the Domain Name System.
+      <% elsif @version.network_error.include? 'ERR_CONNECTION_REFUSED' %>
+        The server refused the request.
+      <% elsif @version.network_error.include? 'ERR_SSL_VERSION_OR_CIPHER_MISMATCH' %>
+        A secure connection could not be established.
+      <% elsif @version.network_error.include? 'ERR_CONNECTION_RESET' %>
+        The server dropped the connection in the middle of the request.
+      <% elsif ['timeout', 'timed out', 'timed_out'].any? { |text| @version.network_error.downcase.include? text } %>
+        We gave up waiting for the server to respond after a long time.
+      <% end %>
+      <span id="error-code">(Code: <code><%= @version.network_error %></code>)</span>
+    </p>
+  </body>
+</html>

--- a/db/migrate/20250202234940_add_network_error_to_versions.rb
+++ b/db/migrate/20250202234940_add_network_error_to_versions.rb
@@ -1,0 +1,7 @@
+class AddNetworkErrorToVersions < ActiveRecord::Migration[8.0]
+  def change
+    change_table :versions do |t|
+      t.string :network_error
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_20_215224) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_02_234940) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -259,6 +259,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_20_215224) do
     t.integer "content_length"
     t.string "media_type"
     t.jsonb "headers"
+    t.string "network_error"
     t.index ["body_hash"], name: "index_versions_on_body_hash"
     t.index ["capture_time", "uuid"], name: "index_versions_on_capture_time_and_uuid"
     t.index ["created_at", "uuid"], name: "index_versions_on_created_at_and_uuid"

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -287,6 +287,24 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal(content, @response.body)
   end
 
+  test 'can synthesize a raw response body for network errors' do
+    page = pages(:home_page)
+    version = page.versions.create(
+      capture_time: Time.now - 1.minute,
+      body_url: nil,
+      body_hash: nil,
+      source_type: 'edgi_statuscheck_v0',
+      url: page.url,
+      status: nil,
+      network_error: 'net::ERR_TIMED_OUT'
+    )
+
+    sign_in users(:alice)
+    get raw_api_v0_version_url(version)
+    assert_response(:success)
+    assert_includes(@response.body, 'net::ERR_TIMED_OUT')
+  end
+
   test 'can query by source_metadata fields' do
     sign_in users(:alice)
     version = versions(:page1_v1)


### PR DESCRIPTION
This gives us a way to model the server itself being down instead of responding with an HTTP 4xx or 5xx error. In the very early times (when this DB was focused around data from Versionista and Pagefreezer), we shoved errors and HTTP statuses in `source_metadata` because we often didn't have a clear representation of different kinds of errors. We later switched to 100% Internet Archive as a source, and didn't consider the fact that they don't track network-level errors since we were no longer seeing whole hostnames disappear at that point. Now at the start of 2025, we're seeing a lot of servers simply being shut down, and need to be able to clearly represent that.

For captures of network-level failures (i.e. no HTTP response message was received), we can record a version with:
- `body_url = nil`
- `body_hash = nil`
- `status = nil`
- `network_error = '<freeform text representation of the error>'`

This also adds a nice template for representing the raw content of a network error so analysts can see something meaningful and so that existing diff and display machinery doesn't break.

Fixes #1177.