### PR TITLE
Ignore `?gsaredirect` query params in SURT

### DIFF
--- a/app/lib/surt/canonicalize.rb
+++ b/app/lib/surt/canonicalize.rb
@@ -75,7 +75,9 @@ module Surt::Canonicalize
     /^(.*)(?:AspxAutoDetectCookieSupport=[^&]+)(?:&(.*))?$/i,
     # TODO: At the moment, we only know `nrg_redirect` to exist on energy.gov.
     #  it would be nice to have a way to scope this by domain or hostname.
-    /^(.*)(?:nrg_redirect=\d+)(?:&(.*))?$/i
+    /^(.*)(?:nrg_redirect=\d+)(?:&(.*))?$/i,
+    # Same for `gsaredirect` on gsa.gov.
+    /^(.*)(?:gsaredirect=[^&]+)(?:&(.*))?$/i
   ].freeze
 
   OCTAL_IP = /^(0[0-7]*)(\.[0-7]+)?(\.[0-7]+)?(\.[0-7]+)?$/


### PR DESCRIPTION
This is a specialized redirect param we’ve seen only in use on gsa.gov. It’s not great to be having all these special cases, but oh well.