### PR TITLE
Redirects to `unblock.federalregister.gov` are bad captures

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -218,20 +218,27 @@ class Version < ApplicationRecord
     # Some pages redirect to a non-4xx response when they are removed.
     redirected_to = redirects.last
     if redirected_to
-      # Special case for the EPA "signpost" page, where they redirected hundreds
-      # of climate-related pages to instead of giving them 4xx status codes.
-      return 404 if redirected_to.ends_with?('epa.gov/sites/production/files/signpost/cc.html')
+      surt_url = Surt.surt(url)
+      surt_destination = Surt.surt(redirected_to)
 
-      # Special case for climate.nasa.gov getting moved with bad redirects for all the sub-pages.
-      return 404 if /^https?:\/\/climate.nasa.gov\/.+$/i.match?(url) &&
-                    redirected_to.ends_with?('://science.nasa.gov/climate-change/')
+      if surt_url != surt_destination
+        original_host, original_path = surt_url.split(')', 2)
+        redirect_host, redirect_path = surt_destination.split(')', 2)
 
-      # We see a lot of redirects to the root of the same domain when a page is removed.
-      parsed_url = Addressable::URI.parse(url)
-      unless home_path?(parsed_url.path)
-        redirect_host, redirect_path = Surt.surt(redirected_to).split(')', 2)
-        original_host = Surt.surt(url).split(')', 2)[0]
-        return 404 if home_path?(redirect_path) && redirect_host == original_host
+        # Special case for the EPA "signpost" page, where they redirected hundreds
+        # of climate-related pages to instead of giving them 4xx status codes.
+        return 404 if surt_destination == 'gov,epa)/sites/production/files/signpost/cc.html'
+
+        # Special case for climate.nasa.gov getting moved with bad redirects for all the sub-pages.
+        return 404 if original_host == 'gov,nasa,climate' &&
+                      surt_destination == 'gov,nasa,science)/climate-change'
+
+        return 429 if surt_destination == 'gov,federalregister,unblock)/'
+
+        # We see a lot of redirects to the root of the same domain when a page is removed.
+        return 404 if redirect_host == original_host &&
+                      !home_path?(original_path) &&
+                      home_path?(redirect_path)
       end
     end
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -235,4 +235,55 @@ class VersionTest < ActiveSupport::TestCase
     )
     assert_equal(200, version.effective_status)
   end
+
+  test 'effective_status considers redirects to EPA climate signpost page as 404' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      url: 'https://www3.epa.gov/climatechange/kids/solutions/index.html',
+      status: 200,
+      source_metadata: {
+        redirects: [
+          'https://www3.epa.gov/climatechange/kids/solutions/index.html',
+          'https://www.epa.gov/sites/production/files/signpost/cc.html'
+        ]
+      },
+      title: ''
+    )
+    assert_equal(404, version.effective_status)
+  end
+
+  test 'effective_status considers redirects to climate.nasa.gov to science.nasa.gov/climage-change as 404' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      url: 'https://climate.nasa.gov/explore/ask-nasa-climate/183/the-year-without-a-summer/',
+      status: 200,
+      source_metadata: {
+        redirects: [
+          'https://climate.nasa.gov/explore/ask-nasa-climate/183/the-year-without-a-summer/',
+          'https://science.nasa.gov/climate-change/'
+        ]
+      },
+      title: ''
+    )
+    assert_equal(404, version.effective_status)
+  end
+
+  test 'effective_status considers redirects to unblock.federalregister.gov as 429' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      url: 'https://www.federalregister.gov/documents/2021/07/27/2021-15122/national-oil-and-hazardous-substances-pollution-contingency-plan-monitoring-requirements-for-use-of',
+      status: 200,
+      source_metadata: {
+        redirects: [
+          'https://www.federalregister.gov/documents/2021/07/27/2021-15122/national-oil-and-hazardous-substances-pollution-contingency-plan-monitoring-requirements-for-use-of',
+          'https://unblock.federalregister.gov/'
+        ]
+      },
+      title: ''
+    )
+    assert_equal(429, version.effective_status)
+  end
 end


### PR DESCRIPTION
The Federal Register (and other OFR sites) are starting to redirect clients to https://unblock.federalregister.gov/ when they detect heavy crawling. This is a soft block, since it prevents capturing the intended web page. Instead of treating this as a normal, successful result (it has a 200 status code), treat it as though this is a 429 status code.

Unfortunately, there’s nothing useful in the headers or other aspects of the response that we can handle generically, so we just have to treat this as a special case, and try to be careful to only consider on redirects from other, meaningfully different URLs.

Fixes edgi-govdata-archiving/web-monitoring#198 for this repo (web-monitoring-db).