### PR TITLE
Update `effective_status` to match task sheets

### DIFF
--- a/app/lib/surt.rb
+++ b/app/lib/surt.rb
@@ -35,6 +35,8 @@ module Surt
   end
 
   def self.parse_url(url)
+    return url if url.is_a?(Addressable::URI)
+
     url = url.strip.gsub(/[\r\n\t]/, '').gsub(/\s/, '%20')
     url = "http://#{url}" unless url.match?(/^[^:\/.]*:/)
     Addressable::URI.parse(url)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -257,7 +257,7 @@ class Version < ApplicationRecord
 
     # Oracle APEX includes this header on errors. It's ambiguous about the
     # kind of error, so only check this if the other heuristics didn't work.
-    return 500 if headers&.fetch('apex-debug-id', nil)&.downcase&.include?('level=error')
+    return 500 if headers.fetch('apex-debug-id', '').downcase.include?('level=error')
 
     status || 200
   end
@@ -276,13 +276,17 @@ class Version < ApplicationRecord
 
   def redirects
     urls = source_metadata&.fetch('redirects', nil) || []
-    raise TypeError.new("Unknown type for source_metadata.redirects on version: #{uuid}") unless urls.is_a?(Array)
+    raise TypeError, "Unknown type for source_metadata.redirects on version: #{uuid}" unless urls.is_a?(Array)
 
     # TODO: add option to fetch raw body and look for client redirects? FWIW, data from the EDGI crawler already
     #  includes these.
 
     urls.shift if urls.first == url
     urls
+  end
+
+  def headers
+    super || {}
   end
 
   def sync_page_title

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -202,7 +202,27 @@ class Version < ApplicationRecord
 
   def effective_status # rubocop:disable Metrics/PerceivedComplexity
     return 404 if network_error.present?
+
+    # Special case for 'greet.anl.gov', which seems to occasionally respond
+    # with a 500 status code even though it's definitely OK content.
+    # We've never seen a real 500 error there, so this is based on what we've
+    # seen with 404 errors.
+    return 200 if status == 500 && url&.include?('greet.anl.gov/') && !title&.include?('500')
+
+    # Otherwise we expect error statuses to really be errors.
     return status if status.present? && status >= 400
+
+    # Some pages redirect to a non-4xx response when they are removed.
+    redirected_to = redirects.last
+    if redirected_to
+      # Special case for the EPA "signpost" page, where they redirected hundreds
+      # of climate-related pages to instead of giving them 4xx status codes.
+      return 404 if redirected_to.ends_with?('epa.gov/sites/production/files/signpost/cc.html')
+
+      # We see a lot of redirects to the root of the same domain when a page is removed.
+      parsed_url = Addressable::URI.parse(url)
+      return 404 if parsed_url.path != '/' && Surt.surt(parsed_url.join('/')) == Surt.surt(redirected_to)
+    end
 
     # Simple heuristics to determine whether a page with an OK status code
     # actually represents an error.
@@ -224,6 +244,7 @@ class Version < ApplicationRecord
 
         # Other more special messages we've seen.
         return 404 if /\b(page|file)( was)? not found\b/.match?(t)
+        return 404 if /\bthis page isn['’]t available\b/.match?(t)
         return 403 if /\baccess denied\b/.match?(t)
         return 403 if /\brestricted access\b/.match?(t)
         return 500 if t == 'error'
@@ -234,11 +255,9 @@ class Version < ApplicationRecord
       end
     end
 
-    # Special case for the EPA "signpost" page, where they redirected hundreds
-    # of climate-related pages to instead of giving them 4xx status codes.
-    return 404 if
-      source_metadata &&
-      source_metadata['redirected_url']&.end_with?('epa.gov/sites/production/files/signpost/cc.html')
+    # Oracle APEX includes this header on errors. It's ambiguous about the
+    # kind of error, so only check this if the other heuristics didn't work.
+    return 500 if headers&.fetch('apex-debug-id', nil)&.downcase&.include?('level=error')
 
     status || 200
   end
@@ -253,6 +272,17 @@ class Version < ApplicationRecord
 
   def domain
     url.present? ? Addressable::URI.parse(url).host : '<unknown>'
+  end
+
+  def redirects
+    urls = source_metadata&.fetch('redirects', nil) || []
+    raise TypeError.new("Unknown type for source_metadata.redirects on version: #{uuid}") unless urls.is_a?(Array)
+
+    # TODO: add option to fetch raw body and look for client redirects? FWIW, data from the EDGI crawler already
+    #  includes these.
+
+    urls.shift if urls.first == url
+    urls
   end
 
   def sync_page_title


### PR DESCRIPTION
We now how have `effective_status` routines for versions in two places: this codebase and the web-monitoring-task sheets project (https://github.com/edgi-govdata-archiving/web-monitoring-task-sheets/blob/841016    4460eb4e970b93ea947af5d70e57768b22/analyst_sheets/analyze.py#L320-L392). This updates the two implementations to match.

Fixes #1193, #1200.