### PR TITLE
Solve minor fuzzing annoyances

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'oj', '~> 3.17'
 gem 'pundit', '~> 2.5.2'
 gem 'google-apis-sheets_v4'
 gem 'addressable', '~> 2.9'
+gem 'rack-utf8_sanitizer', '~> 1.11'
 
 # Workers/Queuing
 gem "good_job", "~> 4.19"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,6 +290,8 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
+    rack-utf8_sanitizer (1.11.1)
+      rack (>= 1.0, < 4.0)
     rackup (2.3.1)
       rack (>= 3)
     rails (8.1.3)
@@ -473,6 +475,7 @@ DEPENDENCIES
   pundit (~> 2.5.2)
   rack-brotli
   rack-cors (~> 3.0)
+  rack-utf8_sanitizer (~> 1.11)
   rails (~> 8.1.3)
   redis (~> 5.4)
   rubocop (~> 1.87.0)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,6 @@
 
 class HomeController < ApplicationController
   def index
-    render
+    respond_to(:html)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,7 @@ module WebpageVersionsDb
 
     config.middleware.use Rack::Deflater
     config.middleware.use Rack::Brotli
+    config.middleware.insert 0, Rack::UTF8Sanitizer, sanitize_null_bytes: true
 
     # Support CORS requests for everything outside /admin
     # TODO: maybe better to have `/api/*` routes and turn CORS on only for those?

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -14,4 +14,24 @@ class Users::SessionsControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse @response.body
     assert_equal ['view', 'annotate', 'import'], body['user']['permissions'], 'User JSON contains permissions'
   end
+
+  test 'handles null bytes in new session get' do
+    get(new_user_session_path, params: {
+      user: {
+        email: users(:alice).email,
+        password: "something\x00bad"
+      }
+    })
+    assert_response :success
+  end
+
+  test 'handles null bytes in new session post' do
+    post new_user_session_path, params: {
+      user: {
+        email: users(:alice).email,
+        password: "something\x00bad"
+      }
+    }
+    assert_response :unprocessable_content
+  end
 end


### PR DESCRIPTION
We regularly get some dumb requests showing up in Sentry that are probably the result of people fuzzing the app. They aren’t currently harmful, but are annoying, and this silences them.
- Non-HTML requests to the home page are now rejected. Fixes https://edgi.sentry.io/issues/7317264542.
- Null bytes in querystrings and POST bodies are now automatically removed. Fixes https://edgi.sentry.io/issues/7510200975.