### PR TITLE
Do a better job normalizing URLs

### DIFF
--- a/lib/tasks/data/renormalize_urls.rake
+++ b/lib/tasks/data/renormalize_urls.rake
@@ -1,0 +1,53 @@
+namespace :data do
+  desc 'Re-normalize the `url` field of Pages and PageUrls`.'
+  task :renormalize_urls, [] => [:environment] do
+    ActiveRecord::Migration.say_with_time('Renormalizing urls...') do
+      DataHelpers.with_activerecord_log_level(:error) do
+        last_update = Time.now - 1.minute
+        expected = Page.all.count
+        total = 0
+        changed = 0
+
+        Page.find_each(cursor: [:created_at, :uuid]) do |page|
+          did_change = false
+          url_records = page.urls.order(created_at: :asc, url: :asc).to_a
+          url_records.each do |record|
+            normalized_url = PageUrl.normalize_value_for(:url, record.url)
+
+            # PageUrls are meant to be immutable, so just delete the current record and try to re-create a new one with
+            # the same attributes.
+            next unless normalized_url != record.url
+
+            attributes = record.slice(:url, :from_time, :to_time, :notes)
+            record.destroy!
+            begin
+              page.urls.create!(attributes)
+            rescue ActiveRecord::RecordNotUnique
+              # It already exists, nothing to do!
+            end
+
+            did_change = true
+          end
+
+          # This could result in multiple pages with the same URL, but that's not explicitly an error and is also not a
+          # case we have in production, so don't bother trying to address it.
+          page.normalize_attribute(:url)
+          did_change ||= page.changed?
+          page.save!
+
+          puts "\n#{page.uuid}\n" if did_change
+          changed += 1 if did_change
+          total += 1
+          if Time.now - last_update >= 2
+            DataHelpers.log_progress(total, expected)
+            last_update = Time.now
+          end
+        end
+
+        DataHelpers.log_progress(total, expected)
+        puts "\n   -> #{changed} pages changed"
+        total
+      end
+    end
+  end
+end

--- a/lib/tasks/data/renormalize_urls.rake
+++ b/lib/tasks/data/renormalize_urls.rake
@@ -35,7 +35,6 @@ namespace :data do
           did_change ||= page.changed?
           page.save!
 
-          puts "\n#{page.uuid}\n" if did_change
           changed += 1 if did_change
           total += 1
           if Time.now - last_update >= 2

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -408,12 +408,15 @@ class ImportVersionsJobTest < ActiveJob::TestCase
   end
 
   test 'adds URL to an existing page if the version was matched to a page with a different URL' do
-    page = Page.create(url: 'https://example.gov/office')
+    url_a = 'https://example.gov/office'
+    url_b = 'http://example.gov/office/'
+
+    page = Page.create(url: url_a)
     import = Import.create_with_data(
       { user: users(:alice) },
       [
         {
-          page_url: 'http://example.gov/office/',
+          page_url: url_b,
           capture_time: Time.now - 1.second,
           body_url: 'https://test-bucket.s3.amazonaws.com/whatever',
           body_hash: 'abc'
@@ -424,8 +427,8 @@ class ImportVersionsJobTest < ActiveJob::TestCase
 
     assert_equal(1, page.versions.count, 'Version was added to the right page')
     assert_equal(
-      ['https://example.gov/office', 'http://example.gov/office/'],
-      page.urls.pluck(:url),
+      [url_a, url_b].sort,
+      page.urls.pluck(:url).sort,
       'New URL was added to the page'
     )
   end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -256,6 +256,12 @@ class PageTest < ActiveSupport::TestCase
     assert_equal(page.urls.count, 2, 'Changing page.url back to a previous value should not add a new PageUrl')
   end
 
+  test 'find_by_url matches by normalized URL' do
+    page = Page.create(title: 'Test Page', url: 'https://example.gov/some_page')
+    found = Page.find_by_url('HTTPS://examplE.Gov/some_page')
+    assert_equal(page, found)
+  end
+
   test 'find_by_url matches by url_key if there is no URL match' do
     page = Page.create(title: 'Test Page', url: 'https://example.gov/some_page')
     found = Page.find_by_url('http://example.gov/some_page/')


### PR DESCRIPTION
We've had a bunch small issues lately with multiple pages and other oddball matching issues because the way we normalize URLs is not expansive enough and not totally consistent between `Page` and `PageUrl`(!). This takes a more serious crack at normalization and also switches to Rails's new(ish) normalization tooling so we can clean up a lot of call-sites because normalization now Just Happens™ at the right times.

Ideally we could lean on Addressable or Surt for a real robust normalization algorithm, but Addressable requires more careful investigation (it would alter over 1,000 of our URLs in ways that are probably correct but I am 100% confident about) and Surt turns out to need some more work in order to be safe (see #1215 for more). So for now we have our own custom normalization.

This also includes a data migration to update all our `PageUrl` instances and clean up any duplication issues this might cause.

This is second part of #1209, and fixes it in conjunction with #1215.