### PR TITLE
Fix incorrect note in TODO comment

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -306,8 +306,7 @@ class Version < ApplicationRecord
       urls = []
     end
 
-    # TODO: add option to fetch raw body and look for client redirects? FWIW, data from the EDGI crawler already
-    #  includes these.
+    # TODO: add option to fetch raw body and look for client redirects?
 
     urls.shift if urls.first == url
     urls


### PR DESCRIPTION
This is pretty minor, but this comment tripped me up recently. I can’t remember what led to me writing it, but this comment about our crawler already including client-side redirects isn't really accurate and I had to go back and verify.

Our crawler only includes client-side redirect data in one very special case: when encountering a WAF challenge that we recognize (mainly just AWS WAF, and not even any others): https://github.com/edgi-govdata-archiving/web-monitoring-processing/blob/f01222be7d9b8784f59592e0c274e51f5523db75/web_monitoring/cli/warc_import.py#L82-L87