### PR TITLE
Drop support for `?different` query param

### DIFF
--- a/app/assets/data/swagger.yaml
+++ b/app/assets/data/swagger.yaml
@@ -130,7 +130,9 @@ paths:
           type: string
           in: query
           description: >
-            Only retrieve pages with versions captured during this time frame. Should be in the format `{start date}..{end date}`, where dates are ISO 8601 formatted. Either date can be left out to make the query open-ended.
+            Only retrieve pages with observed differences (versions that differed in some way from the previous
+            version) during this time frame. Should be in the format `{start date}..{end date}`, where dates
+            are ISO 8601 formatted. Either date can be left out to make the query open-ended.
 
             **Examples…**
 
@@ -262,13 +264,6 @@ paths:
 
 
             🚫 You must be logged in to use this parameter!
-        - name: different
-          in: query
-          description: >-
-            If false, include all versions, not just ones that are different from their preceding version.
-          required: false
-          type: string
-          default: true
         - name: include_change_from_previous
           in: query
           type: boolean
@@ -389,7 +384,7 @@ paths:
         As with other list endpoints, results are chunked. Follow the
         `links.next` property of the response to get the next chunk of results.
         (You can also iterate by manually making requests with sequential
-        `capture_time` parameters, but the `links.next` property willskip past
+        `capture_time` parameters, but the `links.next` property will skip past
         empty time ranges automatically for more efficient querying.)
       consumes:
         - application/json

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -228,10 +228,6 @@ class Api::V0::VersionsController < Api::V0::ApiController
   def version_collection
     collection = (page && page.versions) || Version.order(created_at: :asc)
 
