### PR TITLE
Route differ to fake content for network errors

### DIFF
--- a/app/controllers/api/v0/diff_controller.rb
+++ b/app/controllers/api/v0/diff_controller.rb
@@ -34,8 +34,8 @@ class Api::V0::DiffController < Api::V0::ApiController
     to = change.version
 
     error_details = []
-    error_details << "version #{from.uuid}" if from.body_url.blank?
-    error_details << "version #{to.uuid}" if to.body_url.blank?
+    error_details << "version #{from.uuid}" if from.body_url.blank? && from.network_error.blank?
+    error_details << "version #{to.uuid}" if to.body_url.blank? && to.network_error.blank?
 
     unless error_details.empty?
       raise Api::InputError,

--- a/config/initializers/routing.rb
+++ b/config/initializers/routing.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  # Copy URL options from action_mailer config (which may be set differently per environment).
+  Rails.application.routes.default_url_options.merge!(config.action_mailer.default_url_options.clone)
+end

--- a/lib/differ/simple_diff.rb
+++ b/lib/differ/simple_diff.rb
@@ -28,10 +28,11 @@ module Differ
     protected
 
     def generate_diff(change, options)
+      # TODO: should we be accessing url_helpers from here? Is there a better way to pass URLs in?
       query = options.merge(
-        a: change.from_version.body_url,
+        a: change.from_version.body_url || Rails.application.routes.url_helpers.raw_api_v0_version_url(change.from_version),
         a_hash: change.from_version.body_hash,
-        b: change.version.body_url,
+        b: change.version.body_url || Rails.application.routes.url_helpers.raw_api_v0_version_url(change.version),
         b_hash: change.version.body_hash
       )
 

--- a/test/fixtures/changes.yml
+++ b/test/fixtures/changes.yml
@@ -16,6 +16,12 @@ page1_change_4_5:
   priority: 0.75
   significance: 0.5
 
+page1_change_5_network_error:
+  from_version: page1_v5
+  version: page1_v6
+  priority: 0.75
+  significance: 0.5
+
 page2_change_1_2:
   from_version: page2_v1
   version: page2_v2

--- a/test/fixtures/versions.yml
+++ b/test/fixtures/versions.yml
@@ -159,6 +159,14 @@ page1_v5:
     page_id: 11
     version_id: 115
 
+page1_v6:
+  page: home_page
+  body_url: null
+  capture_time: '2017-03-06T00:00:00Z'
+  body_hash: null
+  source_type: 'blah_blah'
+  network_error: 'net::ERR_NAME_NOT_RESOLVED'
+
 page3_v1:
   page: home_page_site3
   body_url: https://test-bucket.s3.amazonaws.com/page3_v1.html

--- a/test/lib/differ/simple_diff_test.rb
+++ b/test/lib/differ/simple_diff_test.rb
@@ -20,6 +20,25 @@ class Differ::SimpleDiffTest < ActiveSupport::TestCase
     assert_equal 'DIFF!', diff
   end
 
+  test 'it gets the diff for a change that has a network error' do
+    change = changes(:page1_change_5_network_error)
+
+    expected_request = stub_request(:any, 'http://testdiff.com')
+      .with(query: {
+        'a' => change.from_version.body_url,
+        'a_hash' => change.from_version.body_hash,
+        'b' => Rails.application.routes.url_helpers.raw_api_v0_version_url(change.version),
+        'b_hash' => ''
+      })
+      .to_return(body: 'DIFF!', status: 200)
+
+    differ = Differ::SimpleDiff.new('http://testdiff.com')
+    diff = differ.diff(change)
+
+    assert_requested expected_request
+    assert_equal 'DIFF!', diff
+  end
+
   test 'it sends any additional options as query parameters' do
     change = changes(:page1_change_1_2)
 


### PR DESCRIPTION
In #1184, we added a nice HTML representation for versions that were network errors instead of HTTP responses. But the differ routed around that and instead returned an error because there was no content to diff. This updates the differ to use the nice new HTML page for network errors.

That is, we are currently seeing diff results like:
<img width="1238" alt="Screenshot 2025-02-02 at 11 19 20 PM" src="https://github.com/user-attachments/assets/1f7336a3-7ff9-4896-927a-19cb0d3bfbf7" />

And we want to see an actual diff instead of an error.