### PR TITLE
Update Swagger docs for `Version` and `Page`

### DIFF
--- a/app/assets/data/swagger.yaml
+++ b/app/assets/data/swagger.yaml
@@ -1571,12 +1571,29 @@ definitions:
       content_length:
         type: integer
         description: Number of bytes in the version's HTTP response body.
+      different:
+        type: boolean
+        description: >
+          Whether this version has a different `body_hash` from the previous
+          version of the same page. Note this does *not* necessarily mean the
+          difference is meaningful.
       headers:
         type: object
         description: The headers from the version's original HTTP response.
       media_type:
         type: string
         description: The media type of the version, e.g. `text/html`.
+      network_error:
+        type: string
+        description: >-
+          If the version represents a network error instead of a valid HTTP
+          response, this will be a string indicating the type of error. This
+          represents situations where a web server has SSL certificate issues,
+          is offline, or is otherwise unreachable.
+
+          We do our best to only record this when the server appears to be
+          legitimately unreachable and not when a crawler or recording tool
+          was blocked by the server.
       source_type:
         type: string
       source_metadata:
@@ -1586,6 +1603,15 @@ definitions:
           field is free-form, but the data will generally follow one of the
           formats documented under the models section that has a name
           starting with "source_metadata_."  For example: source_metadata_versionista
+      status:
+        type: integer
+        description: The HTTP status code of the version.
+      title:
+        type: string
+        description: >-
+          The title of the version, if one could be extracted. For example,
+          the `<title>` element of an HTML document or the metadata title for
+          a PDF file.
   Page:
     type: object
     properties:
@@ -1605,6 +1631,23 @@ definitions:
           http://crawler.archive.org/articles/user_manual/glossary.html#surt
       title:
         type: string
+        description: >-
+          The title of the page. This is based on the page’s most recent
+          non-error version.
+      status:
+        type: integer
+        description: >-
+          The current *effective* HTTP status of the page. This uses a number
+          of heuristics to come up with a reasonable estimation. It aims to
+          work across situations where recordings are intermittently showing
+          errors and where HTTP responses respond with inaccurate status
+          codes, e.g. a 200 status code for a what is really a 404 error
+          message (in this case, effective status will be `404`).
+      active:
+        type: boolean
+        description: >-
+          Whether this page is actively monitored and new versions should be
+          or are being recorded.
       created_at:
         type: string
         format: datetime

--- a/app/assets/data/swagger.yaml
+++ b/app/assets/data/swagger.yaml
@@ -1579,7 +1579,9 @@ definitions:
           difference is meaningful.
       headers:
         type: object
-        description: The headers from the version's original HTTP response.
+        description: >-
+          The headers from the version's final HTTP response as an object.
+          All keys (header names) are lower-case.
       media_type:
         type: string
         description: The media type of the version, e.g. `text/html`.


### PR DESCRIPTION
I forgot to update these when I added `network_error`, but it looks like there have been a *lot* of updates and changes that have not hit these docs. This updates the fields in the `Page` and `Version` models, although there is still more that's not quite up-to-date here, I think.