### PR TITLE
Expand what counts as root for effective_status

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -228,7 +228,11 @@ class Version < ApplicationRecord
 
       # We see a lot of redirects to the root of the same domain when a page is removed.
       parsed_url = Addressable::URI.parse(url)
-      return 404 if parsed_url.path != '/' && Surt.surt(parsed_url.join('/')) == Surt.surt(redirected_to)
+      unless home_path?(parsed_url.path)
+        redirect_host, redirect_path = Surt.surt(redirected_to).split(')', 2)
+        original_host = Surt.surt(url).split(')', 2)[0]
+        return 404 if home_path?(redirect_path) && redirect_host == original_host
+      end
     end
 
     # Simple heuristics to determine whether a page with an OK status code
@@ -316,5 +320,9 @@ class Version < ApplicationRecord
     return nil unless media.present? && media.match?(MEDIA_TYPE_PATTERN)
 
     normalize_media_type(media)
+  end
+
+  def home_path?(path)
+    path.match?(/^\/((index|home)(\.\w+)?)?$/)
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -167,4 +167,72 @@ class VersionTest < ActiveSupport::TestCase
     )
     assert_equal(10_342, version.content_length)
   end
+
+  test 'effective_status considers redirects to be ok' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      status: 200,
+      url: 'https://hazards.fema.gov/nri/take-action',
+      source_metadata: {
+        redirects: [
+          'https://hazards.fema.gov/nri/take-action',
+          'https://www.fema.gov/emergency-managers/practitioners/resilience-analysis-and-planning-tool'
+        ]
+      },
+      title: ''
+    )
+    assert_equal(200, version.effective_status)
+  end
+
+  test 'effective_status considers redirects to root as 404' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      url: 'https://waterdata.usgs.gov/nwis',
+      status: 200,
+      source_metadata: {
+        redirects: [
+          'https://waterdata.usgs.gov/nwis',
+          'https://waterdata.usgs.gov/'
+        ]
+      },
+      title: ''
+    )
+    assert_equal(404, version.effective_status)
+  end
+
+  test 'effective_status considers redirects to root-like paths as 404' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      url: 'https://eta.lbl.gov/justice-40',
+      status: 200,
+      source_metadata: {
+        redirects: [
+          'https://eta.lbl.gov/justice-40',
+          'https://eta.lbl.gov/home'
+        ]
+      },
+      title: ''
+    )
+    assert_equal(404, version.effective_status)
+  end
+
+  test 'effective_status considers redirects to cross-domain root as ok' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      url: 'https://waterdata.usgs.gov/nwis',
+      status: 200,
+      source_metadata: {
+        redirects: [
+          'https://waterdata.usgs.gov/nwis',
+          'https://www.usgs.gov/'
+        ]
+      },
+      title: ''
+    )
+    assert_equal(200, version.effective_status)
+  end
 end


### PR DESCRIPTION
This is a port of https://github.com/edgi-govdata-archiving/web-monitoring-task-sheets/pull/81.

Based on a conversation about a problematic analysis result with one of the analysts today.

It generally makes sense that if we consider `/index.html` to be a home page for other parts of the analysis, we should consider the same for what counts as the home page in effective status code calculations (we consider a redirect from a non-home to a home page of the same domain to be an error sink, and effectively a 404).