### PR TITLE
Enable Rails cops and address some of them

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,12 @@
 inherit_from: .rubocop_todo.yml
-require: rubocop-performance
 inherit_mode:
   merge:
     - Exclude
     - Include
+
+plugins:
+  - rubocop-performance
+  - rubocop-rails
 
 AllCops:
   NewCops: enable
@@ -121,6 +124,9 @@ Performance/Squeeze:
 
 Performance/StringInclude:
   Enabled: true
+
+Rails/I18nLocaleTexts:
+  Enabled: false
 
 Style/AccessorGrouping:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,6 +125,12 @@ Performance/Squeeze:
 Performance/StringInclude:
   Enabled: true
 
+Rails/DynamicFindBy:
+  Enabled: true
+  AllowedMethods:
+    - find_by_api_id
+    - find_by_url
+
 Rails/I18nLocaleTexts:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-Rails/TimeZone:
-  Enabled: false
-Rails/Date:
-  Enabled: false
-
 Rails/InverseOf:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,9 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-Rails/Pluck:
-  Enabled: false
-
 Rails/TimeZone:
   Enabled: false
 Rails/Date:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,9 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-Rails/DynamicFindBy:
-  Enabled: false
-
 Rails/Pluck:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,6 +6,67 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+Rails/DynamicFindBy:
+  Enabled: false
+
+Rails/Pluck:
+  Enabled: false
+
+Rails/TimeZone:
+  Enabled: false
+Rails/Date:
+  Enabled: false
+
+Rails/InverseOf:
+  Enabled: false
+
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+
+Rails/NegateInclude:
+  Enabled: false
+
+Rails/IndexWith:
+  Enabled: false
+
+Rails/RedundantActiveRecordAllMethod:
+  Enabled: false
+
+Rails/WhereEquals:
+  Enabled: false
+
+Rails/WhereExists:
+  Enabled: false
+
+Rails/WhereRange:
+  Enabled: false
+
+Rails/StrongParametersExpect:
+  Enabled: false
+
+Rails/Output:
+  Enabled: false
+
+Rails/ReversibleMigration:
+  Enabled: false
+
+Rails/ThreeStateBooleanColumn:
+  Enabled: false
+
+Rails/SkipsModelValidations:
+  Enabled: false
+
+Style/CollectionQuerying:
+  Enabled: false
+
+Rails/FindEach:
+  Enabled: false
+
+# I'm not sure this is accurate with our weird customized primary keys (ugh,
+# was such a bad idea). Needs some research.
+Rails/RedundantForeignKey:
+  Enabled: false
+
 # Offense count: 16
 Metrics/AbcSize:
   Max: 70

--- a/app/controllers/api/v0/annotations_controller.rb
+++ b/app/controllers/api/v0/annotations_controller.rb
@@ -71,7 +71,9 @@ class Api::V0::AnnotationsController < Api::V0::ApiController
   end
 
   def parent_change
-    @change ||= Change.find_by_api_id(params[:change_id])
+    return @change if defined?(@change)
+
+    @change = Change.find_by_api_id(params[:change_id])
   end
 
   def inclusions

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -113,7 +113,9 @@ class Api::V0::ApiController < ApplicationController
   def parse_date!(date)
     raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d:\d\d(:\d\d(\.\d+)?)?(Z|([+-]\d\d:?\d\d)))?$/)
 
-    Time.parse date
+    # TODO: should probably be Time.zone.iso8601 or Time.zone.rfc3339, but
+    #  need to make sure everywhere we are sending we conform to those.
+    Time.zone.parse(date) || raise(ArgumentError, 'Nope')
   rescue StandardError => _error
     raise Api::InputError, "Invalid date: '#{date}'"
   end

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -105,7 +105,7 @@ class Api::V0::ApiController < ApplicationController
   # querystring must explicitly set it. (`?param=true`, `?param=false`, etc.)
   def nullable_boolean_param(param)
     value = params[param]
-    return nil unless value.present?
+    return nil if value.blank?
 
     /^(true|t|1)$/i.match?(value.downcase.strip)
   end

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -110,14 +110,15 @@ class Api::V0::ApiController < ApplicationController
     /^(true|t|1)$/i.match?(value.downcase.strip)
   end
 
-  def parse_date!(date)
-    raise 'Nope' unless date.match?(/^\d{4}-\d\d-\d\d(T\d\d:\d\d(:\d\d(\.\d+)?)?(Z|([+-]\d\d:?\d\d)))?$/)
+  # Parse an ISO 8601-style date or datetime.
+  def parse_timestamp!(value, name: 'timestamp')
+    raise 'Nope' unless value.match?(/^\d{4}-\d\d-\d\d(T\d\d:\d\d(:\d\d(\.\d+)?)?(Z|([+-]\d\d:?\d\d)))?$/)
 
     # TODO: should probably be Time.zone.iso8601 or Time.zone.rfc3339, but
     #  need to make sure everywhere we are sending we conform to those.
-    Time.zone.parse(date) || raise(ArgumentError, 'Nope')
+    Time.zone.parse(value) || raise(ArgumentError, 'Nope')
   rescue StandardError => _error
-    raise Api::InputError, "Invalid date: '#{date}'"
+    raise Api::UnprocessableError, "Invalid #{name}: '#{value}'"
   end
 
   def parse_unbounded_range!(string_range, param = nil)
@@ -130,7 +131,7 @@ class Api::V0::ApiController < ApplicationController
 
       if from.nil? && to.nil?
         name = param ? "#{param} range" : 'Range'
-        raise Api::InputError, "#{name} must have a start or end"
+        raise Api::UnprocessableError, "#{name} must have a start or end"
       end
 
       [from, to]

--- a/app/controllers/api/v0/changes_controller.rb
+++ b/app/controllers/api/v0/changes_controller.rb
@@ -38,7 +38,9 @@ class Api::V0::ChangesController < Api::V0::ApiController
   end
 
   def change
-    @change ||= Change.find_by_api_id(params[:id])
+    return @change if defined?(@change)
+
+    @change = Change.find_by_api_id(params[:id])
   end
 
   def paging_path_for_change(*)

--- a/app/controllers/api/v0/diff_controller.rb
+++ b/app/controllers/api/v0/diff_controller.rb
@@ -33,7 +33,9 @@ class Api::V0::DiffController < Api::V0::ApiController
   protected
 
   def change
-    @change ||= Change.find_by_api_id(params[:id])
+    return @change if defined?(@change)
+
+    @change = Change.find_by_api_id(params[:id])
   end
 
   def ensure_diffable

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -153,9 +153,8 @@ class Api::V0::PagesController < Api::V0::ApiController
       collection = where_in_range_param(
         collection.where(versions: { different: true }),
         :capture_time,
-        'versions.capture_time',
-        &method(:parse_timestamp!)
-      )
+        'versions.capture_time'
+      ) { |value| parse_timestamp!(value) }
     end
 
     collection = where_in_interval_param(collection, :status)

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -40,14 +40,14 @@ class Api::V0::PagesController < Api::V0::ApiController
         results = Page
           .where(uuid: page_ids)
           .includes(:versions)
-          .order(sorting_params.present? ? sorting_params : 'pages.updated_at DESC')
+          .order(sorting_params.presence || 'pages.updated_at DESC')
           .order('versions.capture_time DESC')
           .as_json(include: :versions)
         # Tags and Maintainers
         additions = Page
           .where(uuid: page_ids)
           .includes(:tags, :maintainers)
-          .order(sorting_params.present? ? sorting_params : 'pages.updated_at DESC')
+          .order(sorting_params.presence || 'pages.updated_at DESC')
           .index_by(&:uuid)
         # Join them up!
         results.each do |page|
@@ -67,7 +67,7 @@ class Api::V0::PagesController < Api::V0::ApiController
         relations << :latest if should_include_latest
         Page
           .where(uuid: page_ids)
-          .order(sorting_params.present? ? sorting_params : 'updated_at DESC')
+          .order(sorting_params.presence || 'updated_at DESC')
           .includes(*relations)
           .as_json(include: relations)
       end

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -153,8 +153,9 @@ class Api::V0::PagesController < Api::V0::ApiController
       collection = where_in_range_param(
         collection.where(versions: { different: true }),
         :capture_time,
-        'versions.capture_time'
-      ) { |date_string| parse_date!(date_string) }
+        'versions.capture_time',
+        &method(:parse_timestamp!)
+      )
     end
 
     collection = where_in_interval_param(collection, :status)

--- a/app/controllers/api/v0/pages_controller.rb
+++ b/app/controllers/api/v0/pages_controller.rb
@@ -25,7 +25,7 @@ class Api::V0::PagesController < Api::V0::ApiController
       else
         [:updated_at]
       end
