### PR TITLE
Upgrade Bundler to v4.0.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /app
 # will be cached unless changes to one of those two files
 # are made.
 COPY Gemfile Gemfile.lock .ruby-version ./
-RUN gem install bundler && bundle install --jobs 20 --retry 5
+RUN gem install bundler && bundle config set deployment true && bundle install --jobs 20 --retry 5
 
 # Copy the main application.
 COPY . ./

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -495,4 +495,4 @@ RUBY VERSION
    ruby 4.0.6p0
 
 BUNDLED WITH
-   2.7.2
+   4.0.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,7 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
     fugit (1.12.3)
@@ -243,6 +244,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
@@ -257,6 +260,7 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3-aarch64-linux)
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
     postmark (1.22.1)
@@ -446,6 +450,7 @@ GEM
     zeitwerk (2.8.2)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
@@ -492,7 +497,7 @@ DEPENDENCIES
   webmock (~> 3.26)
 
 RUBY VERSION
-   ruby 4.0.6p0
+  ruby 4.0.6p0
 
 BUNDLED WITH
-   4.0.17
+  4.0.17

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ We maintain a publicly available *staging server* at https://api-staging.monitor
 7. Wherever you cloned the repo, go to that directory and install dependencies:
 
     ```sh
-    $ bundle install --without production
+    $ bundle install
     ```
 
 8. Copy the .env.example file to .env - this allows for easy configuration locally.


### PR DESCRIPTION
Bundler v4 overview: https://bundler.io/v4.0/whats_new.html

I still need to do some reading and make sure we don’t need to change any commands we use in the Dockerfile or README. Will probably hold off on merging until at least Sunday when I have more time for it and to address any failures that might happen when deploying.

Fixes #1441.