### PR TITLE
Massive speedup for downcased headers migration

### DIFF
--- a/lib/tasks/data/20250330_downcase_header_names.rake
+++ b/lib/tasks/data/20250330_downcase_header_names.rake
@@ -31,10 +31,11 @@ namespace :data do
   # parameter. This *really* matters given the size of this table.
   def version_batches(collection, batch_size: 1000, &)
     anchor = nil
-    while true
+    loop do
       batch = collection.ordered(:capture_time, point: anchor).limit(batch_size)
       anchor = batch.to_a.last
       break unless anchor
+
       yield batch
     end
   end

--- a/lib/tasks/data/20250330_downcase_header_names.rake
+++ b/lib/tasks/data/20250330_downcase_header_names.rake
@@ -1,12 +1,15 @@
 namespace :data do
   desc 'Ensure the names of headers in Version records are downcased.'
-  task :'20250330_downcase_header_names', [] => [:environment] do
+  task :'20250330_downcase_header_names', [:start_date, :end_date] => [:environment] do |_t, args|
+    start_date = parse_time(args[:start_date], Time.new(2010, 1, 1))
+    end_date = parse_time(args[:end_date], Time.now + 1.day)
+
     ActiveRecord::Migration.say_with_time('Downcasing header names...') do
       DataHelpers.with_activerecord_log_level(:error) do
         progress = DataHelpers::ProgressLogger.new(Version, interval: 10.seconds)
         changed = 0
 
-        Version.in_batches(of: 200, cursor: [:created_at, :uuid]) do |batch|
+        version_batches(Version.where(capture_time: start_date...end_date), batch_size: 200) do |batch|
           changed += DataHelpers.bulk_update(batch, [:headers]) do |version|
             progress.increment
 
@@ -20,6 +23,19 @@ namespace :data do
         progress.complete
         changed
       end
+    end
+  end
+
+  # It turns out that the `.ordered` method we have for Version is more than
+  # 10x faster than AR's `in_batches`, even when using an optimized `cursor`
+  # parameter. This *really* matters given the size of this table.
+  def version_batches(collection, batch_size: 1000, &)
+    anchor = nil
+    while true
+      batch = collection.ordered(:capture_time, point: anchor).limit(batch_size)
+      anchor = batch.to_a.last
+      break unless anchor
+      yield batch
     end
   end
 end


### PR DESCRIPTION
The current version of the data migration is going pretty slow! This runs *much* faster. I had been hoping the new batched query support in the current version of Rails would solve this well enough for us, but it doesn’t.