### PR TITLE
Fix gzip writing bug introduced in #1185

### DIFF
--- a/lib/file_storage/s3.rb
+++ b/lib/file_storage/s3.rb
@@ -53,7 +53,8 @@ module FileStorage
       response = @client.put_object(
         bucket: @bucket,
         key: path,
-        body: @gzip ? ActiveSupport::Gzip.compress(content) : content,
+        # TODO: it would be nice to support streaming through the gzip compressor instead of buffering all `content`.
+        body: @gzip ? ActiveSupport::Gzip.compress(content.try(:read) || content) : content,
         acl: options.fetch(:acl, @acl),
         content_type: options.fetch(:content_type, 'application/octet-stream'),
         content_encoding: @gzip ? 'gzip' : nil

--- a/test/lib/file_storage/s3_test.rb
+++ b/test/lib/file_storage/s3_test.rb
@@ -114,4 +114,16 @@ class FileStorage::S3Test < ActiveSupport::TestCase
     storage.save_file('something.txt', text, content_type: 'text/plain')
     assert_requested(s3_put)
   end
+
+  test 's3 storage can write a gzipped stream' do
+    text = 'Hello from S3!'
+
+    s3_put = stub_request(:put, 'https://test-bucket.s3.us-west-2.amazonaws.com/something.txt')
+               .with(body: ActiveSupport::Gzip.compress(text), headers: { 'Content-Type' => 'text/plain', 'Content-Encoding' => 'gzip' })
+               .to_return(status: 200, body: '', headers: {})
+
+    storage = example_storage(gzip: true)
+    storage.save_file('something.txt', StringIO.new(text), content_type: 'text/plain')
+    assert_requested(s3_put)
+  end
 end

--- a/test/lib/file_storage/s3_test.rb
+++ b/test/lib/file_storage/s3_test.rb
@@ -119,8 +119,8 @@ class FileStorage::S3Test < ActiveSupport::TestCase
     text = 'Hello from S3!'
 
     s3_put = stub_request(:put, 'https://test-bucket.s3.us-west-2.amazonaws.com/something.txt')
-               .with(body: ActiveSupport::Gzip.compress(text), headers: { 'Content-Type' => 'text/plain', 'Content-Encoding' => 'gzip' })
-               .to_return(status: 200, body: '', headers: {})
+      .with(body: ActiveSupport::Gzip.compress(text), headers: { 'Content-Type' => 'text/plain', 'Content-Encoding' => 'gzip' })
+      .to_return(status: 200, body: '', headers: {})
 
     storage = example_storage(gzip: true)
     storage.save_file('something.txt', StringIO.new(text), content_type: 'text/plain')


### PR DESCRIPTION
In #1185, we added support for reading and writing gzipped data to S3. Unfortunately, the support only worked when writing a *string*, but not when writing an IO stream. It turns out that when saving a batched import to execute in a job, we write a stream. Oops.