### PR TITLE
Mark bad `climate.nasa.gov` redirects as 404

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -221,10 +221,8 @@ class Version < ApplicationRecord
       return 404 if redirected_to.ends_with?('epa.gov/sites/production/files/signpost/cc.html')
 
       # Special case for climate.nasa.gov getting moved with bad redirects for all the sub-pages.
-      return 404 if (
-        /^https?:\/\/climate.nasa.gov\/.+$/i.match?(url) &&
-        redirected_to.ends_with?('://science.nasa.gov/climate-change/')
-      )
+      return 404 if /^https?:\/\/climate.nasa.gov\/.+$/i.match?(url) &&
+                    redirected_to.ends_with?('://science.nasa.gov/climate-change/')
 
       # We see a lot of redirects to the root of the same domain when a page is removed.
       parsed_url = Addressable::URI.parse(url)


### PR DESCRIPTION
NASA went through a year-and-a-half long transition of pages from `climate.nasa.gov` to `science.nasa.gov/climate-change` that concluded a couple weeks ago. Unfortunately, when they finished, they started redirecting `climate.nasa.gov/*` to the new climate change home page instead of to the matching page on the new site, making a bunch of URLs effectively into 404s.