### PR TITLE
Set effective status for ASP.net error redirects

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -277,6 +277,11 @@ class Version < ApplicationRecord
     # kind of error, so only check this if the other heuristics didn't work.
     return 500 if headers.fetch('apex-debug-id', '').downcase.include?('level=error')
 
+    # ASP.net servers that are configured to *redirect* to an error page
+    # include the `?aspxerrorpath=<path>` query param. Like the above, it's
+    # ambiguous about the actual type of error, so we check it last.
+    return 500 if redirected_to&.match?(/\?(.+&)?aspxerrorpath=/i)
+
     status || 200
   end
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -308,6 +308,23 @@ class VersionTest < ActiveSupport::TestCase
     assert_equal(429, version.effective_status)
   end
 
+  test 'effective_status considers redirects ?aspxerrorpath as 500' do
+    version = Version.create(
+      page: pages(:home_page),
+      capture_time: '2017-03-01T00:00:00Z',
+      url: 'https://aedt.faa.gov/3g_information.aspx',
+      status: 200,
+      source_metadata: {
+        redirects: [
+          'https://aedt.faa.gov/3g_information.aspx',
+          'https://aedt.faa.gov/ErrorPage.aspx?aspxerrorpath=%252F3g_information.aspx'
+        ]
+      },
+      title: 'FAA: AEDT Support Website'
+    )
+    assert_equal(500, version.effective_status)
+  end
+
   # Test estimate_quality across some real-world examples.
   Pathname('../../fixtures/version_quality').expand_path(__FILE__).each_child do |child|
     next if child.basename.to_s.starts_with? '.'


### PR DESCRIPTION
Old-school ASP.net error handling still allows you to configure the server to redirect to a special error page, which often will send a 200 status code instead of something more appropriate.

By default (not even sure if you can customize it) it will include the path where the error was originally encountered in a query param named `aspxerrorpath`. That doesn’t really tell us what kind of error, but at least we know it shouldn’t be 200!