### PR TITLE
Ignore AspxAutoDetectCookieSupport query param in SURT

### DIFF
--- a/app/lib/surt/canonicalize.rb
+++ b/app/lib/surt/canonicalize.rb
@@ -72,6 +72,7 @@ module Surt::Canonicalize
     /^(.*)(?:sms_ss=[^&]+)(?:&(.*))?$/i,
     /^(.*)(?:awesm=[^&]+)(?:&(.*))?$/i,
     /^(.*)(?:xtor=[^&]+)(?:&(.*))?$/i,
+    /^(.*)(?:AspxAutoDetectCookieSupport=[^&]+)(?:&(.*))?$/i,
     # TODO: At the moment, we only know `nrg_redirect` to exist on energy.gov.
     #  it would be nice to have a way to scope this by domain or hostname.
     /^(.*)(?:nrg_redirect=\d+)(?:&(.*))?$/i


### PR DESCRIPTION
Seen recently on a few pages. It’s an ASP.net feature for detecting how cookies are working when a user has no existing session cookies. The server adds it after the first page visit and removes it on the next, comparing it to what's been set and tracked in cookies. Based on that, it decides whether to put session info in cookies or querystrings from then on.

In any case, it’s a process managed by the web server entirely independent of the actual pages you are browsing, so canonicalization should strip it.