### PR TITLE
Ensure network errors get counted for page status

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -306,7 +306,7 @@ class Page < ApplicationRecord
     total_time = 0.seconds
     error_time = 0.seconds
 
-    status_query = versions.where('status IS NOT NULL').order(capture_time: :desc)
+    status_query = versions.where('status IS NOT NULL OR network_error IS NOT NULL').order(capture_time: :desc)
     candidates = status_query.where('capture_time >= ?', start_time).to_a
     base_version = status_query.where('capture_time < ?', start_time).first
     candidates << base_version if base_version

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -201,6 +201,7 @@ class Version < ApplicationRecord
   end
 
   def effective_status # rubocop:disable Metrics/PerceivedComplexity
+    return 404 if network_error.present?
     return status if status.present? && status >= 400
 
     # Simple heuristics to determine whether a page with an OK status code


### PR DESCRIPTION
In #1184, I added the ability to track versions that represent network errors instead of valid HTTP reponses. I forgot about calculating the page's effective status, though, where these versions were getting ignored (since they have nil status). Ideally, I think we'd set a status of `0`, but there are some validations that disallow that and other places I need to be careful of causing problems. So the easiest thing for now is to treat a network error as a 404. Close enough to do the job.