### PR TITLE
Always render network error bodies as HTML

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -66,7 +66,7 @@ class Api::V0::ApiController < ApplicationController
       errors: errors.collect do |error|
         formatted = {
           status: status_code,
-          title: message_for(error)
+          title: message_for(error, status: status_code)
         }
         formatted[:stack] = error.try(:backtrace) || [] if Rails.env.development?
         formatted
@@ -85,10 +85,16 @@ class Api::V0::ApiController < ApplicationController
     end
   end
 
-  def message_for(error)
-    error.try(:message) ||
-      (error.try(:has_key?, :message) && error.send(:[], :message)) ||
-      error.to_s
+  def message_for(error, status: nil)
+    status ||= status_code_for(error)
+
+    if Rails.env.development? || error.is_a?(Api::ApiError) || status < 500
+      error.try(:message) ||
+        (error.try(:has_key?, :message) && error.send(:[], :message)) ||
+        error.to_s
+    else
+      Rack::Utils::HTTP_STATUS_CODES[status] || 'Unknown error'
+    end
   end
 
   def boolean_param(param, presence_implies_true: true, default: false)

--- a/app/controllers/api/v0/versions_controller.rb
+++ b/app/controllers/api/v0/versions_controller.rb
@@ -121,7 +121,7 @@ class Api::V0::VersionsController < Api::V0::ApiController
     headers.delete('X-Frame-Options')
 
     if @version.network_error.present?
-      render :network_error, layout: nil
+      render :network_error, layout: nil, formats: [:html]
     elsif @version.body_url.nil?
       raise Api::NotFoundError, "No raw content for #{@version.uuid}."
     elsif Archiver.external_archive_url?(@version.body_url)

--- a/test/controllers/api/v0/versions_controller_test.rb
+++ b/test/controllers/api/v0/versions_controller_test.rb
@@ -328,6 +328,24 @@ class Api::V0::VersionsControllerTest < ActionDispatch::IntegrationTest
     assert_includes(@response.body, 'net::ERR_TIMED_OUT')
   end
 
+  test 'only synthesizes HTML raw response body for network errors' do
+    page = pages(:home_page)
+    version = page.versions.create(
+      capture_time: 1.minute.ago,
+      body_url: nil,
+      body_hash: nil,
+      source_type: 'edgi_statuscheck_v0',
+      url: page.url,
+      status: nil,
+      network_error: 'net::ERR_TIMED_OUT'
+    )
+
+    sign_in users(:alice)
+    get raw_api_v0_version_url(version), headers: { accept: 'application/json' }
+    assert_response(:success)
+    assert_includes(@response.body, 'net::ERR_TIMED_OUT')
+  end
+
   test 'can query by source_metadata fields' do
     sign_in users(:alice)
     version = versions(:page1_v1)


### PR DESCRIPTION
It turns out it was possible to tell the versions controller to return a version body as JSON by using the `Accept` header (we had disabled the file extension on the path, but not the header). Rails would dutifully try and render the JSON version of the template for us, except there was no JSON version of the template, so it would simply blow up instead.

This also revealed that we are leaking some more-detailed-than-we'd-like error messages. We are now a little more picky about what messages we expose directly, so a similar error would leak less under-the-hood info in the future.

Fixes https://edgi.sentry.io/issues/7652779644