### PR TITLE
Upgrade Nokogiri to v1.18.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,9 +234,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.8-arm64-darwin)
+    nokogiri (1.18.9-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     oj (3.16.11)
       bigdecimal (>= 3.0)


### PR DESCRIPTION
Fixes a security vulnerability. Dependabot should have created a PR for this, but something seems broken — its logs show that it *think* it made a PR, even though it did not.