### PR TITLE
Fix builds on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ commands:
 jobs:
   install_dependencies:
     executor: rails_executor
+    resource_class: 'medium+'
     steps:
       - checkout
       - setup_bundler


### PR DESCRIPTION
CircleCI seems to suddenly be killing bundler while it is installing, and the problem _appears_ to be specific to sassc. Looking at resource usage on jobs, I think compiling sassc is hitting a resource ceiling and Circle is then killing it.

We’ve generally always had a build of sassc cached, but the cache got removed (or at least is not being loaded) this month, so I'm not sure when this problem started happening in theory (resource limits lowered on Circle or it got more aggressive about killing processes), but that would be why we are only seeing it start to manifest now.

I’m addressing this by trying out larger resource classes; we’ll see what happens.