-    page_ids = id_query.pluck(:uuid, *order_attributes).collect {|data| data[0]}
+    page_ids = id_query.pluck(:uuid, *order_attributes).pluck(0)
 
     oj_mode = :strict
     result_data =

--- a/app/controllers/api/v0/urls_controller.rb
+++ b/app/controllers/api/v0/urls_controller.rb
@@ -79,7 +79,9 @@ class Api::V0::UrlsController < Api::V0::ApiController
   def parse_time(field, time_input)
     return if time_input.nil?
 
-    Time.parse(time_input)
+    # TODO: should probably be Time.zone.iso8601 or Time.zone.rfc3339, but
+    #  need to make sure everywhere we are sending we conform to those.
+    Time.zone.parse(time_input) || raise(ArgumentError, 'Nope')
   rescue ArgumentError
     raise Api::UnprocessableError, "`#{field}` was not a valid time or `null`"
   end

--- a/app/controllers/api/v0/urls_controller.rb
+++ b/app/controllers/api/v0/urls_controller.rb
@@ -70,19 +70,9 @@ class Api::V0::UrlsController < Api::V0::ApiController
       .permit(:url, :from_time, :to_time, :notes)
 
     result.slice('from_time', 'to_time').each do |key, value|
-      result[key] = parse_time(key, value)
+      result[key] = value.nil? ? nil : parse_timestamp!(value, name: key)
     end
 
     result
-  end
-
-  def parse_time(field, time_input)
-    return if time_input.nil?
-
-    # TODO: should probably be Time.zone.iso8601 or Time.zone.rfc3339, but
-    #  need to make sure everywhere we are sending we conform to those.
-    Time.zone.parse(time_input) || raise(ArgumentError, 'Nope')
-  rescue ArgumentError
-    raise Api::UnprocessableError, "`#{field}` was not a valid time or `null`"
   end
 end

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -79,7 +79,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
         params: { capture_time: "#{(next_to - SAMPLE_DAYS_DEFAULT.days).iso8601}..#{next_to.iso8601}" }
       )
     end
-    if time_range[1] < Time.now
+    if time_range[1] < Time.zone.now
       links[:prev] = api_v0_page_versions_sampled_url(
         page,
         params: { capture_time: "#{time_range[1].iso8601}..#{(time_range[1] + SAMPLE_DAYS_DEFAULT.days).iso8601}" }
@@ -202,7 +202,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
       from_time = time_range[0]
       time_range = [from_time, from_time + SAMPLE_DAYS_DEFAULT.days]
     else
-      to_time = Date.today + 1.day
+      to_time = Time.zone.today + 1.day
       time_range = [to_time - SAMPLE_DAYS_DEFAULT.days, to_time]
     end
 

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -118,7 +118,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
     elsif @version.body_url.nil?
       raise Api::NotFoundError, "No raw content for #{@version.uuid}."
     elsif Archiver.external_archive_url?(@version.body_url)
-      redirect_to @version.body_url, status: 301, allow_other_host: true
+      redirect_to @version.body_url, status: :moved_permanently, allow_other_host: true
     elsif Archiver.store.contains_url?(@version.body_url)
       # Get the file
       filename = File.basename(@version.body_url)

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -188,7 +188,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
   end
 
   def parse_sample_range
-    time_range = parse_unbounded_range!(params[:capture_time], 'capture_time') { |d| parse_date!(d).to_date } || []
+    time_range = parse_unbounded_range!(params[:capture_time], 'capture_time') { |d| parse_timestamp!(d).to_date } || []
 
     if time_range[0] && time_range[1]
       time_range[1] = time_range[1] + 1.day
@@ -241,7 +241,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
       end
     end
 
-    collection = where_in_range_param(collection, :capture_time) { |d| parse_date!(d) }
+    collection = where_in_range_param(collection, :capture_time, &method(:parse_timestamp!))
     where_in_interval_param(collection, :status)
   end
 

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -241,7 +241,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
       end
     end
 
-    collection = where_in_range_param(collection, :capture_time, &method(:parse_timestamp!))
+    collection = where_in_range_param(collection, :capture_time) { |value| parse_timestamp!(value) }
     where_in_interval_param(collection, :status)
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -17,7 +17,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     @invitation = current_invitation
     @invitation_error =
       if params[:invitation].present?
-        'The invitation code you used is not valid.' unless @invitation.present?
+        'The invitation code you used is not valid.' if @invitation.blank?
       else
         'You must provide an invitation code.'
       end

--- a/app/jobs/analyze_change_job.rb
+++ b/app/jobs/analyze_change_job.rb
@@ -162,24 +162,24 @@ class AnalyzeChangeJob < ApplicationJob
 
   def analyzable?(change)
     unless change && change.version.uuid != change.from_version.uuid
-      Rails.logger.debug "Cannot analyze change #{change.try(:api_id)}; same versions"
+      Rails.logger.debug { "Cannot analyze change #{change.try(:api_id)}; same versions" }
       return false
     end
 
     unless fetchable?(change.version.body_url)
-      Rails.logger.debug "Cannot analyze with non-http(s) source: #{change.api_id} (#{change.version.body_url})"
+      Rails.logger.debug { "Cannot analyze with non-http(s) source: #{change.api_id} (#{change.version.body_url})" }
       return false
     end
 
     unless fetchable?(change.from_version.body_url)
-      Rails.logger.debug "Cannot analyze with non-http(s) source: #{change.api_id} (#{change.from_version.body_url})"
+      Rails.logger.debug { "Cannot analyze with non-http(s) source: #{change.api_id} (#{change.from_version.body_url})" }
       return false
     end
 
     if diffable_media?(change.version) && diffable_media?(change.from_version)
       true
     else
-      Rails.logger.debug "Cannot analyze change #{change.api_id}; non-text media type"
+      Rails.logger.debug { "Cannot analyze change #{change.api_id}; non-text media type" }
       false
     end
   end

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -35,7 +35,7 @@ class ImportVersionsJob < ApplicationJob
   end
 
   def import_raw_data(raw_data)
-    last_update = Time.now
+    last_update = Time.zone.now
     each_json_line(raw_data) do |record, row, row_count|
       begin
         Rails.logger.info("Importing row #{row}/#{row_count}...") if Rails.env.development? && (row % 25).zero?
@@ -58,12 +58,12 @@ class ImportVersionsJob < ApplicationJob
       end
 
       # Jobs can be *long*, so make sure updates are persisted periodically.
-      next unless Time.now - last_update > 5
+      next unless Time.zone.now - last_update > 5
 
       # save! will set updated_at, but only if something else has changed.
       # Explicitly change updated_at so it always gets set, even if we don't
       # have any other messages to persist.
-      @import.updated_at = last_update = Time.now
+      @import.updated_at = last_update = Time.zone.now
       @import.save!
     end
     log(object: @import, operation: :finished)
@@ -177,7 +177,9 @@ class ImportVersionsJob < ApplicationJob
 
     url = record['url']
 
-    capture_time = Time.parse(record['capture_time'])
+    # TODO: should probably be Time.zone.iso8601 or Time.zone.rfc3339, but
+    #  need to make sure everywhere we are sending we conform to those.
+    capture_time = Time.zone.parse(record['capture_time']) || raise(ArgumentError, 'Invalid capture_time')
     existing_page = Page.find_by_url(url, at_time: capture_time)
     page = if existing_page
              log(object: existing_page, operation: :found, row:)

--- a/app/jobs/import_versions_job.rb
+++ b/app/jobs/import_versions_job.rb
@@ -49,7 +49,7 @@ class ImportVersionsJob < ApplicationJob
         messages = error.record.errors.full_messages.join(', ')
         @import.processing_errors << "Row #{row}: #{messages}"
       rescue StandardError => error
-        @import.processing_errors << if Rails.env.development? || Rails.env.test?
+        @import.processing_errors << if Rails.env.local?
                                        "Row #{row}: #{error.message}"
                                      else
                                        "Row #{row}: Unknown error occurred"
@@ -231,7 +231,7 @@ class ImportVersionsJob < ApplicationJob
       'skip' => 'skipped'
     }.fetch(operation, operation)
 
