### PR TITLE
HOTFIX: handle integer or invalid expires header

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -312,7 +312,7 @@ class Version < ApplicationRecord
   # These two routines are meant to be equivalent. Ideally we need this code
   # to be shared, but for now, make sure to copy any changes you make here
   # to that repo and vice-versa.
-  def estimate_quality # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+  def estimate_quality! # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
     # Some ancient Versionista and PageFreezer data does not have status codes.
     status = self.status || (network_error.present? ? 600 : 200)
 
@@ -445,6 +445,14 @@ class Version < ApplicationRecord
       end
     end
 
+    1.0
+  end
+
+  def estimate_quality
+    estimate_quality!
+  rescue StandardError => error
+    Rails.logger.error(error)
+    Sentry.capture_exception(error)
     1.0
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -331,7 +331,7 @@ class Version < ApplicationRecord
         no_cache = Integer(headers['expires']) < 60
       rescue ArgumentError
         expires = Time.zone.parse(headers['expires']) || capture_time
-        request_time = headers.key?('date') && Time.zone.parse(headers['date']) || capture_time
+        request_time = (headers.key?('date') && Time.zone.parse(headers['date'])) || capture_time
         no_cache = (expires - request_time) < 60
       end
     end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -327,9 +327,13 @@ class Version < ApplicationRecord
       no_cache = cache_control.include?('no-cache') || cache_control.include?('max-age=0')
     end
     if !no_cache && headers.key?('expires')
-      expires = Time.zone.parse(headers['expires'])
-      request_time = headers.key?('date') ? Time.zone.parse(headers['date']) : capture_time
-      no_cache = (expires - request_time) < 60
+      begin
+        no_cache = Integer(headers['expires']) < 60
+      rescue ArgumentError
+        expires = Time.zone.parse(headers['expires']) || capture_time
+        request_time = headers.key?('date') && Time.zone.parse(headers['date']) || capture_time
+        no_cache = (expires - request_time) < 60
+      end
     end
 
     x_cache = headers.fetch('x-cache', '').downcase

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -323,7 +323,7 @@ class VersionTest < ActiveSupport::TestCase
         skip if version_file.basename.to_s == 'b47ca1d6-0f4e-4015-9940-dc666f755eb1.json'
 
         version = Version.new(JSON.parse(version_file.read)['data'])
-        assert_equal(expected, version.estimate_quality)
+        assert_equal(expected, version.estimate_quality!)
       end
     end
   end
@@ -340,7 +340,7 @@ class VersionTest < ActiveSupport::TestCase
       }
     )
 
-    assert_equal(1.0, version.estimate_quality)
+    assert_equal(1.0, version.estimate_quality!)
   end
 
   test 'estimate_quality accepts invalid "date" header' do
@@ -355,6 +355,6 @@ class VersionTest < ActiveSupport::TestCase
       }
     )
 
-    assert_equal(1.0, version.estimate_quality)
+    assert_equal(1.0, version.estimate_quality!)
   end
 end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -333,10 +333,10 @@ class VersionTest < ActiveSupport::TestCase
       url: 'https://websoilsurver.sc.egov.usda.gov/',
       capture_time: Time.zone.parse('2026-03-10T01:31:00Z'),
       headers: {
-        "expires" => "-1",
-        "date" => "Tue, 10 Mar 2026 01:31:00 GMT",
-        "content-type" => "text/html; charset=utf-8",
-        "content-length" => "543681",
+        'expires' => '-1',
+        'date' => 'Tue, 10 Mar 2026 01:31:00 GMT',
+        'content-type' => 'text/html; charset=utf-8',
+        'content-length' => '543681'
       }
     )
 
@@ -348,10 +348,10 @@ class VersionTest < ActiveSupport::TestCase
       url: 'https://websoilsurver.sc.egov.usda.gov/',
       capture_time: Time.zone.parse('2026-03-10T01:31:00Z'),
       headers: {
-        "expires" => "Tue, 10 Mar 2026 01:31:00 GMT",
-        "date" => "Hey hello whats up this is wrong",
-        "content-type" => "text/html; charset=utf-8",
-        "content-length" => "543681",
+        'expires' => 'Tue, 10 Mar 2026 01:31:00 GMT',
+        'date' => 'Hey hello whats up this is wrong',
+        'content-type' => 'text/html; charset=utf-8',
+        'content-length' => '543681'
       }
     )
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -308,6 +308,7 @@ class VersionTest < ActiveSupport::TestCase
     assert_equal(429, version.effective_status)
   end
 
+  # Test estimate_quality across some real-world examples.
   Pathname('../../fixtures/version_quality').expand_path(__FILE__).each_child do |child|
     next if child.basename.to_s.starts_with? '.'
 
@@ -325,5 +326,35 @@ class VersionTest < ActiveSupport::TestCase
         assert_equal(expected, version.estimate_quality)
       end
     end
+  end
+
+  test 'estimate_quality accepts integer "expires" header' do
+    version = Version.new(
+      url: 'https://websoilsurver.sc.egov.usda.gov/',
+      capture_time: Time.zone.parse('2026-03-10T01:31:00Z'),
+      headers: {
+        "expires" => "-1",
+        "date" => "Tue, 10 Mar 2026 01:31:00 GMT",
+        "content-type" => "text/html; charset=utf-8",
+        "content-length" => "543681",
+      }
+    )
+
+    assert_equal(1.0, version.estimate_quality)
+  end
+
+  test 'estimate_quality accepts invalid "date" header' do
+    version = Version.new(
+      url: 'https://websoilsurver.sc.egov.usda.gov/',
+      capture_time: Time.zone.parse('2026-03-10T01:31:00Z'),
+      headers: {
+        "expires" => "Tue, 10 Mar 2026 01:31:00 GMT",
+        "date" => "Hey hello whats up this is wrong",
+        "content-type" => "text/html; charset=utf-8",
+        "content-length" => "543681",
+      }
+    )
+
+    assert_equal(1.0, version.estimate_quality)
   end
 end


### PR DESCRIPTION
Fixes https://edgi.sentry.io/issues/7563478580. The `estimate_quality` routine is raising an exception when the `expires` header is an integer, as in version [25078774-b1bf-4db1-a829-3f89a3f1a054](https://api.monitoring.envirodatagov.org/api/v0/versions/25078774-b1bf-4db1-a829-3f89a3f1a054). I forgot to account for the fact that `expires` can also be a number of seconds, not just a timestamp. This fixes the issue, and also handles `expires` and `date` headers that are just gobbledegook.

In fact, since we’ve had a couple hotfixes for this very complicated method, I went a bit farther and made the controller call a safe version that logs any exceptions to Sentry and then returns 1.0, so we can’t have these horrible failures again, but will still be notified of mistakes in the code.