### PR TITLE
Fix warnings about deprecated `:unprocessable_entity`

### DIFF
--- a/test/controllers/api/v0/annotations_controller_test.rb
+++ b/test/controllers/api/v0/annotations_controller_test.rb
@@ -168,7 +168,7 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
       as: :json,
       params: { 'priority' => 1.1 }
     )
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_not_equal(
       1.1,
       page.versions[0].change_from_previous.priority,
@@ -180,7 +180,7 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
       as: :json,
       params: { 'priority' => -1 }
     )
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_not_equal(
       -1,
       page.versions[0].change_from_previous.priority,
@@ -197,7 +197,7 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
       as: :json,
       params: { 'significance' => 1.1 }
     )
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_not_equal(
       1.1,
       page.versions[0].change_from_previous.priority,
@@ -209,7 +209,7 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
       as: :json,
       params: { 'significance' => -1 }
     )
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_not_equal(
       -1,
       page.versions[0].change_from_previous.priority,
@@ -328,7 +328,7 @@ class Api::V0::AnnotationsControllerTest < ActionDispatch::IntegrationTest
       params: '{}'
     )
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     body = JSON.parse(@response.body)
     assert(body.key?('errors'), 'Response should have an "errors" property')
   end

--- a/test/controllers/api/v0/urls_controller_test.rb
+++ b/test/controllers/api/v0/urls_controller_test.rb
@@ -149,7 +149,7 @@ class Api::V0::UrlsControllerTest < ActionDispatch::IntegrationTest
       as: :json,
       params: { page_url: { url: 'https://example.gov/some_new_url' } }
     )
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal 'application/json', @response.media_type
   end
 
@@ -178,7 +178,7 @@ class Api::V0::UrlsControllerTest < ActionDispatch::IntegrationTest
       as: :json,
       params: { page_url: { from_time: 'This is not a time' } }
     )
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal 'application/json', @response.media_type
   end
 
@@ -208,7 +208,7 @@ class Api::V0::UrlsControllerTest < ActionDispatch::IntegrationTest
 
     sign_in users(:alice)
     delete(api_v0_page_url_path(pages(:home_page), page_url))
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal 'application/json', @response.media_type
   end
 end


### PR DESCRIPTION
The IETF revised the name of status code 422 to "Unprocessable Content" and Rack also renamed the symbol used for the same status code. The previous symbol (`:unprocessable_entity`) has been deprecated and now logs lots of warnings. This fixes all the uses of it in our code, although we still get warnings from within Rails and WebMock.