### PR TITLE
Normalize version header names to lower-case

### DIFF
--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -136,17 +136,6 @@ class ImportVersionsJob < ApplicationJob
     if record.key?('source_metadata')
       meta = record['source_metadata']
       record['media_type'] = meta['mime_type'] if meta.key?('mime_type')
-      unless record.key?('content_length')
-        length = meta.dig('headers', 'Content-Length')
-        record['content_length'] = length if length.present?
-      end
-
-      # Find headers in source_metadata if missing from the top level.
-      # TODO: remove once full transition to top level headers is complete.
-      if meta.key?('headers') && !record.key?('headers')
-        record['headers'] = meta['headers']
-        meta.delete('headers')
-      end
     end
     record
   end

--- a/app/lib/data_helpers.rb
+++ b/app/lib/data_helpers.rb
@@ -2,6 +2,7 @@
 module DataHelpers
   class ProgressLogger
     attr_accessor :total
+
     def initialize(expected, interval: 2.seconds)
       expected = DataHelpers.estimate_row_count(expected) if expected.is_a?(Class)
       @expected = expected

--- a/app/lib/data_helpers.rb
+++ b/app/lib/data_helpers.rb
@@ -1,5 +1,31 @@
 # Tools for working with database data. These are mostly used in rake tasks and migrations.
 module DataHelpers
+  class ProgressLogger
+    attr_accessor :total
+    def initialize(expected, interval: 2.seconds)
+      expected = DataHelpers.estimate_row_count(expected) if expected.is_a?(Class)
+      @expected = expected
+      @interval = interval
+      @last_update = Time.now - @interval
+      @total = 0
+    end
+
+    def increment(amount = 1, log: nil)
+      @total += amount
+      log = Time.now - @last_update >= @interval if log.nil?
+      self.log if log
+    end
+
+    def log(end_line: false)
+      DataHelpers.log_progress(@total, @expected, end_line:)
+      @last_update = Time.now
+    end
+
+    def complete
+      log(end_line: true)
+    end
+  end
+
   # Log and rewrite a progress indicator like "  x/y completed"
   def self.log_progress(completed, total, description: 'completed', end_line: false)
     ending = if $stdout.isatty
@@ -77,7 +103,15 @@ module DataHelpers
       changes = yield item
       next if changes.nil? || changes.empty?
 
-      changes = changes.collect {|value| connection.quote(value)}
+      changes = changes.collect do |value|
+        # TODO: consider using model_type.attribute_types[field_name] to determine to to serialize
+        if value.is_a? Hash
+          "#{connection.quote(value.to_json)}::jsonb"
+        else
+          connection.quote(value)
+        end
+      end
+
       values << "('#{item.uuid}', #{changes.join(', ')})"
     end
 
@@ -98,5 +132,15 @@ module DataHelpers
           #{model_type.table_name}.uuid = valueset.uuid::uuid
       QUERY
     )
+
+    values.length
+  end
+
+  def self.estimate_row_count(model)
+    model.connection.select_value(
+      'SELECT reltuples FROM pg_class WHERE relname = $1',
+      'ROW ESTIMATE',
+      [model.table_name]
+    ).to_i
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -53,6 +53,7 @@ class Version < ApplicationRecord
            class_name: 'Change',
            foreign_key: 'uuid_to'
 
+  # HTTP header names are case-insensitive. Store them lower-case for easy lookups/comparisons.
   normalizes :headers, with: ->(h) { h.transform_keys { |k| k.to_s.downcase } }
   before_create :derive_media_type
   before_create :derive_content_length

--- a/lib/tasks/data/20250330_downcase_header_names.rake
+++ b/lib/tasks/data/20250330_downcase_header_names.rake
@@ -1,0 +1,25 @@
+namespace :data do
+  desc 'Ensure the names of headers in Version records are downcased.'
+  task :'20250330_downcase_header_names', [] => [:environment] do
+    ActiveRecord::Migration.say_with_time('Downcasing header names...') do
+      DataHelpers.with_activerecord_log_level(:error) do
+        progress = DataHelpers::ProgressLogger.new(Version, interval: 10.seconds)
+        changed = 0
+
+        Version.in_batches(of: 200, cursor: [:created_at, :uuid]) do |batch|
+          changed += DataHelpers.bulk_update(batch, [:headers]) do |version|
+            progress.increment
+
+            unless version.headers.blank?
+              normalized = Version.normalize_value_for(:headers, version.headers)
+              [normalized] if normalized != version.headers
+            end
+          end
+        end
+
+        progress.complete
+        changed
+      end
+    end
+  end
+end

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -376,37 +376,6 @@ class ImportVersionsJobTest < ActiveJob::TestCase
     assert_equal(body_url, new_version.body_url)
   end
 
-  test 'sets "headers" based on "source_metadata.headers" for backwards-compatibility' do
-    now = Time.now.round
-    body_url = 'https://test-bucket.s3.amazonaws.com/example-v1'
-
-    stub_request(:any, body_url)
-      .to_return(body: 'Hello!', status: 200)
-
-    import = Import.create_with_data(
-      {
-        user: users(:alice)
-      },
-      [
-        {
-          page_url: pages(:home_page).url,
-          capture_time: now,
-          uri: body_url,
-          source_type: 'test_source',
-          source_metadata: {
-            'headers' => {
-              'x-fancy-header' => 'header_value'
-            }
-          }
-        }
-      ].map(&:to_json).join("\n")
-    )
-    ImportVersionsJob.perform_now(import)
-
-    new_version = pages(:home_page).versions.where(capture_time: now).first
-    assert_equal({ 'x-fancy-header' => 'header_value' }, new_version.headers)
-  end
-
   test 'adds URL to an existing page if the version was matched to a page with a different URL' do
     url_a = 'https://example.gov/office'
     url_b = 'http://example.gov/office/'

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -105,6 +105,15 @@ class VersionTest < ActiveSupport::TestCase
     assert_not(version.valid?, 'A text status was valid')
   end
 
+  test 'version header names are always lower-case strings' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      headers: { 'Content-Type': 'text/plain' }
+    )
+    assert_equal({ 'content-type' => 'text/plain' }, version.headers)
+  end
+
   test 'basic media types are valid' do
     version = Version.new(page: Page.new, media_type: 'text/plain')
     assert(version.valid?, 'A common media type should be valid')
@@ -146,5 +155,14 @@ class VersionTest < ActiveSupport::TestCase
     version = Version.new(page: Page.new, content_length: -10)
     assert_not(version.valid?, 'A negative content_length should not be valid')
     assert_includes(version.errors, :content_length)
+  end
+
+  test 'content_length is extracted from headers if not set' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      headers: { 'Content-Length' => '10342' }
+    )
+    assert_equal(10_342, version.content_length)
   end
 end


### PR DESCRIPTION
HTTP headers names are not case-sensitive, so normalize the keys on `Version.headers` to be lower-case strings to simplify usage. This also drops some long-deprecated import format handling where headers were part of `source_metadata`.

Includes a data migration task to normalize all *existing* headers in version records. Future updates will automatically be normalized by the new code.

Fixes #1194.