### PR TITLE
HOTFIX: handle versions with invalid redirect data

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -294,7 +294,12 @@ class Version < ApplicationRecord
 
   def redirects
     urls = source_metadata['redirects'] || []
-    raise TypeError, "Unknown type for source_metadata.redirects on version: #{uuid}" unless urls.is_a?(Array)
+    unless urls.is_a?(Array)
+      message = "Invalid `source_metadata.redirects` for version #{uuid}"
+      Rails.logger.error(message)
+      Sentry.capture_message(message, level: :error)
+      urls = []
+    end
 
     # TODO: add option to fetch raw body and look for client redirects? FWIW, data from the EDGI crawler already
     #  includes these.

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -436,7 +436,7 @@ class Version < ApplicationRecord
     # Special cases for redirects to known sinks that represent crawl blocking.
     if status == 200 && redirects.present?
       block_url = 'unblock.federalregister.gov/'
-      if redirects[-1].downcase.sub(/^https?:\/\//, '') == block_url && url.downcase.sub(/^https?:\/\//, '') != block_url
+      if redirects.last.downcase.sub(/^https?:\/\//, '') == block_url && url.downcase.sub(/^https?:\/\//, '') != block_url
         return 0.0
       end
     end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -299,7 +299,8 @@ class Version < ApplicationRecord
     # TODO: add option to fetch raw body and look for client redirects? FWIW, data from the EDGI crawler already
     #  includes these.
 
-    urls.shift if urls.first == url
+    # Some malformed data has the original URL repeated.
+    urls.shift while urls.first == url
     urls
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -293,7 +293,7 @@ class Version < ApplicationRecord
   end
 
   def redirects
-    urls = source_metadata['redirects'] || []
+    urls = source_metadata['redirects'].dup || []
     unless urls.is_a?(Array)
       message = "Invalid `source_metadata.redirects` for version #{uuid}"
       Rails.logger.error(message)
@@ -304,8 +304,7 @@ class Version < ApplicationRecord
     # TODO: add option to fetch raw body and look for client redirects? FWIW, data from the EDGI crawler already
     #  includes these.
 
-    # Some malformed data has the original URL repeated.
-    urls.shift while urls.first == url
+    urls.shift if urls.first == url
     urls
   end
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -168,6 +168,27 @@ class VersionTest < ActiveSupport::TestCase
     assert_equal(10_342, version.content_length)
   end
 
+  test 'redirects removes requested URL from front of redirects if present' do
+    version = Version.create(
+      page: pages(:home_page),
+      url: pages(:home_page).url,
+      capture_time: '2017-03-01T00:00:00Z',
+      source_metadata: { 'redirects' => [pages(:home_page).url, 'https://somewhere.else/'] }
+    )
+    assert_equal(['https://somewhere.else/'], version.redirects)
+  end
+
+  test 'redirects does not remove more URLs on repeated calls' do
+    version = Version.create(
+      page: pages(:home_page),
+      url: pages(:home_page).url,
+      capture_time: '2017-03-01T00:00:00Z',
+      source_metadata: { 'redirects' => [pages(:home_page).url, pages(:home_page).url, 'https://somewhere.else/'] }
+    )
+    assert_equal([pages(:home_page).url, 'https://somewhere.else/'], version.redirects)
+    assert_equal([pages(:home_page).url, 'https://somewhere.else/'], version.redirects)
+  end
+
   test 'effective_status considers redirects to be ok' do
     version = Version.create(
       page: pages(:home_page),


### PR DESCRIPTION
This is a hotfix followup to #1415.

Some versions have a list of redirects that includes the original URL, and when we load redirects, we attempt to handle that by removing the first entry if it is the same as the requested URL (`Version#url`). It turns out that some versions have the same URL twice, e.g:

```json
{
  "redirects": [
    "https://cpo.noaa.gov/",
    "https://cpo.noaa.gov/"
  ]
}
```

(Example: https://api.monitoring.envirodatagov.org/api/v0/versions/f897f683-8496-4f3f-8682-96cb55b101ba; I think maybe the first response was a CloudFront challenge screen.)

If we call `Version#redirects` once, it removes the first entry as expected. But if we call it twice, it removes the second one, because each call modifies the array of redirects in place! We trigger this when we do:

```rb
if redirects.present?
  destination = redirects.last  # <- second call mutates the array again
```

This solves the problem by operating on a copy of the redirects array, rather than mutating the actual data in-place.

I also noticed that this method can raise on some other kinds of bad data. That’s probably good when we’re trying to *write*, but not so good here when we are reading. So for now I’ve turned that into a log instead.