### PR TITLE
Add more detail to `MismatchedHashError`

### DIFF
--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -58,8 +58,10 @@ module Api
       502
     end
 
-    def initialize(url, hash)
-      super("Response body for '#{url}' did not match expected hash (#{hash})")
+    def initialize(url, expected, actual = nil)
+      detail = "expected: '#{expected}'"
+      detail += ", 'actual: '#{actual}'" if actual
+      super("Response body for '#{url}' did not match expected hash (#{detail})")
     end
   end
 

--- a/lib/archiver/archiver.rb
+++ b/lib/archiver/archiver.rb
@@ -47,7 +47,7 @@ module Archiver
 
     hash = hash_content(response.body)
     if expected_hash && expected_hash != hash
-      raise Api::MismatchedHashError.new(url, expected_hash)
+      raise Api::MismatchedHashError.new(url, expected_hash, hash)
     end
 
     url =


### PR DESCRIPTION
While debugging some import issues this week, I realized it would have been *very* helpful to know what hash we actually got when trying to archive content, not just what hash we expected. This adds it to the error message.