### PR TITLE
Disable Stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,1 +1,0 @@
-_extends: .github


### PR DESCRIPTION
Long ago, we added the stale issue bot to help manage the influx of a lot of ideas and brainstorming against a small implementation team. Today, the web-monitoring tools mostly just have one maintainer (me) and are not flooded with a lot of issues and ideas. Long-lived issues are more common, and they are helpful for me to keep track of things over the slow pace and timeframe in which I can individually address stuff. Stale bot feels like it is getting more in the way than helping in the current moment, so I’m disabling it. (Also, it’s deprecated! Where we need it, we should switch to [the action](https://github.com/actions/stale), which is the currently supported approach.)

Context: Stale bot seems to have been dead for a while (I actually thought we’d disabled it), but it seems to have woken up today and marked a huge pile of issues as stale across a whole lot of repos.