-    Rails.logger.debug("[import=#{@import.id}]#{"[row=#{row}]" if row} #{conjugated_operation.capitalize} #{object_name} #{object_id}")
+    Rails.logger.debug { "[import=#{@import.id}]#{"[row=#{row}]" if row} #{conjugated_operation.capitalize} #{object_name} #{object_id}" }
   end
 
   # iterate through a JSON array or series of newline-delimited JSON objects

--- a/app/lib/data_helpers.rb
+++ b/app/lib/data_helpers.rb
@@ -104,7 +104,7 @@ module DataHelpers
     values = []
     collection.each do |item|
       changes = yield item
-      next if changes.nil? || changes.empty?
+      next if changes.blank?
 
       changes = changes.collect do |value|
         # TODO: consider using model_type.attribute_types[field_name] to determine to to serialize

--- a/app/lib/data_helpers.rb
+++ b/app/lib/data_helpers.rb
@@ -9,19 +9,19 @@ module DataHelpers
       expected = DataHelpers.estimate_row_count(expected) if expected.is_a?(Class)
       @expected = expected
       @interval = interval
-      @last_update = Time.now - @interval
+      @last_update = Time.zone.now - @interval
       @total = 0
     end
 
     def increment(amount = 1, log: nil)
       @total += amount
-      log = Time.now - @last_update >= @interval if log.nil?
+      log = Time.zone.now - @last_update >= @interval if log.nil?
       self.log if log
     end
 
     def log(end_line: false)
       DataHelpers.log_progress(@total, @expected, end_line:)
-      @last_update = Time.now
+      @last_update = Time.zone.now
     end
 
     def complete
@@ -34,7 +34,7 @@ module DataHelpers
     ending = if $stdout.isatty
                end_line ? "\n" : ''
              else
-               " (#{Time.now})\n"
+               " (#{Time.zone.now})\n"
              end
     $stdout.write("\r   #{completed}/#{total} #{description}#{ending}")
   end
@@ -73,11 +73,11 @@ module DataHelpers
   # column, like :created_at, indexed).
   def self.iterate_time(collection, interval: nil, start_time: nil, end_time: nil, field: :created_at, &)
     interval ||= 15.days
-    start_time ||= Time.new(2016, 1, 1)
+    start_time ||= Time.zone.local(2016, 1, 1)
     batch_size = 500
     total = 0
 
-    while start_time < (end_time || Time.now)
+    while start_time < (end_time || Time.zone.now)
       iterable = collection.order({ field => :asc }).where_in_unbounded_range(
         field,
         [start_time, start_time + interval]
@@ -128,7 +128,7 @@ module DataHelpers
           #{model_type.table_name}
         SET
           #{setters},
-          updated_at = #{connection.quote(Time.now)}
+          updated_at = #{connection.quote(Time.zone.now)}
         FROM
           (values #{values.join(',')}) as valueset(uuid, #{fields.join(', ')})
         WHERE

--- a/app/lib/numeric_interval.rb
+++ b/app/lib/numeric_interval.rb
@@ -8,8 +8,8 @@ class NumericInterval
     components = string_interval.match(/^\s*(\[|\()?\s*(\d*(?:\.\d+)?)\s*(?:,|\.\.)\s*(\d*(?:\.\d+)?)\s*(\]|\))?\s*$/)
     raise ArgumentError, "Invalid interval format: '#{string_interval}'" unless components
 
-    @start = components[2].present? ? components[2].to_f : nil
-    @end = components[3].present? ? components[3].to_f : nil
+    @start = components[2].presence&.to_f
+    @end = components[3].presence&.to_f
     @start_open = components[1] == '('
     @end_open = components[4] == ')'
     raise ArgumentError, 'An interval must have at least a start or end.' unless @start || @end

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -3,8 +3,8 @@
 class Annotation < ApplicationRecord
   include UuidPrimaryKey
 
-  belongs_to :change, foreign_key: :change_uuid, required: true, inverse_of: :annotations
-  belongs_to :author, class_name: 'User', foreign_key: :author_id, required: true
+  belongs_to :change, foreign_key: :change_uuid, optional: false, inverse_of: :annotations
+  belongs_to :author, class_name: 'User', foreign_key: :author_id, optional: false
   validate :annotation_must_be_an_object
   validate :priority_in_range
   validate :significance_in_range

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -3,8 +3,8 @@
 class Change < ApplicationRecord
   include UuidPrimaryKey
 
-  belongs_to :version, foreign_key: :uuid_to, required: true
-  belongs_to :from_version, class_name: 'Version', foreign_key: :uuid_from, required: true
+  belongs_to :version, foreign_key: :uuid_to, optional: false
+  belongs_to :from_version, class_name: 'Version', foreign_key: :uuid_from, optional: false
   has_many :annotations, -> { order(updated_at: :asc) }, foreign_key: 'change_uuid', inverse_of: :change
   validate :from_must_be_before_to_version
   validates :priority, allow_nil: true, numericality: {

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -2,8 +2,8 @@
 
 class Import < ApplicationRecord
   belongs_to :user
-  enum :status, [:pending, :processing, :complete]
-  enum :update_behavior, [:skip, :replace, :merge], suffix: :existing_records
+  enum :status, { pending: 0, processing: 1, complete: 2 }
+  enum :update_behavior, { skip: 0, replace: 1, merge: 2 }, suffix: :existing_records
   validates :file, presence: true
   after_initialize :ensure_processing_errors_and_warnings
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -12,11 +12,11 @@ class Invitation < ApplicationRecord
   validates :email, format: { with: /\A[^@\s]+@([^@.\s]+\.)+[^@.\s]+\z/ }, allow_blank: true
 
   def self.expired
-    where('expires_on < ?', Time.now)
+    where('expires_on < ?', Time.zone.now)
   end
 
   def expired?
-    expires_on.present? && Time.now < expires_on
+    expires_on.present? && Time.zone.now < expires_on
   end
 
   def send_email
@@ -65,7 +65,7 @@ class Invitation < ApplicationRecord
 
   def ensure_expiration
     unless expires_on
-      self.expires_on = Time.now + EXPIRATION_DAYS.days
+      self.expires_on = Time.zone.now + EXPIRATION_DAYS.days
     end
   end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -70,7 +70,7 @@ class Invitation < ApplicationRecord
   end
 
   def not_for_existing_user
-    if email.present? && User.find_by_email(email)
+    if email.present? && User.find_by(email: email)
       errors.add(:email, 'is already a user')
     end
   end

--- a/app/models/merged_page.rb
+++ b/app/models/merged_page.rb
@@ -12,5 +12,5 @@ class MergedPage < ApplicationRecord
   belongs_to :target,
              class_name: 'Page',
              foreign_key: :target_uuid,
-             required: true
+             optional: false
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -284,7 +284,7 @@ class Page < ApplicationRecord
   # just take the latest status. Instead, we only treat failures as real
   # if they account for a certain percentage of the last N days.
   def calculate_status(relative_to: nil)
-    now = relative_to || Time.now
+    now = relative_to || Time.zone.now
     start_time = now - STATUS_TIMEFRAME
     last_time = now
     latest_error = nil

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -69,8 +69,8 @@ class Page < ApplicationRecord
   end)
 
   normalizes :url, with: ->(url) { PageUrl.normalize_url(url) }
-  after_create :ensure_domain_and_news_tags
   before_save :derive_url_key
+  after_create :ensure_domain_and_news_tags
   after_save :ensure_page_urls
   validate :url_must_have_domain
   validates :status,
@@ -274,7 +274,7 @@ class Page < ApplicationRecord
   end
 
   def url_must_have_domain
-    unless domain.present?
+    if domain.blank?
       errors.add(:url, 'must have a domain')
     end
   end

--- a/app/models/page_url.rb
+++ b/app/models/page_url.rb
@@ -63,7 +63,7 @@ class PageUrl < ApplicationRecord
   #   https://github.com/rails/rails/issues/39833
   # Then this can just be: `where('timeframe @> ?::timestamp', Time.now)`
   def self.current(at_time = nil)
-    at_time ||= Time.now
+    at_time ||= Time.zone.now
     where('from_time <= ?', at_time).where('to_time > ?', at_time)
   end
 

--- a/app/models/page_url.rb
+++ b/app/models/page_url.rb
@@ -17,7 +17,7 @@
 class PageUrl < ApplicationRecord
   include UuidPrimaryKey
 
-  belongs_to :page, foreign_key: :page_uuid, required: true, inverse_of: :urls
+  belongs_to :page, foreign_key: :page_uuid, optional: false, inverse_of: :urls
 
   validates :url,
             allow_nil: false,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
   has_one :invitation, class_name: 'Invitation', foreign_key: 'redeemer_id', inverse_of: :redeemer
 
   validates :permissions, contains_only: PERMISSIONS
-  attribute :permissions, :string, array: true, default: [VIEW_PERMISSION, ANNOTATE_PERMISSION]
+  attribute :permissions, :string, array: true, default: -> { [VIEW_PERMISSION, ANNOTATE_PERMISSION] }
 
   # We need to enforce some additional constraints on the invitation
   # relationship. This isn't great, but the best way I can see for now.

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,8 @@ module WebpageVersionsDb
     #  think segregating lib and app/lib on autoloading is better.)
     config.eager_load_paths << "#{Rails.root}/lib/api"
 
+    config.time_zone = 'UTC'
+
     # Re-instate secrets for simpler management of `secret_key_base`. We currently use other methods for managing
     # secrets in production, so it doesn't make a whole lot of sense to migrate to credentials (which replaces secrets)
     # just for secret_key_base (which then requires more complicated key management work).

--- a/db/migrate/20170517222310_change_annotation_author_to_not_null.rb
+++ b/db/migrate/20170517222310_change_annotation_author_to_not_null.rb
@@ -13,7 +13,7 @@ class ChangeAnnotationAuthorToNotNull < ActiveRecord::Migration[5.1]
 
     if default_author.nil?
       # create a default_author if one doesn't exist
-      default_author = User.create(email: 'someone@example.com', password: 'password', confirmed_at: Time.now)
+      default_author = User.create(email: 'someone@example.com', password: 'password', confirmed_at: Time.zone.now)
     end
 
     do_sql(

--- a/db/migrate/20180207061655_copy_agency_and_site_fields_to_associated_models.rb
+++ b/db/migrate/20180207061655_copy_agency_and_site_fields_to_associated_models.rb
@@ -3,8 +3,8 @@
 class CopyAgencyAndSiteFieldsToAssociatedModels < ActiveRecord::Migration[5.1]
   def up
     DataHelpers.iterate_each(Page.order(created_at: :asc)) do |page|
-      page.add_maintainer(page.agency) unless page.agency.blank?
-      page.add_tag("site:#{page.site}") unless page.site.blank?
+      page.add_maintainer(page.agency) if page.agency.present?
+      page.add_tag("site:#{page.site}") if page.site.present?
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,7 +25,7 @@ unless admin
   password = 'PASSWORD'
   admin.email = 'seed-admin@example.com'
   admin.password = password
-  admin.confirmed_at = Time.now
+  admin.confirmed_at = Time.zone.now
   admin.permissions << 'manage_users'
   admin.save
 

--- a/lib/differ/differ.rb
+++ b/lib/differ/differ.rb
@@ -34,7 +34,7 @@ module Differ
   # diffs when a diff algorithm is updated. Note that this is broad, though:
   # updating this date will expire all diff types.
   def self.cache_date
-    @cache_date ||= Time.new(2000, 1, 1)
+    @cache_date ||= Time.zone.local(2000, 1, 1)
   end
 
   def self.cache_date=(time)

--- a/lib/jwt_tools/jwt_auth_strategy.rb
+++ b/lib/jwt_tools/jwt_auth_strategy.rb
@@ -12,7 +12,7 @@ module JwtTools
       user_id = claims['sub'].match(/^User:(\d+)$/).try(:[], 1)
       return pass unless user_id
 
-      user = User.find_by_id(user_id)
+      user = User.find_by(id: user_id)
       if user
         success! user
       else

--- a/lib/jwt_tools/jwt_coder.rb
+++ b/lib/jwt_tools/jwt_coder.rb
@@ -24,7 +24,7 @@ module JwtTools
     def self.encode(payload)
       raise 'You must set a private key for tokens in order to use JWTs' unless @private_key
 
-      expire_at = payload[:exp] || (Time.now + expire_after)
+      expire_at = payload[:exp] || (Time.zone.now + expire_after)
 
       payload = payload.dup
       payload[:exp] = expire_at.to_i

--- a/lib/tasks/analyze_changes.rake
+++ b/lib/tasks/analyze_changes.rake
@@ -2,8 +2,8 @@
 
 desc 'Queue up automated analysis for versions added in a given timeframe.'
 task :analyze_changes, [:start_date, :end_date] => [:environment] do |_t, args|
-  start_date = args.key?(:start_date) ? Time.parse(args[:start_date]) : nil
-  end_date = args.key?(:end_date) ? Time.parse(args[:end_date]) : nil
+  start_date = args.key?(:start_date) ? Time.zone.iso8601(args[:start_date]) : nil
+  end_date = args.key?(:end_date) ? Time.zone.iso8601(args[:end_date]) : nil
   puts "Searching for versions between #{start_date || 'now'} and #{end_date || 'now'}"
 
   versions = Version

--- a/lib/tasks/data/20180926_move_versionista_s3_data.rake
+++ b/lib/tasks/data/20180926_move_versionista_s3_data.rake
@@ -5,8 +5,8 @@ namespace :data do
   # smaller, more time-constrained chunks.
   desc 'Migrate raw Versionista data stored in S3 to new EDGI-owned bucket.'
   task :'20180926_move_versionista_s3_data', [:start_date, :end_date] => [:environment] do |_t, args|
-    start_date = args[:start_date] && Time.parse(args[:start_date])
-    end_date = args[:end_date] && Time.parse(args[:end_date])
+    start_date = args[:start_date] && Time.zone.iso8601(args[:start_date])
+    end_date = args[:end_date] && Time.zone.iso8601(args[:end_date])
 
     new_versionista_prefix = 'https://edgi-wm-versionista.s3.amazonaws.com/'
     old_versionista_prefixes = [
@@ -69,7 +69,7 @@ namespace :data do
             versions
           SET
             uri = valueset.uri,
-            updated_at = #{Version.connection.quote(Time.now)}
+            updated_at = #{Version.connection.quote(Time.zone.now)}
           FROM
             (values #{values.join(',')}) as valueset(uuid, uri)
           WHERE

--- a/lib/tasks/data/20181124_normalize_titles.rake
+++ b/lib/tasks/data/20181124_normalize_titles.rake
@@ -43,7 +43,7 @@ namespace :data do
             #{model_type.table_name}
           SET
             title = valueset.title,
-            updated_at = #{Version.connection.quote(Time.now)}
+            updated_at = #{Version.connection.quote(Time.zone.now)}
           FROM
             (values #{values.join(',')}) as valueset(uuid, title)
           WHERE

--- a/lib/tasks/data/20181205_update_version_different.rake
+++ b/lib/tasks/data/20181205_update_version_different.rake
@@ -14,7 +14,7 @@ namespace :data do
     ordered_pages = Page.all.order(uuid: :asc)
     total_pages = ordered_pages.count
 
-    last_update = Time.now - 10
+    last_update = Time.zone.now - 10
     page_count = 0
     version_count = 0
     DataHelpers.iterate_each(ordered_pages, batch_size: 500) do |page|
@@ -39,10 +39,10 @@ namespace :data do
       end
 
       page_count += 1
-      if page_count == total_pages || Time.now - last_update > 2
+      if page_count == total_pages || Time.zone.now - last_update > 2
         print "  Updated #{page_count} of #{total_pages} pages (#{version_count} versions, date: #{page.created_at})\r"
         $stdout.flush
-        last_update = Time.now
+        last_update = Time.zone.now
       end
     end
 

--- a/lib/tasks/data/20190112_add_page_domain_tags.rake
+++ b/lib/tasks/data/20190112_add_page_domain_tags.rake
@@ -5,16 +5,16 @@ namespace :data do
   task :'20190112_add_page_domain_tags', [] => [:environment] do |_t|
     ActiveRecord::Migration.say_with_time('Updating domain tags on pages...') do
       DataHelpers.with_activerecord_log_level(:error) do
-        last_update = Time.now
+        last_update = Time.zone.now
         completed = 0
         total = Page.all.count
 
         DataHelpers.iterate_each(Page.all.order(created_at: :asc), batch_size: 500) do |page|
           page.ensure_domain_tags
           completed += 1
-          if Time.now - last_update > 2
+          if Time.zone.now - last_update > 2
             DataHelpers.log_progress(completed, total, description: 'pages tagged')
-            last_update = Time.now
+            last_update = Time.zone.now
           end
         end
 

--- a/lib/tasks/data/20200218_add_version_length_media_type.rake
+++ b/lib/tasks/data/20200218_add_version_length_media_type.rake
@@ -4,8 +4,8 @@ namespace :data do
   desc 'Set `content_length`, and `media_type` on all versions.'
   task :'20200218_add_version_length_media_type', [:force, :start_date, :end_date] => [:environment] do |_t, args|
     force = ['t', 'true', '1'].include? args.fetch(:force, '').downcase
-    start_date = parse_time(args[:start_date], Time.new(2016, 1, 1))
-    end_date = parse_time(args[:end_date], Time.now + 1.day)
+    start_date = parse_time(args[:start_date], Time.zone.local(2016, 1, 1))
+    end_date = parse_time(args[:end_date], 1.day.from_now)
 
     update_version_length_media_type(start_date, end_date, force:)
   end
@@ -17,7 +17,7 @@ namespace :data do
     ActiveRecord::Migration.say_with_time('Updating content_length and media_type on versions...') do
       DataHelpers.with_activerecord_log_level(:error) do
         query = Version
-        last_update = Time.now
+        last_update = Time.zone.now
         completed = 0
         fixed = 0
         total = query
@@ -29,10 +29,10 @@ namespace :data do
           changed = update_version_media_length(version, force:)
           fixed += 1 if changed
           completed += 1
-          if Time.now - last_update > progress_interval
+          if Time.zone.now - last_update > progress_interval
             message = "#{fixed} updated, #{completed}"
             DataHelpers.log_progress(message, total, description: 'versions processed')
-            last_update = Time.now
+            last_update = Time.zone.now
           end
         end
 
@@ -129,6 +129,6 @@ namespace :data do
   end
 
   def parse_time(value, default)
-    value ? Time.parse(value) : default
+    value ? Time.zone.iso8601(value) : default
   end
 end

--- a/lib/tasks/data/20201116_add_page_urls.rake
+++ b/lib/tasks/data/20201116_add_page_urls.rake
@@ -5,7 +5,7 @@ namespace :data do
   task :'20201116_add_page_urls', [] => [:environment] do
     ActiveRecord::Migration.say_with_time('Adding page.urls records for existing pages...') do
       DataHelpers.with_activerecord_log_level(:error) do
-        last_update = Time.now - 1.minute
+        last_update = 1.minute.ago
         expected = Page.all.count
         total = 0
 
@@ -13,9 +13,9 @@ namespace :data do
           page.urls.find_or_create_by(url: page.url)
           total += 1
 
-          if Time.now - last_update >= 2
+          if Time.zone.now - last_update >= 2
             DataHelpers.log_progress(total, expected)
-            last_update = Time.now
+            last_update = Time.zone.now
           end
         end
 

--- a/lib/tasks/data/20210605_fill_version_headers_from_source_metadata.rake
+++ b/lib/tasks/data/20210605_fill_version_headers_from_source_metadata.rake
@@ -44,7 +44,7 @@ namespace :data do
   end
 
   def update_version_headers(version, force: false)
-    return false if version.headers && !version.headers.empty? && !force
+    return false if version.headers.present? && !force
     return false unless version.source_metadata
 
     version.headers = version.source_metadata['headers']

--- a/lib/tasks/data/20210605_fill_version_headers_from_source_metadata.rake
+++ b/lib/tasks/data/20210605_fill_version_headers_from_source_metadata.rake
@@ -4,8 +4,8 @@ namespace :data do
   desc 'Fill in `headers` on versions from `source_metadata.headers`.'
   task :'20210605_fill_version_headers_from_source_metadata', [:force, :start_date, :end_date] => [:environment] do |_t, args|
     force = ['t', 'true', '1'].include? args.fetch(:force, '').downcase
-    start_date = parse_time(args[:start_date], Time.new(2016, 1, 1))
-    end_date = parse_time(args[:end_date], Time.now + 1.day)
+    start_date = parse_time(args[:start_date], Time.zone.local(2016, 1, 1))
+    end_date = parse_time(args[:end_date], 1.day.from_now)
 
     fill_version_headers(start_date, end_date, force:)
   end
@@ -17,7 +17,7 @@ namespace :data do
     ActiveRecord::Migration.say_with_time('Filling in headers on versions...') do
       DataHelpers.with_activerecord_log_level(:error) do
         query = Version
-        last_update = Time.now
+        last_update = Time.zone.now
         completed = 0
         fixed = 0
         total = query
@@ -29,10 +29,10 @@ namespace :data do
           changed = update_version_headers(version, force:)
           fixed += 1 if changed
           completed += 1
-          if Time.now - last_update > progress_interval
+          if Time.zone.now - last_update > progress_interval
             message = "#{fixed} updated, #{completed}"
             DataHelpers.log_progress(message, total, description: 'versions processed')
-            last_update = Time.now
+            last_update = Time.zone.now
           end
         end
 

--- a/lib/tasks/data/20230119_reset_page_titles.rake
+++ b/lib/tasks/data/20230119_reset_page_titles.rake
@@ -5,7 +5,7 @@ namespace :data do
   task :'20230119_reset_page_titles', [] => [:environment] do
     ActiveRecord::Migration.say_with_time('Resetting titles for existing pages...') do
       DataHelpers.with_activerecord_log_level(:error) do
-        last_update = Time.now - 1.minute
+        last_update = 1.minute.ago
         expected = Page.all.count
         total = 0
 
@@ -13,9 +13,9 @@ namespace :data do
           page.update_page_title
           total += 1
 
-          if Time.now - last_update >= 2
+          if Time.zone.now - last_update >= 2
             DataHelpers.log_progress(total, expected)
-            last_update = Time.now
+            last_update = Time.zone.now
           end
         end
 

--- a/lib/tasks/data/20250330_downcase_header_names.rake
+++ b/lib/tasks/data/20250330_downcase_header_names.rake
@@ -3,8 +3,8 @@
 namespace :data do
   desc 'Ensure the names of headers in Version records are downcased.'
   task :'20250330_downcase_header_names', [:start_date, :end_date] => [:environment] do |_t, args|
-    start_date = parse_time(args[:start_date], Time.new(2010, 1, 1))
-    end_date = parse_time(args[:end_date], Time.now + 1.day)
+    start_date = parse_time(args[:start_date], Time.zone.local(2010, 1, 1))
+    end_date = parse_time(args[:end_date], 1.day.from_now)
 
     ActiveRecord::Migration.say_with_time('Downcasing header names...') do
       DataHelpers.with_activerecord_log_level(:error) do

--- a/lib/tasks/data/20250330_downcase_header_names.rake
+++ b/lib/tasks/data/20250330_downcase_header_names.rake
@@ -20,7 +20,7 @@ namespace :data do
           changed += DataHelpers.bulk_update(batch, [:headers]) do |version|
             progress.increment
 
-            unless version.headers.blank?
+            if version.headers.present?
               normalized = Version.normalize_value_for(:headers, version.headers)
               [normalized] if normalized != version.headers
             end

--- a/lib/tasks/data/renormalize_urls.rake
+++ b/lib/tasks/data/renormalize_urls.rake
@@ -5,7 +5,7 @@ namespace :data do
   task :renormalize_urls, [] => [:environment] do
     ActiveRecord::Migration.say_with_time('Renormalizing urls...') do
       DataHelpers.with_activerecord_log_level(:error) do
-        last_update = Time.now - 1.minute
+        last_update = 1.minute.ago
         expected = Page.all.count
         total = 0
         changed = 0
@@ -39,9 +39,9 @@ namespace :data do
 
           changed += 1 if did_change
           total += 1
-          if Time.now - last_update >= 2
+          if Time.zone.now - last_update >= 2
             DataHelpers.log_progress(total, expected)
-            last_update = Time.now
+            last_update = Time.zone.now
           end
         end
 

--- a/lib/tasks/import_from_sheets.rake
+++ b/lib/tasks/import_from_sheets.rake
@@ -73,7 +73,7 @@ task :import_annotations_from_sheet, [:sheet_id, :user_email, :tabs, :start_row,
 end
 
 def change_for_version_url(url)
-  return nil unless url.present?
+  return nil if url.blank?
 
   # Handle versionista URLs
   match = /versionista\.com\/\d+\/\d+\/(\d+):(\d+)/.match(url)

--- a/lib/tasks/update_page_statuses.rake
+++ b/lib/tasks/update_page_statuses.rake
@@ -21,7 +21,7 @@ task :update_page_statuses, [:where, :at_time] => [:environment] do |_t, args|
         page_set = page_set
           .joins(:versions)
           .where('pages.status IS NULL')
-          .where('versions.status IS NOT NULL')
+          .where.not(versions: { status: nil })
       end
 
       last_update = Time.now

--- a/lib/tasks/update_page_statuses.rake
+++ b/lib/tasks/update_page_statuses.rake
@@ -8,7 +8,7 @@ task :update_page_statuses, [:where, :at_time] => [:environment] do |_t, args|
 
   at_time = args[:at_time]
   if at_time.present? && at_time != 'latest_version'
-    at_time = Time.parse(args[:at_time])
+    at_time = Time.zone.parse(args[:at_time]) || raise(ArgumentError, 'Nope')
   end
 
   ActiveRecord::Migration.say_with_time('Updating status codes on pages...') do
@@ -24,7 +24,7 @@ task :update_page_statuses, [:where, :at_time] => [:environment] do |_t, args|
           .where.not(versions: { status: nil })
       end
 
-      last_update = Time.now
+      last_update = Time.zone.now
       completed = 0
       total = page_set.size
 
@@ -37,9 +37,9 @@ task :update_page_statuses, [:where, :at_time] => [:environment] do |_t, args|
 
         page.update_status(relative_to:)
         completed += 1
-        if Time.now - last_update > 2
+        if Time.zone.now - last_update > 2
           DataHelpers.log_progress(completed, total)
-          last_update = Time.now
+          last_update = Time.zone.now
         end
       end
 

--- a/test/controllers/api/v0/imports_controller_test.rb
+++ b/test/controllers/api/v0/imports_controller_test.rb
@@ -603,7 +603,7 @@ class Api::V0::ImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can skip versions that are the same as the previous version if ?skip_unchanged_versions=true' do
-    now = Time.now
+    now = Time.zone.now
     page = Page.create(url: 'http://thecoolest.com/for/reals')
     page.versions.create(capture_time: now - 5.days, body_hash: 'abc', source_type: 'a')
     page.versions.create(capture_time: now - 4.days, body_hash: 'def', source_type: 'b')

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -385,7 +385,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
       include_versions: true,
       capture_time: "..#{now.iso8601}"
     )
-    found_ids = get_all_pages(base_url).collect {|page| page['uuid']}.sort
+    found_ids = get_all_pages(base_url).pluck('uuid').sort
     all_ids = Page
       .where_in_unbounded_range('versions.capture_time', [nil, now])
       .pluck(:uuid)

--- a/test/controllers/api/v0/pages_controller_test.rb
+++ b/test/controllers/api/v0/pages_controller_test.rb
@@ -362,7 +362,7 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     # pages, so the actual page records on a given result page may not match up
     # with the full set.
     first_page = Page.first
-    now = Time.now
+    now = Time.zone.now
     Page.transaction do
       100.times {|i| first_page.versions.create(capture_time: now - i.days)}
 
@@ -402,16 +402,16 @@ class Api::V0::PagesControllerTest < ActionDispatch::IntegrationTest
     # Add some versions out of order
     sign_in users(:alice)
     page = Page.first
-    page.versions.create(capture_time: Time.now - 5.days)
-    page.versions.create(capture_time: Time.now)
-    page.versions.create(capture_time: Time.now - 1.day)
+    page.versions.create(capture_time: 5.days.ago)
+    page.versions.create(capture_time: Time.zone.now)
+    page.versions.create(capture_time: 1.day.ago)
     page = Page.last
-    page.versions.create(capture_time: Time.now - 5.days)
-    page.versions.create(capture_time: Time.now)
-    page.versions.create(capture_time: Time.now - 1.day)
+    page.versions.create(capture_time: 5.days.ago)
+    page.versions.create(capture_time: Time.zone.now)
+    page.versions.create(capture_time: 1.day.ago)
 
     get api_v0_pages_path(
-      capture_time: "..#{(Time.now - 1.day).iso8601}",
+      capture_time: "..#{1.day.ago.iso8601}",
       include_latest: true
     )
     assert_response(:success)

--- a/test/controllers/api/v0/urls_controller_test.rb
+++ b/test/controllers/api/v0/urls_controller_test.rb
@@ -139,7 +139,7 @@ class Api::V0::UrlsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal 'application/json', @response.media_type
     body = JSON.parse @response.body
-    assert_equal(new_from_time.round, Time.parse(body.dig('data', 'from_time')).round)
+    assert_equal(new_from_time.round, Time.zone.iso8601(body.dig('data', 'from_time')).round)
   end
 
   test 'cannot update url.url' do

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -292,7 +292,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   test 'can synthesize a raw response body for network errors' do
     page = pages(:home_page)
     version = page.versions.create(
-      capture_time: Time.now - 1.minute,
+      capture_time: 1.minute.ago,
       body_url: nil,
       body_hash: nil,
       source_type: 'edgi_statuscheck_v0',
@@ -382,7 +382,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'lists all versions regardless if different from the previous version' do
-    now = Time.now
+    now = Time.zone.now
     page_versions = [
       { body_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
       { body_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -216,7 +216,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     get api_v0_page_versions_url(pages(:home_page), source_type: 'pagefreezer')
 
     body_json = JSON.parse @response.body
-    types = body_json['data'].collect { |v| v['source_type'] }.uniq
+    types = body_json['data'].pluck('source_type').uniq
 
     assert_equal ['pagefreezer'], types, 'Got versions with wrong source_type'
   end
@@ -395,7 +395,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     get(api_v0_versions_url)
     assert_response(:success)
     body = JSON.parse(@response.body)
-    uuids = body['data'].collect { |version| version['uuid'] }
+    uuids = body['data'].pluck('uuid')
 
     assert_includes(uuids, page_versions[0].uuid)
     assert_includes(uuids, page_versions[1].uuid)

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -361,7 +361,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     page = pages(:home_page)
 
     get(api_v0_page_versions_url(page, params: { include_total: true }))
-    assert_response(400)
+    assert_response(:bad_request)
     assert_equal('application/json', @response.media_type)
   end
 
@@ -386,7 +386,7 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     page_versions = [
       { body_hash: 'abc', source_type: 'a', capture_time: now - 2.days },
       { body_hash: 'abc', source_type: 'b', capture_time: now - 1.9.days },
-      { body_hash: 'abc', source_type: 'a', capture_time: now - 1.days },
+      { body_hash: 'abc', source_type: 'a', capture_time: now - 1.day },
       { body_hash: 'abc', source_type: 'b', capture_time: now - 0.9.days }
     ].collect { |data| pages(:home_page).versions.create(data) }
     page_versions.each(&:update_different_attribute)

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -144,12 +144,12 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
       pages(:home_page),
       capture_time: 'ugh'
     )
-    assert_response :bad_request
+    assert_response :unprocessable_entity
 
     body_json = JSON.parse @response.body
     assert body_json.key?('errors'), 'Response should have an "errors" property'
-    assert_match(/date/i, body_json['errors'][0]['title'],
-                 'Error does not mention date')
+    assert_match(/timestamp/i, body_json['errors'][0]['title'],
+                 'Error does not mention timestamp')
   end
 
   test 'can filter versions by date range' do
@@ -203,12 +203,12 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
       pages(:home_page),
       capture_time: 'ugh..2017-03-04'
     )
-    assert_response :bad_request
+    assert_response :unprocessable_entity
 
     body_json = JSON.parse @response.body
     assert body_json.key?('errors'), 'Response should have an "errors" property'
-    assert_match(/date/i, body_json['errors'][0]['title'],
-                 'Error does not mention date')
+    assert_match(/timestamp/i, body_json['errors'][0]['title'],
+                 'Error does not mention timestamp')
   end
 
   test 'can filter versions by source_type' do

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -10,20 +10,20 @@ class ImportVersionsJobTest < ActiveJob::TestCase
       @logs ||= []
     end
 
-    def debug(message)
-      logs.push(message)
+    def debug(message = nil)
+      logs.push(block_given? ? yield : message)
     end
 
-    def info(message)
-      logs.push(message)
+    def info(message = nil)
+      logs.push(block_given? ? yield : message)
     end
 
-    def warn(message)
-      logs.push(message)
+    def warn(message = nil)
+      logs.push(block_given? ? yield : message)
     end
 
-    def error(message)
-      logs.push(message)
+    def error(message = nil)
+      logs.push(block_given? ? yield : message)
     end
   end
 

--- a/test/jobs/import_versions_job_test.rb
+++ b/test/jobs/import_versions_job_test.rb
@@ -82,7 +82,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
       {
         **raw_data.with_indifferent_access.except(:page_maintainers, :page_tags),
         'page_uuid' => page.uuid,
-        'capture_time' => Time.parse(raw_data[:capture_time]),
+        'capture_time' => Time.zone.iso8601(raw_data[:capture_time]),
         'headers' => raw_data[:headers].transform_keys(&:downcase),
         'network_error' => nil
       }.sort.to_h,
@@ -122,7 +122,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
       {
         **raw_data.with_indifferent_access.except(:page_maintainers, :page_tags),
         'page_uuid' => page.uuid,
-        'capture_time' => Time.parse(raw_data[:capture_time]),
+        'capture_time' => Time.zone.iso8601(raw_data[:capture_time]),
         'headers' => nil,
         'body_url' => nil,
         'body_hash' => nil,
@@ -271,7 +271,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
 
   test 'does not import versions for inactive pages' do
     page_versions_count = pages(:inactive_page).versions.count
-    now = Time.now
+    now = Time.zone.now
 
     import = Import.create_with_data(
       {
@@ -298,7 +298,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
 
   test 'does not import versions if URL did not match body_hash' do
     page_versions_count = pages(:home_page).versions.count
-    now = Time.now
+    now = Time.zone.now
 
     stub_request(:any, 'http://example.com')
       .to_return(body: 'Hello!', status: 200)
@@ -327,7 +327,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
 
   test 'allows "hash" instead of "body_hash"' do
     page_versions_count = pages(:home_page).versions.count
-    now = Time.now
+    now = Time.zone.now
 
     stub_request(:any, 'http://example.com')
       .to_return(body: 'Hello!', status: 200)
@@ -357,7 +357,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
 
   test 'allows "version_hash" instead of "body_hash"' do
     page_versions_count = pages(:home_page).versions.count
-    now = Time.now
+    now = Time.zone.now
 
     stub_request(:any, 'http://example.com')
       .to_return(body: 'Hello!', status: 200)
@@ -387,7 +387,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
 
   test 'gets content_length from archiver' do
     page_versions_count = pages(:home_page).versions.count
-    now = Time.now
+    now = Time.zone.now
     hash = 'fd9b8b0e5e12450cae7c43aba3209ffc54bf5cbcb4bcaf70287d9201c6845d1d'
 
     stub_request(:any, 'http://example.com')
@@ -424,7 +424,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
   end
 
   test 'normalizes media_type' do
-    now = Time.now
+    now = Time.zone.now
     import = Import.create_with_data(
       {
         user: users(:alice)
@@ -447,7 +447,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
   end
 
   test 'allows "uri" instead of "body_url" for backwards-compatibility' do
-    now = Time.now.round
+    now = Time.zone.now.round
     body_url = 'https://test-bucket.s3.amazonaws.com/example-v1'
 
     stub_request(:any, body_url)
@@ -483,7 +483,7 @@ class ImportVersionsJobTest < ActiveJob::TestCase
       [
         {
           url: url_b,
-          capture_time: Time.now - 1.second,
+          capture_time: 1.second.ago,
           body_url: 'https://test-bucket.s3.amazonaws.com/whatever',
           body_hash: 'abc'
         }

--- a/test/lib/numeric_interval_test.rb
+++ b/test/lib/numeric_interval_test.rb
@@ -7,8 +7,8 @@ class NumericIntervalTest < ActiveSupport::TestCase
     interval = NumericInterval.new('[1.1,2]')
     assert_equal(1.1, interval.start, 'Incorrect start value')
     assert_equal(2, interval.end, 'Incorrect end value')
-    assert(!interval.start_open, 'Incorrect start_open value')
-    assert(!interval.end_open, 'Incorrect end_open value')
+    assert_not(interval.start_open, 'Incorrect start_open value')
+    assert_not(interval.end_open, 'Incorrect end_open value')
   end
 
   test 'it parses open intervals' do

--- a/test/models/application_record_test.rb
+++ b/test/models/application_record_test.rb
@@ -6,7 +6,7 @@ class ApplicationRecordTest < ActiveSupport::TestCase
   test 'where_in_unbounded_range on an association should not return repeated primary model records' do
     pages = Page.where_in_unbounded_range(
       'versions.capture_time',
-      [Time.parse('2017-01-01'), nil]
+      [Time.zone.iso8601('2017-01-01'), nil]
     ).pluck(:uuid).to_a
 
     unique_pages = pages.uniq

--- a/test/models/invitation_test.rb
+++ b/test/models/invitation_test.rb
@@ -13,11 +13,11 @@ class InvitationTest < ActiveSupport::TestCase
     assert invitation.valid?
 
     invitation = Invitation.create(email: 'blahblahblah')
-    assert !invitation.valid?
+    assert_not invitation.valid?
   end
 
   test 'invitations for existing users are invalid' do
     invitation = Invitation.create(email: users(:alice).email)
-    assert !invitation.valid?
+    assert_not invitation.valid?
   end
 end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -26,11 +26,11 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title)
 
     page.versions.create(title: 'Newest Version', capture_time: '2017-03-05T00:00:00Z')
-    refute(page.changed?, 'The page was left with unsaved changes')
+    assert_not(page.changed?, 'The page was left with unsaved changes')
     assert_equal('Newest Version', page.title, 'The page title should always sync against the title of the version with the most recent capture time')
     page.versions.create(title: 'Older Version', capture_time: '2017-03-01T00:00:00Z')
-    refute(page.changed?, 'The page was left with unsaved changes')
-    refute_equal('Older Version', page.title, 'The page title should not sync against the title of a newly created version with an older capture time')
+    assert_not(page.changed?, 'The page was left with unsaved changes')
+    assert_not_equal('Older Version', page.title, 'The page title should not sync against the title of a newly created version with an older capture time')
   end
 
   test "page title should not sync with a version's title if it's nil or blank" do
@@ -38,10 +38,10 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title)
 
     page.versions.create(capture_time: '2017-03-05T00:00:00Z')
-    refute(page.changed?, 'The page was left with unsaved changes')
+    assert_not(page.changed?, 'The page was left with unsaved changes')
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has a nil title')
     page.versions.create(title: '', capture_time: '2017-03-05T00:00:00Z')
-    refute(page.changed?, 'The page was left with unsaved changes')
+    assert_not(page.changed?, 'The page was left with unsaved changes')
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it has an empty title')
   end
 
@@ -50,7 +50,7 @@ class PageTest < ActiveSupport::TestCase
     assert_equal('Page One', page.title)
 
     page.versions.create(capture_time: '2017-03-05T00:00:00Z', status: 500, title: 'Page One v2')
-    refute(page.changed?, 'The page was left with unsaved changes')
+    assert_not(page.changed?, 'The page was left with unsaved changes')
     assert_equal('Page One', page.title, 'The page title should not sync with the incoming version if it is an error status')
   end
 

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -202,18 +202,18 @@ class PageTest < ActiveSupport::TestCase
 
   test 'pages can calculate their effective status code' do
     page = Page.create(url: 'https://example.gov/')
-    page.versions.create(capture_time: Time.now - 15.days, status: 200)
-    page.versions.create(capture_time: Time.now - 12.days, status: 500)
-    page.versions.create(capture_time: Time.now - 10.days, status: 200)
-    page.versions.create(capture_time: Time.now - 1.day, status: 404)
+    page.versions.create(capture_time: 15.days.ago, status: 200)
+    page.versions.create(capture_time: 12.days.ago, status: 500)
+    page.versions.create(capture_time: 10.days.ago, status: 200)
+    page.versions.create(capture_time: 1.day.ago, status: 404)
     assert_equal(page.update_status, 200, 'Status should be 200 when most of the timeframe was non-error versions')
   end
 
   test 'pages use the latest error code for their status when there is an error' do
     page = Page.create(url: 'https://example.gov/')
-    page.versions.create(capture_time: Time.now - 15.days, status: 200)
-    page.versions.create(capture_time: Time.now - 12.days, status: 500)
-    page.versions.create(capture_time: Time.now - 10.days, status: 403)
+    page.versions.create(capture_time: 15.days.ago, status: 200)
+    page.versions.create(capture_time: 12.days.ago, status: 500)
+    page.versions.create(capture_time: 10.days.ago, status: 403)
     assert_equal(page.update_status, 403, 'Status should match the latest error code')
 
     page.latest.update(status: 404)
@@ -222,19 +222,19 @@ class PageTest < ActiveSupport::TestCase
 
   test 'pages use version#effective_status, not raw status' do
     page = Page.create(url: 'https://example.gov/')
-    page.versions.create(capture_time: Time.now - 15.days, status: 200, title: '404 Not Found')
-    page.versions.create(capture_time: Time.now - 12.days, status: 200, title: '404 Not Found')
-    page.versions.create(capture_time: Time.now - 10.days, status: 200, title: '404 Not Found')
-    page.versions.create(capture_time: Time.now - 1.day, status: 200, title: '404 Not Found')
+    page.versions.create(capture_time: 15.days.ago, status: 200, title: '404 Not Found')
+    page.versions.create(capture_time: 12.days.ago, status: 200, title: '404 Not Found')
+    page.versions.create(capture_time: 10.days.ago, status: 200, title: '404 Not Found')
+    page.versions.create(capture_time: 1.day.ago, status: 200, title: '404 Not Found')
     assert_equal(page.update_status, 404, 'Status should be the effective_status of the versions')
   end
 
   test 'pages can calculate a status even when some versions have no status' do
     page = Page.create(url: 'https://example.gov/')
-    page.versions.create(capture_time: Time.now - 12.days)
+    page.versions.create(capture_time: 12.days.ago)
     assert_nil(page.update_status, 'Status should be nil if no versions have status')
 
-    page.versions.create(capture_time: Time.now - 15.days, status: 200)
+    page.versions.create(capture_time: 15.days.ago, status: 200)
     assert_equal(page.update_status, 200, 'Status should be based only on versions with status codes')
   end
 
@@ -273,13 +273,13 @@ class PageTest < ActiveSupport::TestCase
   test 'find_by_url prefers pages currently at the given URL' do
     url = 'https://example.gov/'
     old_page = Page.create(title: 'Old page', url:)
-    old_page.urls.first.update(to_time: Time.now - 5.days)
+    old_page.urls.first.update(to_time: 5.days.ago)
 
     new_page = Page.create(title: 'New Page', url:)
-    new_page.urls.first.update(from_time: Time.now - 5.days)
+    new_page.urls.first.update(from_time: 5.days.ago)
 
     older_page = Page.create(title: 'Ancient Page', url:)
-    older_page.urls.first.update(to_time: Time.now - 10.days)
+    older_page.urls.first.update(to_time: 10.days.ago)
 
     assert_equal('New Page', Page.find_by_url('http://example.gov/').title)
   end
@@ -287,13 +287,13 @@ class PageTest < ActiveSupport::TestCase
   test 'find_by_url returns latest non-current page if no current match is found' do
     url = 'https://example.gov/'
     old_page = Page.create(title: 'Old page', url:)
-    old_page.urls.first.update(to_time: Time.now - 5.days)
+    old_page.urls.first.update(to_time: 5.days.ago)
 
     new_page = Page.create(title: 'New Page', url:)
-    new_page.urls.first.update(to_time: Time.now - 2.days)
+    new_page.urls.first.update(to_time: 2.days.ago)
 
     older_page = Page.create(title: 'Ancient Page', url:)
-    older_page.urls.first.update(to_time: Time.now - 10.days)
+    older_page.urls.first.update(to_time: 10.days.ago)
 
     assert_equal('New Page', Page.find_by_url('http://example.gov/').title)
   end
@@ -351,8 +351,8 @@ class PageTest < ActiveSupport::TestCase
     # Round the times, since precision seems to be lost in the DB.
     merge_audit = merge_record.audit_data
     merge_audit.update({
-      'created_at' => Time.zone.parse(merge_audit['created_at']).round.as_json,
-      'updated_at' => Time.zone.parse(merge_audit['updated_at']).round.as_json
+      'created_at' => Time.zone.iso8601(merge_audit['created_at']).round.as_json,
+      'updated_at' => Time.zone.iso8601(merge_audit['updated_at']).round.as_json
     })
     assert_equal(
       {

--- a/test/models/page_url_test.rb
+++ b/test/models/page_url_test.rb
@@ -27,8 +27,8 @@ class PageUrlTest < ActiveSupport::TestCase
 
   test 'PageUrls.current returns only records with matching from_time and to_time' do
     page = Page.create(url: 'https://example.gov/')
-    page.urls.first.update(to_time: Time.now - 1.day)
-    page.urls.create(url: 'https://example.gov/2', from_time: Time.now - 1.day)
+    page.urls.first.update(to_time: 1.day.ago)
+    page.urls.create(url: 'https://example.gov/2', from_time: 1.day.ago)
     current = page.urls.current
     assert_equal(1, current.count)
     assert_equal('https://example.gov/2', current.first.url)
@@ -36,9 +36,9 @@ class PageUrlTest < ActiveSupport::TestCase
 
   test 'PageUrls.current works with specified times instead of the current time' do
     page = Page.create(url: 'https://example.gov/')
-    page.urls.first.update(to_time: Time.now - 1.day)
-    page.urls.create(url: 'https://example.gov/2', from_time: Time.now - 1.day)
-    current = page.urls.current(Time.now - 1.month)
+    page.urls.first.update(to_time: 1.day.ago)
+    page.urls.create(url: 'https://example.gov/2', from_time: 1.day.ago)
+    current = page.urls.current(1.month.ago)
     assert_equal(1, current.count)
     assert_equal('https://example.gov/', current.first.url)
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -38,18 +38,18 @@ class UserTest < ActiveSupport::TestCase
     assert user.valid?, 'Empty permissions array should be valid'
 
     user.permissions = ['blargle']
-    refute user.valid?, 'Invalid permission string should NOT be valid'
+    assert_not user.valid?, 'Invalid permission string should NOT be valid'
 
     user.permissions = nil
-    refute user.valid?, 'Permission value should be an array'
+    assert_not user.valid?, 'Permission value should be an array'
 
     user.permissions = false
-    refute user.valid?, 'Permission value should be an array'
+    assert_not user.valid?, 'Permission value should be an array'
   end
 
   test '#permission? describes whether use has permission' do
     user = users(:alice)
-    refute user.permission?(User::MANAGE_USERS_PERMISSION), 'User should not be an admin'
+    assert_not user.permission?(User::MANAGE_USERS_PERMISSION), 'User should not be an admin'
 
     user.permissions << User::MANAGE_USERS_PERMISSION
     assert user.permission?(User::MANAGE_USERS_PERMISSION), 'User with manage_users should be admin'
@@ -57,7 +57,7 @@ class UserTest < ActiveSupport::TestCase
 
   test 'user has permission predicates' do
     user = users(:alice)
-    refute user.can_manage_users?, 'User should not be able to manage users'
+    assert_not user.can_manage_users?, 'User should not be able to manage users'
 
     user.permissions << User::MANAGE_USERS_PERMISSION
     assert user.can_manage_users?, 'User should be able to manage users'
@@ -72,6 +72,6 @@ class UserTest < ActiveSupport::TestCase
   test 'user default permissions do not override explicit permissions' do
     user = User.create(email: 'new-user@example.com', password: 'PASSWORD', permissions: [User::VIEW_PERMISSION])
     assert user.can_view?
-    assert !user.can_annotate?
+    assert_not user.can_annotate?
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -10,11 +10,11 @@ class VersionTest < ActiveSupport::TestCase
 
   test 'previous(different: false) should get the previous version regardless of its `different` value' do
     page = pages(:home_page)
-    v1 = page.versions.create!(capture_time: Time.now + 1.minute, body_hash: 'abc')
+    v1 = page.versions.create!(capture_time: 1.minute.from_now, body_hash: 'abc')
     v1.update_different_attribute
-    v2 = page.versions.create!(capture_time: Time.now + 2.minutes, body_hash: 'abc')
+    v2 = page.versions.create!(capture_time: 2.minutes.from_now, body_hash: 'abc')
     v2.update_different_attribute
-    v3 = page.versions.create!(capture_time: Time.now + 3.minutes, body_hash: 'abc')
+    v3 = page.versions.create!(capture_time: 3.minutes.from_now, body_hash: 'abc')
     v3.update_different_attribute
 
     assert_predicate(v1, :different?)
@@ -43,11 +43,11 @@ class VersionTest < ActiveSupport::TestCase
 
   test 'next(different: false) should get the next version regardless of its `different` value' do
     page = pages(:home_page)
-    v1 = page.versions.create!(capture_time: Time.now + 1.minute, body_hash: 'abc')
+    v1 = page.versions.create!(capture_time: 1.minute.from_now, body_hash: 'abc')
     v1.update_different_attribute
-    v2 = page.versions.create!(capture_time: Time.now + 2.minutes, body_hash: 'abc')
+    v2 = page.versions.create!(capture_time: 2.minutes.from_now, body_hash: 'abc')
     v2.update_different_attribute
-    v3 = page.versions.create!(capture_time: Time.now + 3.minutes, body_hash: 'abc')
+    v3 = page.versions.create!(capture_time: 3.minutes.from_now, body_hash: 'abc')
     v3.update_different_attribute
 
     assert_predicate(v1, :different?)
@@ -69,14 +69,14 @@ class VersionTest < ActiveSupport::TestCase
 
   test 'update_different_attribute' do
     page = Page.create(url: 'http://somerandomsite.com/')
-    a1 = page.versions.create(source_type: 'a', body_hash: 'abc', capture_time: Time.now - 3.days)
-    b1 = page.versions.create(source_type: 'b', body_hash: 'abc', capture_time: Time.now - 2.days)
+    a1 = page.versions.create(source_type: 'a', body_hash: 'abc', capture_time: 3.days.ago)
+    b1 = page.versions.create(source_type: 'b', body_hash: 'abc', capture_time: 2.days.ago)
     a1.update_different_attribute
     b1.update_different_attribute
     assert(a1.different?, 'The first version should have been different')
     assert_not(b1.different?, 'The second version should not have been different')
 
-    a2 = page.versions.create(source_type: 'a', body_hash: 'def', capture_time: Time.now - 2.5.days)
+    a2 = page.versions.create(source_type: 'a', body_hash: 'def', capture_time: 2.5.days.ago)
     a2.update_different_attribute
     assert(a2.different?, 'A version with a different hash is different')
     assert(Version.find(b1.uuid).different?, 'Updating a version inserted before an existing version updates the existing version, too')

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -101,7 +101,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     Capybara.using_session(:user) do
       visit root_path
-      refute page.has_link?('Admin'), 'User should not have admin permissions'
+      assert_not page.has_link?('Admin'), 'User should not have admin permissions'
     end
 
     #
@@ -121,7 +121,7 @@ class UsersTest < ApplicationSystemTestCase
     #
     Capybara.using_session(:user) do
       visit root_path
-      refute page.has_content?("Logged in as #{viewer_email}"), 'User should NOT have an active session'
+      assert_not page.has_content?("Logged in as #{viewer_email}"), 'User should NOT have an active session'
 
       click_on 'Login'
 


### PR DESCRIPTION
Follow-on to #1412. We've had rubocop-rails installed forever but apparently it's never been enabled! This turns it on and address a bunch of items, although there are quite a few more left in the TODO file.