### PR TITLE
Allow cross-domain embedding raw versions

### DIFF
--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -113,11 +113,11 @@ class Api::V0::VersionsController < Api::V0::ApiController
     @version ||= version_collection.find(params[:id])
 
     expires_in 1.year, public: true
-    # Allow this response to be embedded in frames.
-    # TODO: consider whether this should target specific hosts with
-    #  `Content-Security-Policy: frame-ancestors <origin>;`. For now we aren't
-    #  especially concerned about sensitive data here, but it may be a future
-    #  concern to handle better. Would need to be configurable.
+    # Web-monitoring-ui is usually on a different origin, but needs to be able
+    # to display archived version bodies. For now, allow any origin to embed,
+    # since we treat these as public archives and want to be flexible.
+    # TODO: consider whether this should be configurable to target specific
+    #  hosts instead with `Content-Security-Policy: frame-ancestors <origin>;`
     headers.delete('X-Frame-Options')
 
     if @version.network_error.present?

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -113,6 +113,12 @@ class Api::V0::VersionsController < Api::V0::ApiController
     @version ||= version_collection.find(params[:id])
 
     expires_in 1.year, public: true
+    # Allow this response to be embedded in frames.
+    # TODO: consider whether this should target specific hosts with
+    #  `Content-Security-Policy: frame-ancestors <origin>;`. For now we aren't
+    #  especially concerned about sensitive data here, but it may be a future
+    #  concern to handle better. Would need to be configurable.
+    headers.delete('X-Frame-Options')
 
     if @version.network_error.present?
       render :network_error, layout: nil

--- a/lib/tasks/copy_data.rake
+++ b/lib/tasks/copy_data.rake
@@ -86,7 +86,7 @@ def copy_page_versions(page, api_options, verbose)
       next
     end
 
-    version = page.versions.create(version_data)
+    version = page.versions.create(version_data.slice(*Version.attribute_names))
     if version.valid?
       summary[:count] += 1
       puts "  Copied version #{version_data['uuid']}" if verbose


### PR DESCRIPTION
I am not sure what changed in Rails (or something else?) recently, but viewing Rails-rendered raw version bodies in the UI (which is at a different origin from this API) seems to have broken recently. The fix is to turn off the `X-Frame-Options` that Rails sets by default. For rendering the raw bodies of archived pages that's OK and seems safe, but I've kept this behavior to just that route for now.

Even though we’re fixing this in Rails here, nothing related to this in Rails seems to have actually changed recently. This fixes the issue locally, but I wonder what we’ll see in production, and if this is actually something that changed in CloudFront (possibly it was stripping this header before, and recently stopped doing so?).

This also fixes an issue in the data copy script, since I was using it to test this fix. It turns out I broke it when adding the virtual `quality` property to versions (#1415).