-    if boolean_param(:different, default: true)
-      collection = collection.where(different: true)
-    end
-
     collection = collection.where({
       body_hash: params[:hash],
       source_type: params[:source_type]

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -16,7 +16,7 @@ class Page < ApplicationRecord
            -> { order(capture_time: :desc) },
            foreign_key: 'page_uuid',
            inverse_of: :page,
-           # You must explcitly dissociate or move versions before destroying.
+           # You must explicitly dissociate or move versions before destroying.
            # It's OK for a version to be orphaned from all pages, but we want
            # to make sure that's an intentional action and not accidental.
            dependent: :restrict_with_error
@@ -40,11 +40,11 @@ class Page < ApplicationRecord
             # `DISTINCT ON` statement has to be at the start of the WHERE clause, but
             # all public methods append to the end.
             relation.select_values = ['DISTINCT ON (versions.page_uuid) versions.*']
-            relation.order('versions.capture_time DESC').where(different: true)
+            relation.order('versions.capture_time DESC')
           end),
           foreign_key: 'page_uuid',
           class_name: 'Version'
-  # This needs a funky name because `changes` is a an activerecord method
+  # This needs a funky name because `changes` is an activerecord method
   has_many :tracked_changes, through: :versions
   has_many :urls,
            class_name: 'PageUrl',

--- a/app/models/page_url.rb
+++ b/app/models/page_url.rb
@@ -5,7 +5,7 @@
 #
 # Pages have many PageUrls, each representing a single URL associated with
 # the page. They can also store timeframe information and analyst-supplied
-# notes (both are human-managed, anecdocal information that should not be
+# notes (both are human-managed, anecdotal information that should not be
 # treated as mechanistic, measured, objective values -- for example, we can
 # never measure the true valid timeframe for a (page, URL) combination
 # because we only sample the responses from a web server on a regular basis

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -114,23 +114,23 @@ class Version < ApplicationRecord
     self.page.versions.reorder(capture_time: :asc).first
   end
 
-  def previous(different: true)
+  def previous(different: false)
     query = self.page.versions.where('capture_time < ?', self.capture_time)
     query = query.where(different: true) if different
     query.first
   end
 
-  def next(different: true)
+  def next(different: false)
     query = self.page.versions.where('capture_time > ?', self.capture_time)
     query = query.where(different: true) if different
     query.last
   end
 
-  def change_from_previous(different: true)
+  def change_from_previous(different: false)
     Change.between(from: previous(different:), to: self, create: nil)
   end
 
-  def change_from_next(different: true)
+  def change_from_next(different: false)
     Change.between(from: self, to: self.next(different:), create: nil)
   end
 
@@ -138,11 +138,11 @@ class Version < ApplicationRecord
     Change.between(from: earliest, to: self, create: nil)
   end
 
-  def ensure_change_from_previous(different: true)
+  def ensure_change_from_previous(different: false)
     Change.between(from: previous(different:), to: self, create: :new)
   end
 
-  def ensure_change_from_next(different: true)
+  def ensure_change_from_next(different: false)
     Change.between(from: self, to: self.next(different:), create: :new)
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -48,10 +48,6 @@ class Version < ApplicationRecord
   # legitimate scenario.
   belongs_to :page, foreign_key: :page_uuid, optional: true, inverse_of: :versions, touch: true
   has_many :tracked_changes, class_name: 'Change', foreign_key: 'uuid_to'
-  has_many :invalid_changes,
-           ->(version) { where.not(uuid_from: version.previous.uuid) },
-           class_name: 'Change',
-           foreign_key: 'uuid_to'
 
   # HTTP header names are case-insensitive. Store them lower-case for easy lookups/comparisons.
   normalizes :headers, with: ->(h) { h.transform_keys { |k| k.to_s.downcase } }

--- a/lib/tasks/analyze_changes.rake
+++ b/lib/tasks/analyze_changes.rake
@@ -12,7 +12,7 @@ task :analyze_changes, [:start_date, :end_date] => [:environment] do |_t, args|
   queued_jobs = 0
   DataHelpers.iterate_each(versions, batch_size: 1000) do |version|
     found_versions += 1
-    unless version.change_from_previous
+    if version.different? && version.change_from_previous.nil?
       AnalyzeChangeJob.perform_later(version)
       queued_jobs += 1
     end

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -379,25 +379,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test 'only lists versions that are different from the previous version' do
-    now = Time.now
-    page_versions = [
-      { body_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
-      { body_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days }
-    ].collect { |data| pages(:home_page).versions.create(data) }
-    page_versions.each(&:update_different_attribute)
-
-    sign_in users(:alice)
-    get(api_v0_versions_url)
-    assert_response(:success)
-    body = JSON.parse(@response.body)
-    uuids = body['data'].collect { |version| version['uuid'] }
-
-    assert_includes(uuids, page_versions[0].uuid)
-    assert_not_includes(uuids, page_versions[1].uuid)
-  end
-
-  test 'lists versions regardless if different from the previous version if ?different=false' do
+  test 'lists all versions regardless if different from the previous version' do
     now = Time.now
     page_versions = [
       { body_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
@@ -408,7 +390,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     page_versions.each(&:update_different_attribute)
 
     sign_in users(:alice)
-    get(api_v0_versions_url(params: { different: false }))
+    get(api_v0_versions_url)
     assert_response(:success)
     body = JSON.parse(@response.body)
     uuids = body['data'].collect { |version| version['uuid'] }


### PR DESCRIPTION
This covers part 1 of #1208 and generally removes support for the `different` query param, which doesn't behave like you would probably expect and regularly causes problems. It was designed in a world where we expected to have such frequent and continuous captures of pages that any time we had a "different" version, we knew it had *just* changed. The reality is that you can never get captures frequent enough to do that even in practical terms, and in theoretical terms it's just wrong. We've long since switched to always querying in a way that removes checking the `different` field, and it's past time to remove it from the API.

This leaves it in place in ONE spot of the API, which does not return an actual list of versions and thus does not have the same problems: `GET /pages?capture_time=abc...def` implicitly checks the `different` column because the goal is to tell you what pages had observed changes in that time period. We could back off that idea and just have it check whether there were any captures, but I think the valuable use cases for that are pretty rare. But maybe I’ll wind up revisiting that.

This also drops `Version.invalid_changes`, which I noticed is:
1. Not (no longer?) definitionally sensible, and
2. Not used anywhere.